### PR TITLE
Use root user when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 FROM jupyter/minimal-notebook
 
-#ENV VIRTUAL_ENV=/home/jovyan/nearmap-ai-user-guides/.venv
-#RUN python -m venv $VIRTUAL_ENV
-#ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-#
-#RUN pip install --upgrade pip
-#RUN which pip
+USER root
 
-#COPY ./requirements.txt /home/jovyan/nearmap-ai-user-guides/requirements.txt
-#RUN cd /home/jovyan/nearmap-ai-user-guides \
-# && pip install -r requirements.txt
+COPY ./requirements.txt /home/jovyan/nearmap-ai-user-guides/requirements.txt
+RUN cd /home/jovyan/nearmap-ai-user-guides \
+ && pip install -r requirements.txt
 
 COPY ./ /home/jovyan/nearmap-ai-user-guides
 RUN cd /home/jovyan/nearmap-ai-user-guides \
- && pip install -r requirements.txt \
  && pip install .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nearmap_ai:
     build: .
     environment:
-      - API_KEY=${APIKEYPROD}
+      - API_KEY=${API_KEY}
       - NB_UID=${NB_UID}
       - NB_GID=${NB_GID}
       - GRANT_SUDO=yes
@@ -11,7 +11,7 @@ services:
       - JUPYTER_LAB_ENABLE=yes
     user: root
     volumes:
-      - ./data:/home/jovyan/data
+      - <local path to data directory>:/home/jovyan/data
     entrypoint: [
         "start.sh",
         "python", "/home/jovyan/nearmap-ai-user-guides/scripts/ai_offline_parcel.py",


### PR DESCRIPTION
## Reproducer

Following the [README](https://github.com/nearmap/nearmap-ai-user-guides/blob/main/README.md):

```
$ docker build -t nearmap_ai .
...
  Step 5/5 : RUN cd /home/jovyan/nearmap-ai-user-guides  && pip install .
 ---> Running in 2e2939df6daa
Processing /home/jovyan/nearmap-ai-user-guides
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: nearmap-ai
  Building wheel for nearmap-ai (setup.py): started
  Building wheel for nearmap-ai (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [4 lines of output]
      running bdist_wheel
      running build
      running build_py
      error: could not create 'build': Permission denied
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nearmap-ai
  Running setup.py clean for nearmap-ai
Failed to build nearmap-ai
Installing collected packages: nearmap-ai
  Running setup.py install for nearmap-ai: started
  Running setup.py install for nearmap-ai: finished with status 'error'
  error: subprocess-exited-with-error

  × Running setup.py install for nearmap-ai did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      running install
      /opt/conda/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_py
      error: could not create 'build': Permission denied
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> nearmap-ai

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```

## Testing

After this change, the following output is observed and appears to build successfully:
```
$ $ docker build -t nearmap_ai .
...
Step 6/6 : RUN cd /home/jovyan/nearmap-ai-user-guides  && pip install .
 ---> Running in f6ff634db0a6
WARNING: The directory '/home/jovyan/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
Processing /home/jovyan/nearmap-ai-user-guides
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: nearmap-ai
  Building wheel for nearmap-ai (setup.py): started
  Building wheel for nearmap-ai (setup.py): finished with status 'done'
  Created wheel for nearmap-ai: filename=nearmap_ai-0.0.0-py3-none-any.whl size=14809 sha256=626f912b2c2f5ff07cb0042cc14766d306a8b30deed41c73ed71ef619d6149ba
  Stored in directory: /tmp/pip-ephem-wheel-cache-6pi6x57v/wheels/84/eb/a5/7d5cf3d5c8f567ec178b73717aea7ea48e3bf8e857112d986e
Successfully built nearmap-ai
Installing collected packages: nearmap-ai
Successfully installed nearmap-ai-0.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Removing intermediate container f6ff634db0a6
 ---> 954862aa63ec
Successfully built 954862aa63ec
Successfully tagged nearmap-ai-user-guides_nearmap_ai:latest
```

... and able to complete the README steps, as well as execute each step within `notebooks/nearmap-ai-user-guides/notebooks/Payload_Rollup_Minimal_Example.ipynb` without error.

## Alternatives considered

Explored using virtualenvs, however, the conda path would take precedence to the venv when running `start.sh`, which prevents (conda) python runtime from accessing the installed requirements.

## Questions

- Are others seeing the same thing? Perhaps picking up the `latest` `jupyter/minimal-notebook` image introduces this problem compared to older images?
- Are the warnings of any concern?

```
WARNING: The directory '/home/jovyan/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
...
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```