### PR TITLE
Misc cleanup

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,20 +5,21 @@ channels:
   - main
 dependencies:
   # Environment specific dependencies
-  - python=3.11
+  - black
+  - click
+  - descartes
+  - geopandas
+  - ipykernel
+  - isort
+  - matplotlib
   - numpy
   - pandas
-  - shapely
-  - rtree
-  - geopandas
-  - matplotlib
-  - descartes
-  - tqdm
-  - stringcase
   - pyarrow
-  - isort
-  - black
   - pytest
-  - ipykernel
+  - python=3.11
+  - python-dotenv
   - requests
-  - click
+  - rtree
+  - shapely
+  - stringcase
+  - tqdm

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1,31 +1,28 @@
-import logging
-
 import concurrent.futures
+import contextlib
+import gzip
 import hashlib
-from http import HTTPStatus
 import json
+import logging
 import os
-from pathlib import Path
 import threading
 import time
-from typing import Dict, List, Optional, Tuple, Union
 import uuid
+from http import HTTPStatus
 from io import StringIO
-import contextlib
-from functools import wraps
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
-import gzip
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from shapely.geometry import MultiPolygon, Polygon, shape
 import shapely.geometry
 import stringcase
-
 from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from shapely.geometry import MultiPolygon, Polygon, shape
+from urllib3.util.retry import Retry
 
 # Load environment variables from .env file
 load_dotenv()
@@ -35,20 +32,20 @@ API_KEY = os.getenv("API_KEY", "")
 
 from nmaipy import log
 from nmaipy.constants import (
-    AOI_ID_COLUMN_NAME,
-    LAT_LONG_CRS,
-    SINCE_COL_NAME,
-    UNTIL_COL_NAME,
-    SURVEY_RESOURCE_ID_COL_NAME,
-    MAX_RETRIES,
-    AOI_EXCEEDS_MAX_SIZE,
     ADDRESS_FIELDS,
-    SQUARED_METERS_TO_SQUARED_FEET,
-    AREA_CRS,
+    AOI_EXCEEDS_MAX_SIZE,
+    AOI_ID_COLUMN_NAME,
     API_CRS,
+    AREA_CRS,
     CONNECTED_CLASS_IDS,
+    LAT_LONG_CRS,
+    MAX_RETRIES,
     ROLLUP_SURVEY_DATE_ID,
     ROLLUP_SYSTEM_VERSION_ID,
+    SINCE_COL_NAME,
+    SQUARED_METERS_TO_SQUARED_FEET,
+    SURVEY_RESOURCE_ID_COL_NAME,
+    UNTIL_COL_NAME,
 )
 
 TIMEOUT_SECONDS = 120  # Max time to wait for a server response.
@@ -155,6 +152,7 @@ class FeatureApi:
     """
     Class to connect to the AI Feature API
     """
