### PR TITLE
INDS-1665 Get unclipped multiparcel buildings

### DIFF
--- a/nmaipy/empty_roof_attributes.json
+++ b/nmaipy/empty_roof_attributes.json
@@ -1,0 +1,462 @@
+[
+    {
+        "classId": "89c7d478-58de-56bd-96d2-e71e27a36905",
+        "internalClassId": 3,
+        "description": "Roof material",
+        "components": [
+            {
+                "classId": "516fdfd5-0be9-59fe-b849-92faef8ef26e",
+                "internalClassId": 1007,
+                "description": "Tile",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4bbf8dbd-cc81-5773-961f-0121101422be",
+                "internalClassId": 1008,
+                "description": "Shingle",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4424186a-0b42-5608-a5a0-d4432695c260",
+                "internalClassId": 1009,
+                "description": "Metal",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4558c4fb-3ddf-549d-b2d2-471384be23d1",
+                "internalClassId": 1100,
+                "description": "Ballasted",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "87437e20-d9f5-57e1-8b87-4a9c81ec3b65",
+                "internalClassId": 1101,
+                "description": "Mod-Bit",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "383930f1-d866-5aa3-9f97-553311f3162d",
+                "internalClassId": 1103,
+                "description": "PVC/TPO",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "64db6ea0-7248-53f5-b6a6-6ed733c5f9b8",
+                "internalClassId": 1104,
+                "description": "EPDM",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "9fc4c92e-4405-573e-bce6-102b74ab89a3",
+                "internalClassId": 1105,
+                "description": "Wood Shake",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "09ed6bf9-182a-5c79-ae59-f5531181d298",
+                "internalClassId": 1160,
+                "description": "Clay Tile",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "cdc50dcc-e522-5361-8f02-4e30673311bb",
+                "internalClassId": 1163,
+                "description": "Slate",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "3563c8f1-e81e-52c7-bd56-eaa937010403",
+                "internalClassId": 1165,
+                "description": "Built Up",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "b2573072-b3a5-5f7c-973f-06b7649665ff",
+                "internalClassId": 1168,
+                "description": "Roof Coating",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            }
+        ]
+    },
+    {
+        "classId": "20a58db2-bc02-531d-98f5-451f88ce1fed",
+        "internalClassId": 4,
+        "description": "Roof types",
+        "components": [
+            {
+                "classId": "ac0a5f75-d8aa-554c-8a43-cee9684ef9e9",
+                "internalClassId": 1013,
+                "description": "Hip",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "59c6e27e-6ef2-5b5c-90e7-31cfca78c0c2",
+                "internalClassId": 1014,
+                "description": "Gable",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "3719eb40-d6d1-5071-bbe6-379a551bb65f",
+                "internalClassId": 1015,
+                "description": "Dutch Gable",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "224f98d3-b853-542a-8b18-e1e46e3a8200",
+                "internalClassId": 1016,
+                "description": "Flat (Deprecated)",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7ac62320-52f3-5301-94c5-7adf6b93a3b8",
+                "internalClassId": 1018,
+                "description": "Shed",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "4bb630b9-f9eb-5f95-85b8-f0c6caf16e9b",
+                "internalClassId": 1019,
+                "description": "Gambrel",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "89582082-e5b8-5853-bc94-3a0392cab98a",
+                "internalClassId": 1020,
+                "description": "Turret",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1234ea84-e334-5c58-88a9-6554be3dfc05",
+                "internalClassId": 1173,
+                "description": "Parapet",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7eb3b1b6-0d75-5b1f-b41c-b14146ff0c54",
+                "internalClassId": 1174,
+                "description": "Mansard",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "924afbab-aae6-5c26-92e8-9173e4320495",
+                "internalClassId": 1176,
+                "description": "Jerkinhead",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "e92bc8a2-9fa3-5094-b3b6-2881d94642ab",
+                "internalClassId": 1178,
+                "description": "Quonset",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "09b925d2-df1d-599b-89f1-3ffd39df791e",
+                "internalClassId": 1180,
+                "description": "Bowstring Truss",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1ab60ef7-e770-5ab6-995e-124676b2be11",
+                "internalClassId": 1191,
+                "description": "Flat",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    },
+    {
+        "classId": "7ab56e15-d5d4-51bb-92bd-69e910e82e56",
+        "internalClassId": 5,
+        "description": "Roof overhang attributes",
+        "components": [
+            {
+                "classId": "8e9448bd-4669-5f46-b8f0-840fee25c34c",
+                "internalClassId": 1045,
+                "description": "Tree Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "042a1d14-4a23-50dc-aabb-befc9645af3b",
+                "internalClassId": 1084,
+                "description": "Leaf-off Tree Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "38c4dd92-868c-582a-a4d5-537c88dcec75",
+                "internalClassId": 1085,
+                "description": "Low Vegetation (0.5m-2m) Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "fcbb15ea-93e5-587c-8941-246353817741",
+                "internalClassId": 1086,
+                "description": "Very Low Vegetation (<0.5m) Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1ef797a5-8057-5e8b-a24d-dc7cd8f1fa7b",
+                "internalClassId": 1087,
+                "description": "Power Line Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    },
+    {
+        "classId": "39072960-5582-52af-9051-4bc8625ff9ba",
+        "internalClassId": 7,
+        "description": "Roof 3d attributes",
+        "has3dAttributes": false
+    },
+    {
+        "classId": "3065525d-3f14-5b9d-8c4c-077f1ad5c694",
+        "internalClassId": 10,
+        "description": "Roof Condition",
+        "components": [
+            {
+                "classId": "f907e625-26b3-59db-a806-d41f62ce1f1b",
+                "internalClassId": 1049,
+                "description": "Structural Damage",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "abb1f304-ce01-527b-b799-cbfd07551b2c",
+                "internalClassId": 1050,
+                "description": "Roof with Temporary Repair",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "f41e02b0-adc0-5b46-ac95-8c59aa9fe317",
+                "internalClassId": 1051,
+                "description": "Roof Ponding",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "526496bf-7344-5024-82d7-77ceb671feb4",
+                "internalClassId": 1052,
+                "description": "Roof Rusting",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "cfa8951a-4c29-54de-ae98-e5f804c305e3",
+                "internalClassId": 1053,
+                "description": "Tile or Shingle Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "dec855e2-ae6f-56b5-9cbb-f9967ff8ca12",
+                "internalClassId": 1079,
+                "description": "Missing Roof Tile or Shingle",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7218eb36-0d36-5b53-a2fe-6e99c7d950bc",
+                "internalClassId": 1080,
+                "description": "Roof with Permanent Repair",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "f55813f9-a39d-571d-9688-8d3f76aa35b9",
+                "internalClassId": 1081,
+                "description": "Zinc Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "8ab218a7-8173-5f1e-a5cb-bb2cd386a73e",
+                "internalClassId": 1139,
+                "description": "Roof Debris",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "2905ba1c-6d96-58bc-9b1b-5911b3ead023",
+                "internalClassId": 1140,
+                "description": "Exposed Roof Deck",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "82b4547b-b8c0-5e9a-84c2-5c7564b4586c",
+                "internalClassId": 1141,
+                "description": "Missing Asphalt shingles",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "94944057-968c-5df3-828b-285091b7e266",
+                "internalClassId": 1142,
+                "description": "Active Ponding",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "319f552f-f4b7-520d-9b16-c8abb394b043",
+                "internalClassId": 1144,
+                "description": "Roof Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "97a6f930-82ae-55f2-b856-635e2250af29",
+                "internalClassId": 1146,
+                "description": "Worn Shingles",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "2322ca41-5d3d-5782-b2b7-1a2ffd0c4b78",
+                "internalClassId": 1147,
+                "description": "Exposed Underlayment",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "8b30838b-af41-5d1d-bdbd-29e682fe3b00",
+                "internalClassId": 1149,
+                "description": "Roof Patching",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    }
+]

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -235,7 +235,7 @@ def read_from_file(
 
 
 def filter_features_in_parcels(
-    features_gdf: gpd.GeoDataFrame, aoi_gdf: gpd.GeoDataFrame, region: str
+    features_gdf: gpd.GeoDataFrame, aoi_gdf: gpd.GeoDataFrame, region: str, clip_multiparcel_buildings: bool = True
 ) -> gpd.GeoDataFrame:
     """
     Drop features that are not considered as "inside" or "belonging to" a parcel. These fall into two categories:
@@ -293,26 +293,31 @@ def filter_features_in_parcels(
         gdf_aoi = gdf.loc[[aoi_id]]
         gdf_aoi_buildings = gdf_aoi[gdf_aoi.class_id.isin(building_style_ids)]
         if len(gdf_aoi_buildings) == 0:
-            continue # Skip if there are no buildings in the AOI
+            continue  # Skip if there are no buildings in the AOI
         features_from_aoi = aoi_gdf.loc[[aoi_id]]
         aoi_poly = (
             features_from_aoi.to_crs(AREA_CRS[region]).iloc[0].geometry
         )  # Get in metric projection for area/geospatial calcs in metres.
         building_statuses = []
-        for building_poly in gdf_aoi_buildings.to_crs(AREA_CRS[region]).geometry: # Loop through buildings in the AOI
+        for building_poly in gdf_aoi_buildings.to_crs(AREA_CRS[region]).geometry:  # Loop through buildings in the AOI
             building_status = nmaipy.reference_code.get_building_status(building_poly, aoi_poly)
             building_statuses.append(building_status)
         building_statuses = pd.DataFrame(building_statuses)
         building_statuses.index = gdf_aoi_buildings.index
-        gdf_aoi_buildings = pd.concat([gdf_aoi_buildings, building_statuses], axis=1) # Append extra columns for all buildings in this parcel
-        gdf_aoi_buildings = gdf_aoi_buildings[gdf_aoi_buildings.building_keep].drop(columns=["building_keep"]) # Remove any we should filter out
+        gdf_aoi_buildings = pd.concat(
+            [gdf_aoi_buildings, building_statuses], axis=1
+        )  # Append extra columns for all buildings in this parcel
+        gdf_aoi_buildings = gdf_aoi_buildings[gdf_aoi_buildings.building_keep].drop(
+            columns=["building_keep"]
+        )  # Remove any we should filter out
 
-        # Clip any building that is "multiparcel" to the intersection with the AOI
-        multiparcel_mask = gdf_aoi_buildings["building_multiparcel"]
-        if multiparcel_mask.any():
-            aoi_poly_api_crs = features_from_aoi.iloc[0].geometry
-            new_geometries = gdf_aoi_buildings[multiparcel_mask].intersection(aoi_poly_api_crs).geometry
-            gdf_aoi_buildings.loc[multiparcel_mask, "geometry"] = new_geometries
+        if clip_multiparcel_buildings:
+            # Clip any building that is "multiparcel" to the intersection with the AOI
+            multiparcel_mask = gdf_aoi_buildings["building_multiparcel"]
+            if multiparcel_mask.any():
+                aoi_poly_api_crs = features_from_aoi.iloc[0].geometry
+                new_geometries = gdf_aoi_buildings[multiparcel_mask].intersection(aoi_poly_api_crs).geometry
+                gdf_aoi_buildings.loc[multiparcel_mask, "geometry"] = new_geometries
 
         out_gdf_building_style.append(gdf_aoi_buildings)
 
@@ -339,9 +344,15 @@ def filter_features_in_parcels(
     features_to_update = gdf[has_parent].copy().reset_index().set_index(idx_cols)
 
     # Wherever a parent exists in the same AOI, identify the parent geometry as a column next to the child feature "geometry".
-    gdf_parent_lookup = features_to_update["geometry"].reset_index().rename(columns={"feature_id": "parent_id", "geometry": "parent_geometry"})
-    features_to_update = features_to_update.reset_index().merge(gdf_parent_lookup, on=["aoi_id", "parent_id"], how="left").set_index(
-        idx_cols
+    gdf_parent_lookup = (
+        features_to_update["geometry"]
+        .reset_index()
+        .rename(columns={"feature_id": "parent_id", "geometry": "parent_geometry"})
+    )
+    features_to_update = (
+        features_to_update.reset_index()
+        .merge(gdf_parent_lookup, on=["aoi_id", "parent_id"], how="left")
+        .set_index(idx_cols)
     )
 
     # Update our knowledge of which features actually have a parent (as some may have a parent ID that isn't in the dataframe)
@@ -355,9 +366,9 @@ def filter_features_in_parcels(
     new_area = features_to_update.geometry.to_crs(AREA_CRS[region]).area
 
     # Recalculate areas for clipped features
-    if 'area_sqm' in gdf.columns:
-        features_to_update.loc[has_parent, 'area_sqm'] = new_area
-    elif 'area_sqft' in gdf.columns:
+    if "area_sqm" in gdf.columns:
+        features_to_update.loc[has_parent, "area_sqm"] = new_area
+    elif "area_sqft" in gdf.columns:
         features_to_update.loc[has_parent, "area_sqft"] = new_area * METERS_TO_FEET * METERS_TO_FEET
 
     # Update gdf with the new information, from rows matching AOI_ID_COLUMN_NAME and feature_id

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 from pathlib import Path
 from typing import List, Optional, Union
@@ -366,10 +367,10 @@ def filter_features_in_parcels(
     new_area = features_to_update.geometry.to_crs(AREA_CRS[region]).area
 
     # Recalculate areas for clipped features
-    if "area_sqm" in gdf.columns:
-        features_to_update.loc[has_parent, "area_sqm"] = new_area
-    elif "area_sqft" in gdf.columns:
-        features_to_update.loc[has_parent, "area_sqft"] = new_area * METERS_TO_FEET * METERS_TO_FEET
+    if "clipped_area_sqm" in gdf.columns:
+        features_to_update.loc[has_parent, "clipped_area_sqm"] = new_area
+    if "clipped_area_sqft" in gdf.columns:
+        features_to_update.loc[has_parent, "clipped_area_sqft"] = new_area * METERS_TO_FEET * METERS_TO_FEET
 
     # Update gdf with the new information, from rows matching AOI_ID_COLUMN_NAME and feature_id
     gdf = gdf.reset_index().set_index(idx_cols)
@@ -377,6 +378,173 @@ def filter_features_in_parcels(
     assert not features_to_update.index.has_duplicates
     gdf.update(features_to_update)
     gdf = gdf.reset_index().set_index(AOI_ID_COLUMN_NAME)
+
+    # Get all of the structural damage composite features
+    all_damage_gdf = gdf[gdf["class_id"] == CLASS_1186_STRUCTURAL_DAMAGE]
+
+    # Iterate over the AOIs with structural damage composite features
+    for aoi_id in all_damage_gdf.index.unique():
+        # Get the structural damage composite features in this AOI
+        aoi_damage_gdf = all_damage_gdf.loc[aoi_id]
+
+        # Skip this AOI if the total structrual damage area is 0
+        if aoi_damage_gdf["clipped_area_sqm"].sum() == 0:
+            continue
+
+        # Filter for only the features in this AOI
+        # NOTE: This was needed just in case some features span multiple AOIs
+        aoi_gdf = gdf.loc[aoi_id]
+        aoi_roof_gdf = aoi_gdf[aoi_gdf["class_id"] == ROOF_ID]
+
+        # Get the building lifecycle features in this AOI with structural damage composite children
+        lifecycle_gdf = aoi_gdf[aoi_gdf["feature_id"].isin(aoi_damage_gdf["parent_id"])]
+
+        # Iterate over the building lifecycle features with structural damage composite children
+        for lifecycle_row in lifecycle_gdf.itertuples():
+            # Get the structural damage composite features that are children of this building lifecycle feature
+            damage_gdf = aoi_damage_gdf[aoi_damage_gdf["parent_id"] == lifecycle_row.feature_id]
+
+            # Get the roofs that intersect with this building lifecycle feature
+            # Reproject both roof rows and building lifecycle rows to a projected CRS (EPSG:3857) for the intersection
+            lifecycle_geometry = gpd.GeoSeries(lifecycle_row.geometry, crs="EPSG:4326")
+            aoi_roof_gdf_3857 = aoi_roof_gdf.to_crs("EPSG:3857")
+            lifecycle_geometry_3857 = lifecycle_geometry.to_crs("EPSG:3857").unary_union
+            intersecting_roof_gdf = aoi_roof_gdf[aoi_roof_gdf_3857["geometry"].intersects(lifecycle_geometry_3857)]
+
+            if intersecting_roof_gdf.empty:
+                # If there are no roof rows that intersect
+                roof_covers_damage = False
+            else:
+                # Do these intersecting roofs fully contain the structural damage composite features inside of their geometries?
+                roof_covers_damage = (
+                    intersecting_roof_gdf["geometry"]
+                    .to_crs("EPSG:3857")
+                    .unary_union.contains(damage_gdf["geometry"].to_crs("EPSG:3857").unary_union)
+                )
+
+            # If the roofs fully cover the structural damage composite features, then we will use the roof geometries
+            # and not the building lifecycle geometries since they look better.
+            # We just need to update the roof structural damage attributes so the rollup gets calculated correctly
+            if roof_covers_damage:
+                # Iterate over the roofs
+                for roof_row in intersecting_roof_gdf.itertuples():
+                    # Get the structural damage composite features that intersect with this roof
+                    roof_geometry = gpd.GeoSeries(roof_row.geometry, crs="EPSG:4326").to_crs("EPSG:3857").iloc[0]
+                    intersecting_damage_gdf = damage_gdf[
+                        damage_gdf["geometry"].to_crs("EPSG:3857").intersects(roof_geometry)
+                    ]
+
+                    # Change the parent ID of these structural damage composite features to the roof feature ID
+                    # NOTE: This will allow for the attributes to get calculated correctly in the rollup
+                    gdf.loc[
+                        (gdf.index == aoi_id) & (gdf["feature_id"].isin(intersecting_damage_gdf["feature_id"])),
+                        "parent_id",
+                    ] = roof_row.feature_id
+
+                # Remove this building lifecycle to avoid confusion downstream
+                gdf = gdf[
+                    ~(
+                        (gdf.index == aoi_id)
+                        & (gdf["feature_id"] == lifecycle_row.feature_id)
+                        & (gdf["class_id"] == BUILDING_LIFECYCLE_ID)
+                    )
+                ]
+            else:
+                # If the roofs do not fully cover the structural damage composite features, then we will replace the
+                # the roof features with the building lifecycle feature
+
+                # Update the building lifecycle feature to be a roof feature
+                lifecycle_mask = (gdf.index == aoi_id) & (gdf["feature_id"] == lifecycle_row.feature_id)
+                gdf.loc[lifecycle_mask, "class_id"] = ROOF_ID
+                gdf.loc[lifecycle_mask, "internal_class_id"] = 1002
+                gdf.loc[lifecycle_mask, "description"] = "Roof"
+
+                if intersecting_roof_gdf.empty:
+                    # If there are no roofs that intersect, then manually create the roof attributes with just the structural damage
+                    # NOTE: Just needs a placeholder so the component can be updated in the next step for the rollup
+
+                    # Read in the empty roof attributes from a json file
+                    current_dir = Path(__file__).parent
+                    roof_attributes_file_path = current_dir / "empty_roof_attributes.json"
+                    with open(roof_attributes_file_path) as f:
+                        empty_roof_attributes = json.load(f)
+                    # Copy the empty roof attributes over to the building lifecycle feature
+                    empty_roof_attributes_series = pd.Series([empty_roof_attributes], name="attributes")
+                    gdf.loc[lifecycle_mask, "attributes"] = empty_roof_attributes_series
+                else:
+                    # Copy the roof attributes from one of the roofs over to the building lifecycle feature
+                    # NOTE: Doesn't matter which one we copy over as these will get updated in the next step
+                    # NOTE: Index (aoi_id is not unique at this point so need to use nlargest)
+                    largest_intersecting_roof = intersecting_roof_gdf.nlargest(1, "clipped_area_sqm")
+                    gdf.loc[lifecycle_mask, "attributes"] = largest_intersecting_roof["attributes"]
+
+                    # Update the parent ID of all intersecting roof child features to the building lifecycle feature ID
+                    # NOTE: This is needed so that the rollup gets calculated correctly
+                    intersecting_roof_feature_ids = intersecting_roof_gdf["feature_id"]
+                    gdf.loc[gdf["parent_id"].isin(intersecting_roof_feature_ids), "parent_id"] = (
+                        lifecycle_row.feature_id
+                    )
+
+                    # Remove all of the intersecting roof features (these have been replaced by the building lifecycle feature)
+                    gdf = gdf[~((gdf.index == aoi_id) & (gdf["feature_id"].isin(intersecting_roof_feature_ids)))]
+
+    # Get all of the features that have attributes
+    features_with_attributes_df = gdf[gdf["attributes"].astype(bool)]
+
+    # Update the areas, ratios, and confidences for the features with attributes (e.g. roofs) in case we applied clipping above.
+    for parent_feature in features_with_attributes_df.itertuples():
+        for attribute in parent_feature.attributes:
+            if "components" in attribute:
+                for component in attribute["components"]:
+                    child_class_id = component["classId"]
+                    parent_feature_id = parent_feature.feature_id
+
+                    # Feature API uses the STRUCTURALLY_DAMAGED_ROOF for the Roof Condition attribute. However, the
+                    # structural damage composite class is what is being used for the RSI score and displayed in Tower.
+                    # Therefore, if the structural damage composite class is available as a feature returned from the API,
+                    # we should use that instead of the STRUCTURALLY_DAMAGED_ROOF class.
+                    if child_class_id == STRUCTURALLY_DAMAGED_ROOF:
+                        has_structural_damage_composite = (
+                            (gdf["class_id"] == CLASS_1186_STRUCTURAL_DAMAGE) & (gdf["parent_id"] == parent_feature_id)
+                        ).any()
+                        # If structural damage composite is available, use that one instead
+                        if has_structural_damage_composite:
+                            child_class_id = CLASS_1186_STRUCTURAL_DAMAGE
+                            component["classId"] = child_class_id
+
+                    # Get all of the child features for this parent feature
+                    child_features_df = gdf[
+                        (gdf["class_id"] == child_class_id) & (gdf["parent_id"] == parent_feature_id)
+                    ]
+                    # If there are no child features found, then don't do anything
+                    if len(child_features_df) == 0:
+                        continue
+
+                    # If the child area has been clipped to 0, then update the values accordingly
+                    child_area_sqm = child_features_df["clipped_area_sqm"].sum()
+                    if child_area_sqm == 0:
+                        component["areaSqm"] = 0
+                        component["areaSqft"] = 0
+                        component["ratio"] = 0
+                        component["confidence"] = None
+                        continue
+
+                    # Update the areas in case we applied clipping
+                    component["areaSqm"] = child_area_sqm
+                    child_area_sqft = child_features_df["clipped_area_sqft"].sum()
+                    component["areaSqft"] = child_area_sqft
+
+                    # Update the ratio in case we applied clipping
+                    parent_area_sqm = parent_feature.clipped_area_sqm
+                    # Handle edge case in case the parent area is zero
+                    ratio = (child_area_sqm / parent_area_sqm) if parent_area_sqm > 0 else 0
+                    component["ratio"] = ratio
+
+                    # Update the (area-weighted) confidence in case we applied clipping
+                    child_confidence = (
+                        child_features_df["confidence"] * child_features_df["clipped_area_sqm"]
+                    ).sum() / child_area_sqm
+                    component["confidence"] = child_confidence
 
     # TODO: Decide what to do do about ratios etc, and whether they get recalculated. Currently left as is.
     return gdf
@@ -540,6 +708,16 @@ def feature_attributes(
                         .idxmin()
                     )
                 primary_feature = class_features_gdf.loc[nearest_feature_idx, :]
+            elif primary_decision == "nearest_no_filter":
+                primary_point = Point(primary_lon, primary_lat)
+                primary_point = gpd.GeoSeries(primary_point).set_crs("EPSG:4326").to_crs("EPSG:3857")[0]
+                nearest_feature_idx = (
+                    class_features_gdf.set_geometry("geometry_feature")
+                    .to_crs("EPSG:3857")
+                    .distance(primary_point)
+                    .idxmin()
+                )
+                primary_feature = class_features_gdf.loc[nearest_feature_idx, :]
             else:
                 raise NotImplementedError(f"Have not implemented primary_decision type '{primary_decision}'")
             if country in IMPERIAL_COUNTRIES:
@@ -674,7 +852,7 @@ def parcel_rollup(
         raise Exception(
             f"AOI id index {AOI_ID_COLUMN_NAME} is NOT unique in parcels/AOI dataframe, but it should be: there are {len(parcels_gdf.index.unique())} unique AOI ids and {len(parcels_gdf)} rows in the dataframe"
         )
-    if primary_decision == "nearest":
+    if primary_decision == "nearest" or primary_decision == "nearest_no_filter":
         merge_cols = [
             LAT_PRIMARY_COL_NAME,
             LON_PRIMARY_COL_NAME,
@@ -690,7 +868,7 @@ def parcel_rollup(
     rollups = []
     # Loop over parcels with features in them
     for aoi_id, group in df.reset_index().groupby(AOI_ID_COLUMN_NAME):
-        if primary_decision == "nearest":
+        if primary_decision == "nearest" or primary_decision == "nearest_no_filter":
             primary_lon = group[LON_PRIMARY_COL_NAME].unique()
             if len(primary_lon) == 1:
                 primary_lon = primary_lon[0]

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -609,7 +609,12 @@ def feature_attributes(
                     buffered_primary_roof_geom_area = primary_roof_geom_area.buffer(buffer_dist)
 
                     if not buffered_primary_roof_geom_area.within(parcel_geom_area):
+                        # logger.info(features_gdf)
                         # Skip if the buffer protrudes outside the parcel
+                        # logger.info(
+                        #     f"""skipping buffer calculation for aoi_id:feature_id {features_gdf["aoi_id"].tolist()[0]}, nmaipy feature_id {features_gdf["feature_id"].tolist()[0]}; buffer {buffer_dist} extends outside parcel."""
+                        # )
+                        # logger.info(gpd.GeoSeries([primary_feature.geometry_feature], crs=LAT_LONG_CRS).iloc[0])
                         continue
 
                     # Proceed calculating intersections etc. with the buffered primary roof


### PR DESCRIPTION
When getting roof geometries for the defensible space calculations in the insurance retro pipeline, we want to be able to get the entire unclipped roof geometries in the case of a multiparcel building. This PR adds a flag to the `AOIExporter` called `clip_multiparcel_buildings` that gives the user a choice to skip the clipping of a multiparcel building to the AOI.

Note: most of the code diff is due to black and isort formatting. I will note the main change in a comment below.