### PR TITLE
Fix for poles not being returned (objects with 0 area)

### DIFF
--- a/nearmap_ai/feature_api.py
+++ b/nearmap_ai/feature_api.py
@@ -440,7 +440,8 @@ class FeatureApi:
 
         # Add packs if given
         if packs:
-            packs = ",".join(packs)
+            if isinstance(packs, list):
+                packs = ",".join(packs)
             request_string += f"&packs={packs}"
 
         return request_string, exact

--- a/nearmap_ai/parcels.py
+++ b/nearmap_ai/parcels.py
@@ -189,21 +189,21 @@ def filter_features_in_parcels(features_gdf: gpd.GeoDataFrame, config: Optional[
 
     # Filter small features
     filter = config.get("min_size", DEFAULT_FILTERING["min_size"])
-    gdf = gdf[gdf.class_id.map(filter).fillna(0) < gdf.unclipped_area_sqm]
+    gdf = gdf[gdf.class_id.map(filter).fillna(0) <= gdf.unclipped_area_sqm]
 
     # Filter low confidence features
     filter = config.get("min_confidence", DEFAULT_FILTERING["min_confidence"])
-    gdf = gdf[gdf.class_id.map(filter).fillna(0) < gdf.confidence]
+    gdf = gdf[gdf.class_id.map(filter).fillna(0) <= gdf.confidence]
 
     # Filter low fidelity features. If fidelity not present, assume 1 (perfect shape) to avoid rejection.
     filter = config.get("min_fidelity", DEFAULT_FILTERING["min_fidelity"])
-    gdf = gdf[gdf.class_id.map(filter).fillna(0) < gdf.fidelity.fillna(1)]
+    gdf = gdf[gdf.class_id.map(filter).fillna(0) <= gdf.fidelity.fillna(1)]
 
     # Filter based on area and ratio in parcel
     filter = config.get("min_area_in_parcel", DEFAULT_FILTERING["min_area_in_parcel"])
-    area_mask = gdf.class_id.map(filter).fillna(0) < gdf.clipped_area_sqm
+    area_mask = gdf.class_id.map(filter).fillna(0) <= gdf.clipped_area_sqm
     filter = config.get("min_ratio_in_parcel", DEFAULT_FILTERING["min_ratio_in_parcel"])
-    ratio_mask = gdf.class_id.map(filter).fillna(0) < gdf.intersection_ratio
+    ratio_mask = gdf.class_id.map(filter).fillna(0) <= gdf.intersection_ratio
     gdf = gdf[area_mask | ratio_mask]
 
     # Only drop objects where the parent has been explicitly removed as above (otherwise we drop solar panels without a building request, etc.)

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -69,7 +69,7 @@ class TestParcels:
             },
         }
         filtered_gdf = parcels.filter_features_in_parcels(features_gdf, config=config)
-        assert len(filtered_gdf) == 44
+        assert len(filtered_gdf) == 45
         assert not (filtered_gdf.confidence < 0.8).any()
         assert not (filtered_gdf.unclipped_area_sqm < 25).any()
         assert not (filtered_gdf.fidelity < 0.4).any()


### PR DESCRIPTION
I found a bug where power and light poles were filtered out, because their min area defaulted to 0 sqm, and the filter compared 0 < 0, and rejected them. This is now a <=. I also made it so the code copes if a single pack string (rather than a list of packs) is given.