+
     CHAR_LIMIT = 3800
     SOURCE_CRS = LAT_LONG_CRS
     FLOAT_COLS = [
@@ -260,7 +258,7 @@ class FeatureApi:
 
     def cleanup(self):
         """Clean up all sessions"""
-        if hasattr(self, '_lock') and hasattr(self, '_sessions'):
+        if hasattr(self, "_lock") and hasattr(self, "_sessions"):
             with self._lock:
                 for session in self._sessions:
                     try:
@@ -269,7 +267,7 @@ class FeatureApi:
                         pass
                 self._sessions.clear()
         else:  # Fallback if attributes don't exist
-            if hasattr(self, '_sessions'):
+            if hasattr(self, "_sessions"):
                 for session in self._sessions:
                     try:
                         session.close()
@@ -302,7 +300,7 @@ class FeatureApi:
         try:
             yield session
         finally:
-            pass # Don't close here - keep session alive for thread reuse
+            pass  # Don't close here - keep session alive for thread reuse
 
     def _get_feature_api_results_as_data(self, base_url: str) -> Tuple[requests.Response, Dict]:
         """
@@ -350,7 +348,7 @@ class FeatureApi:
             # Strip out any classes that we don't get a valid description for from the "packs" endpoint.
             all_classes = [c for c in all_classes if c in df_classes.index]
             df_classes = df_classes.loc[all_classes]
-            df_classes = df_classes.query("type == 'Feature'") # Filter out non-feature classes
+            df_classes = df_classes.query("type == 'Feature'")  # Filter out non-feature classes
 
         return df_classes
 
@@ -523,7 +521,9 @@ class FeatureApi:
 
         # Add dates if given
         if ((since is not None) or (until is not None)) and (survey_resource_id is not None):
-            logger.debug(f"Request made with survey_resource_id {survey_resource_id} and either since or until - ignoring dates.")
+            logger.debug(
+                f"Request made with survey_resource_id {survey_resource_id} and either since or until - ignoring dates."
+            )
         elif (since is not None) or (until is not None):
             if since and not isinstance(since, str):
                 raise ValueError("Since must be a string")
@@ -716,7 +716,9 @@ class FeatureApi:
 
                                 if feature["classId"] in CONNECTED_CLASS_IDS:
                                     # Replace geometry, with geojson style mapped clipped geometry
-                                    data["features"][i]["geometry"] = shapely.geometry.mapping(gdf_clip.loc[i, "geometry"])
+                                    data["features"][i]["geometry"] = shapely.geometry.mapping(
+                                        gdf_clip.loc[i, "geometry"]
+                                    )
                                     data["features"][i]["areaSqm"] = gdf_clip.loc[i, "clipped_area_sqm"]
                                     data["features"][i]["areaSqft"] = gdf_clip.loc[i, "clipped_area_sqft"]
 
@@ -969,7 +971,7 @@ class FeatureApi:
                 df[col_name] = None
 
         for col in FeatureApi.FLOAT_COLS:
-            if (col in df):
+            if col in df:
                 df[col] = df[col].astype("float")
 
         df = df.rename(columns={"id": "feature_id"})
@@ -978,7 +980,7 @@ class FeatureApi:
         # Add AOI ID if specified
         if aoi_id is not None:
             try:
-                df[AOI_ID_COLUMN_NAME] = [aoi_id]*len(df)
+                df[AOI_ID_COLUMN_NAME] = [aoi_id] * len(df)
                 df = df.set_index(AOI_ID_COLUMN_NAME)
             except Exception as e:
                 logger.error(
@@ -1101,7 +1103,9 @@ class FeatureApi:
                     metadata = metadata[0]
             else:
                 features_gdf, metadata, error = None, None, None
-                payload = self.get_features(geometry, region, packs, classes, since, until, address_fields, survey_resource_id)
+                payload = self.get_features(
+                    geometry, region, packs, classes, since, until, address_fields, survey_resource_id
+                )
                 features_gdf, metadata = self.payload_gdf(payload, aoi_id)
         except AIFeatureAPIRequestSizeError as e:
             features_gdf, metadata, error = None, None, None
@@ -1122,9 +1126,17 @@ class FeatureApi:
                 logger.debug(f"Found an over-sized AOI (id {aoi_id}). Trying gridding...")
                 try:
                     features_gdf, metadata_df, errors_df = self.get_features_gdf_gridded(
-                        geometry, region, packs, classes, aoi_id, since, until, survey_resource_id, aoi_grid_inexact=self.aoi_grid_inexact,
+                        geometry,
+                        region,
+                        packs,
+                        classes,
+                        aoi_id,
+                        since,
+                        until,
+                        survey_resource_id,
+                        aoi_grid_inexact=self.aoi_grid_inexact,
                     )
-                    error = None # Reset error if we got here without an exception
+                    error = None  # Reset error if we got here without an exception
 
                     # Recombine gridded features
                     features_gdf = FeatureApi.combine_features_gdf_from_grid(features_gdf)
@@ -1257,7 +1269,7 @@ class FeatureApi:
                 since_bulk=since,
                 until_bulk=until,
                 survey_resource_id_bulk=survey_resource_id,
-                max_allowed_error_pct=100-self.aoi_grid_min_pct,
+                max_allowed_error_pct=100 - self.aoi_grid_min_pct,
                 fail_hard_regrid=True,
             )
         except AIFeatureAPIError as e:
@@ -1277,7 +1289,9 @@ class FeatureApi:
                 logger.warning(
                     f"Failed whole grid for aoi_id {aoi_id}. Multiple dates detected - certain to contain duplicates on grid boundaries."
                 )
-                raise AIFeatureAPIGridError(DUMMY_STATUS_CODE, message="Multiple dates on non survey resource ID query.")
+                raise AIFeatureAPIGridError(
+                    DUMMY_STATUS_CODE, message="Multiple dates on non survey resource ID query."
+                )
         elif survey_resource_id is None:
             logger.debug(
                 f"AOI {aoi_id} gridded on a single date - possible but unlikely to include deduplication errors (if two overlapping surveys flown on same date)."
@@ -1285,7 +1299,9 @@ class FeatureApi:
             # TODO: We should change query to guarantee same survey id is used somehow.
 
         if len(errors_df) > 0:
-            logger.debug(f"Allowing partial grid results on aoi {aoi_id} with {len(features_gdf)} good results and {len(errors_df)} errors of types {errors_df.status_code.value_counts().to_json()}.")
+            logger.debug(
+                f"Allowing partial grid results on aoi {aoi_id} with {len(features_gdf)} good results and {len(errors_df)} errors of types {errors_df.status_code.value_counts().to_json()}."
+            )
 
             # raise AIFeatureAPIGridError(errors_df.query("status_code != 200").status_code.mode())
 
@@ -1380,7 +1396,9 @@ class FeatureApi:
                         if aoi_error is not None:
                             if len(errors) > max_allowed_error_count:
                                 cleanup_executor(executor)
-                                logger.debug(f"Exceeded maximum error count of {max_allowed_error_count} out of {len(gdf)} AOIs.")
+                                logger.debug(
+                                    f"Exceeded maximum error count of {max_allowed_error_count} out of {len(gdf)} AOIs."
+                                )
                                 raise AIFeatureAPIError(aoi_error, aoi_error["request"])
                             else:
                                 errors.append(aoi_error)
@@ -1412,7 +1430,7 @@ class FeatureApi:
         Args:
             geometry: AOI in EPSG4326
             region: The country code, used as a key to AREA_CRS.
-            packs: List of AI 
+            packs: List of AI
             classes: List of classes
             aoi_id: ID of the AOI to add to the data
             since: Earliest date to pull data for
@@ -1460,7 +1478,9 @@ class FeatureApi:
                     metadata = metadata[0]
             else:
                 rollup_df, metadata, error = None, None, None
-                payload = self.get_rollup(geometry, region, packs, classes, since, until, address_fields, survey_resource_id)
+                payload = self.get_rollup(
+                    geometry, region, packs, classes, since, until, address_fields, survey_resource_id
+                )
                 rollup_df, metadata = self.payload_rollup_df(payload, aoi_id)
         except AIFeatureAPIError as e:
             # Catch acceptable errors

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,29 @@ package_dir = {"": pysrc_dir}
 with open("LICENSE") as f:
     _license = f.read()
 
+dev_packages = [
+    "black",
+    "isort",
+    "pytest",
+]
+
+required_packages = [
+    "click",
+    "descartes",
+    "geopandas",
+    "ipykernel",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "python-dotenv",
+    "requests",
+    "rtree",
+    "shapely",
+    "stringcase",
+    "tqdm",
+]
+
 setup(
     name=name,
     version="0.0.0",
@@ -18,7 +41,10 @@ setup(
     license=_license,
     packages=packages,
     package_dir=package_dir,
-    python_requires=">=3.8",
-    install_requires=[],
+    python_requires=">=3.11",
+    install_requires=required_packages,
+    extras_require={
+        "dev": dev_packages,
+    },
     zip_safe=False,
 )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,14 +1,14 @@
+import os
+import sys
 from pathlib import Path
-import logging
 
 import geopandas as gpd
 import pandas as pd
 import pytest
 
-from nmaipy.feature_api import FeatureApi
 from nmaipy.constants import *
-
 from nmaipy.exporter import AOIExporter
+from nmaipy.feature_api import FeatureApi
 
 
 class TestExporter:
@@ -65,7 +65,6 @@ class TestExporter:
             chunk_id=chunk_id,
             aoi_gdf=parcels_3_gdf,
             classes_df=classes_df,
-
         )
 
         data_rollup_api_errors = []
@@ -345,7 +344,12 @@ class TestExporter:
             # "link",
             # "mesh_date",
         ]:
-            pass # TODO: Enable once we've reconciled formats and filtering rules with rollup API.
+            pass  # TODO: Enable once we've reconciled formats and filtering rules with rollup API.
             # pd.testing.assert_series_equal(
             #     data_feature_api.loc[:, ident_col], data_rollup_api.loc[:, ident_col], check_names=False
             # )
+
+
+if __name__ == "__main__":
+    current_file = os.path.abspath(__file__)
+    sys.exit(pytest.main([current_file]))

--- a/tests/test_feature_api.py
+++ b/tests/test_feature_api.py
@@ -1,29 +1,30 @@
+import os
+import sys
 from pathlib import Path
 
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 import pytest
 from shapely.affinity import translate
-from shapely.geometry import Polygon, MultiPolygon
+from shapely.geometry import MultiPolygon, Polygon
 from shapely.wkt import loads
 
-from nmaipy import parcels
+from nmaipy import parcels, reference_code
 from nmaipy.constants import (
-    BUILDING_ID,
-    ROOF_ID,
-    BUILDING_NEW_ID,
-    SOLAR_ID,
-    VEG_MEDHIGH_ID,
-    ASPHALT_ID,
-    SOLAR_HW_ID,
+    AOI_ID_COLUMN_NAME,
     API_CRS,
+    AREA_CRS,
+    ASPHALT_ID,
+    BUILDING_ID,
+    BUILDING_NEW_ID,
     ROLLUP_BUILDING_COUNT_ID,
     ROLLUP_BUILDING_PRIMARY_UNCLIPPED_AREA_SQM_ID,
-    AOI_ID_COLUMN_NAME,
-    AREA_CRS,
+    ROOF_ID,
+    SOLAR_HW_ID,
+    SOLAR_ID,
+    VEG_MEDHIGH_ID,
 )
 from nmaipy.feature_api import FeatureApi
-from nmaipy import reference_code
 
 
 class TestFeatureAPI:
@@ -35,7 +36,9 @@ class TestFeatureAPI:
         aoi_id = "123"
 
         feature_api = FeatureApi(cache_dir=cache_directory)
-        rollup_df, metadata, error = feature_api.get_rollup_df(sydney_aoi, region, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        rollup_df, metadata, error = feature_api.get_rollup_df(
+            sydney_aoi, region, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
         print(rollup_df.T)
         print(f"WKT of Query AOI: {sydney_aoi}")
 
@@ -61,8 +64,10 @@ class TestFeatureAPI:
         aoi_id = "123"
 
         feature_api = FeatureApi(cache_dir=cache_directory)
-        features_gdf, metadata, error = feature_api.get_features_gdf(sydney_aoi, region, packs, aoi_id=aoi_id, since=date_1, until=date_2)
-        features_gdf = features_gdf.query("class_id == @ROOF_ID") # Filter out building classes, just keep roof.
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            sydney_aoi, region, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
+        features_gdf = features_gdf.query("class_id == @ROOF_ID")  # Filter out building classes, just keep roof.
         # No error
         assert error is None
         # Date is in range
@@ -95,7 +100,9 @@ class TestFeatureAPI:
         ).set_index("id")
 
         feature_api = FeatureApi(cache_dir=cache_directory)
-        features_gdf, metadata, error = feature_api.get_features_gdf(aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
 
         print(metadata)
         print(features_gdf.T)
@@ -178,14 +185,18 @@ class TestFeatureAPI:
         aoi_id = "123"
         # First do a standard pull to ensure the file is populated in the cache.
         feature_api = FeatureApi(cache_dir=cache_directory, compress_cache=False)
-        features_gdf, metadata, error = feature_api.get_features_gdf(sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
         assert error is None
 
         # Then re-request using invalid API key to ensure data is not being pulled from the API but read from the cache.
         api_key = "not an api key"
         # Run
         feature_api = FeatureApi(api_key, cache_dir=cache_directory, compress_cache=False)
-        features_gdf, metadata, error = feature_api.get_features_gdf(sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
         # Check output
         assert error is None
         assert date_1 <= metadata["date"] <= date_2
@@ -200,14 +211,18 @@ class TestFeatureAPI:
         aoi_id = "123"
         # First do a standard pull to ensure the file is populated in the cache.
         feature_api = FeatureApi(cache_dir=cache_directory, compress_cache=True)
-        features_gdf, metadata, error = feature_api.get_features_gdf(sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
         assert error is None
 
         # Then re-request using invalid API key to ensure data is not being pulled from the API but read from the cache.
         api_key = "not an api key"
         # Run
         feature_api = FeatureApi(api_key, cache_dir=cache_directory, compress_cache=True)
-        features_gdf, metadata, error = feature_api.get_features_gdf(sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2)
+        features_gdf, metadata, error = feature_api.get_features_gdf(
+            sydney_aoi, country, packs, aoi_id=aoi_id, since=date_1, until=date_2
+        )
         # Check output
         assert error is None
         assert date_1 <= metadata["date"] <= date_2
@@ -242,7 +257,9 @@ class TestFeatureAPI:
         assert len(features_gdf) == 69
         assert len(features_gdf[features_gdf.class_id == ROOF_ID]) == 69
 
-        rollup_df, metadata_df, errors_df = feature_api.get_rollup_df_bulk(aoi_gdf, country, packs, since_bulk=date_1, until_bulk=date_2)
+        rollup_df, metadata_df, errors_df = feature_api.get_rollup_df_bulk(
+            aoi_gdf, country, packs, since_bulk=date_1, until_bulk=date_2
+        )
         # Check metadata
         assert len(metadata_df) == 16
         assert len(metadata_df.merge(aoi_gdf, on="aoi_id", how="inner")) == 16
@@ -445,8 +462,11 @@ class TestFeatureAPI:
         assert features_gdf_asphalt["clipped_area_sqm"].sum() == pytest.approx(259.2, rel=0.02)
 
     def test_multiparcel_building_filter_1(self, cache_directory: Path):
-        aoi = loads("Polygon ((151.27703696149524148 -33.79262202320504827, 151.27733681519475795 -33.79266133351605816, 151.27731228659985163 -33.79279055527718612, 151.27701243290030675 -33.79275124502552075, 151.27703696149524148 -33.79262202320504827))")
-        building = loads(""" POLYGON ((
+        aoi = loads(
+            "Polygon ((151.27703696149524148 -33.79262202320504827, 151.27733681519475795 -33.79266133351605816, 151.27731228659985163 -33.79279055527718612, 151.27701243290030675 -33.79275124502552075, 151.27703696149524148 -33.79262202320504827))"
+        )
+        building = loads(
+            """ POLYGON ((
             151.27712199999999143 -33.7926259999999985,
             151.27713900000000535 -33.79253500000000088,
             151.2771669999999915 -33.79253899999999788,
@@ -488,7 +508,7 @@ class TestFeatureAPI:
         """
         )
         country = "au"
-        pass # TODO: Implement test. This should come up as a multi parcel building.
+        pass  # TODO: Implement test. This should come up as a multi parcel building.
 
         # Convert the polygons to a metric CRS
         aoi_metric = gpd.GeoDataFrame(geometry=[aoi], crs=API_CRS).to_crs(AREA_CRS[country]).iloc[0].geometry
@@ -547,3 +567,8 @@ class TestFeatureAPI:
             "trampoline",
         }
         assert not expected_subset.difference(packs.keys())
+
+
+if __name__ == "__main__":
+    current_file = os.path.abspath(__file__)
+    sys.exit(pytest.main([current_file]))


### PR DESCRIPTION
Non-urgent cleanup PR (to be merged directly into `fix_buffers`):

- Added missing `python-dotenv` to `environment.yaml`
- Added all required dependencies to `setup.py` and updated python version to match `environment.yaml`.
  - Note: If we are going to include both a `setup.py` and `environment.yaml`, we should keep this maintained. Alternatively, we can remove one or the other depending on target user.
- Although `black` and `isort` were specified in the dependencies, it doesn't appear that they were actually being run on these files. So I minimally ran them on the main files and tests. We can clean up the remainder of the repo at a later time.
  - Note: The only 2 custom black formatter args that are turned on are `--line-length` of `120` and the `--preview` flag. These are consistent with what we were using for the Betterview ML Python code, but I am open to whatever formatting that Nearmap follows.

Additionally, we may want to start pinning package versions in the future to help avoid any issues.