### PR TITLE
INDS-1666 Clip detections to clipped multi-parcel buildings

### DIFF
--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -524,13 +524,8 @@ def feature_attributes(
 
         # Add attributes that apply to all feature classes
         # TODO: This sets a column to "N" even if it's not possible to return it with the query (e.g. alpha/beta attribute permissions, or version issues). Need to filter out columns that pertain to this. Need to parse "availability" column in classes_df and determine what system version this row is.
-        parcel[f"{name}_present"] = (
-            TRUE_STRING if len(class_features_gdf) > 0 else FALSE_STRING
-        )  # PROBLEM: All of these features could be empty but we are simply using the existence of them to determine if they are present.
-        parcel[f"{name}_count"] = len(
-            class_features_gdf
-        )  # PROBLEM: All of these features could be empty but we are simply using the existence of them to determine the count.
-        # However, do we keep them around because there is an unclipped area? Or do we remove them because they are not present in the clipped area like the building?
+        parcel[f"{name}_present"] = TRUE_STRING if len(class_features_gdf) > 0 else FALSE_STRING
+        parcel[f"{name}_count"] = len(class_features_gdf)
         if country in IMPERIAL_COUNTRIES:
             parcel[f"{name}_total_area_sqft"] = class_features_gdf.area_sqft.sum()
             parcel[f"{name}_total_clipped_area_sqft"] = round(class_features_gdf.clipped_area_sqft.sum(), 1)


### PR DESCRIPTION
_NOTE: This PR is not to be merged into main and is a temporary fix specific to the insurance retro pipeline._

In the case of a multi-parcel building that gets clipped to the parcel, we are currently correctly clipping the child features for that roof. However, we are not updating the values (e.g. `areaSqm`, `areaSqft`, `ratio`, `confidence`) of the roof `attributes` (e.g. `Roof Condition`, `Roof material`, `Roof types`, `Roof overhand attributes`) that later get used downstream for calculating the primary_roof attributes (e.g. `primary_roof_roof_staining_area_sqft`) in the parcel rollup. This is causing an issue in the insurance retro pipeline since we are depending on these primary_roof attributes for the calculations of scores such as the peril scores.

This is considered a "hack" and a temporary fix specific to the retro pipeline because of several reasons. The main reason being that in the case that the user doesn't request all of the required classes in the request to the feature API, then that class/feature/geometry will not be available to clip to the newly clipped multi-parcel building and therefore we will not be able to update the corresponding roof `attributes`. For the retro pipeline, we will ensure that all available classes are requested in the API call so that we can ensure that their corresponding roof attributes will be properly clipped and updated.

Additionally, the `Roof condition` attribute returned from the feature API appears fixed to an older structural damage class and not the structural damage _composite_ class we are currently using for the RSI score and Tower product. Therefore, there is also a hack here that replaces the older structural damage values with the composite class if it was made available as a feature in the request.