### PR TITLE
INDS-1691 Handle more edge cases for structural damage and building lifecycle

### DIFF
--- a/nmaipy/empty_roof_attributes.json
+++ b/nmaipy/empty_roof_attributes.json
@@ -1,0 +1,462 @@
+[
+    {
+        "classId": "89c7d478-58de-56bd-96d2-e71e27a36905",
+        "internalClassId": 3,
+        "description": "Roof material",
+        "components": [
+            {
+                "classId": "516fdfd5-0be9-59fe-b849-92faef8ef26e",
+                "internalClassId": 1007,
+                "description": "Tile",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4bbf8dbd-cc81-5773-961f-0121101422be",
+                "internalClassId": 1008,
+                "description": "Shingle",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4424186a-0b42-5608-a5a0-d4432695c260",
+                "internalClassId": 1009,
+                "description": "Metal",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "4558c4fb-3ddf-549d-b2d2-471384be23d1",
+                "internalClassId": 1100,
+                "description": "Ballasted",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "87437e20-d9f5-57e1-8b87-4a9c81ec3b65",
+                "internalClassId": 1101,
+                "description": "Mod-Bit",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "383930f1-d866-5aa3-9f97-553311f3162d",
+                "internalClassId": 1103,
+                "description": "PVC/TPO",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "64db6ea0-7248-53f5-b6a6-6ed733c5f9b8",
+                "internalClassId": 1104,
+                "description": "EPDM",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "9fc4c92e-4405-573e-bce6-102b74ab89a3",
+                "internalClassId": 1105,
+                "description": "Wood Shake",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "09ed6bf9-182a-5c79-ae59-f5531181d298",
+                "internalClassId": 1160,
+                "description": "Clay Tile",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "cdc50dcc-e522-5361-8f02-4e30673311bb",
+                "internalClassId": 1163,
+                "description": "Slate",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "3563c8f1-e81e-52c7-bd56-eaa937010403",
+                "internalClassId": 1165,
+                "description": "Built Up",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            },
+            {
+                "classId": "b2573072-b3a5-5f7c-973f-06b7649665ff",
+                "internalClassId": 1168,
+                "description": "Roof Coating",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0,
+                "dominant": false
+            }
+        ]
+    },
+    {
+        "classId": "20a58db2-bc02-531d-98f5-451f88ce1fed",
+        "internalClassId": 4,
+        "description": "Roof types",
+        "components": [
+            {
+                "classId": "ac0a5f75-d8aa-554c-8a43-cee9684ef9e9",
+                "internalClassId": 1013,
+                "description": "Hip",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "59c6e27e-6ef2-5b5c-90e7-31cfca78c0c2",
+                "internalClassId": 1014,
+                "description": "Gable",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "3719eb40-d6d1-5071-bbe6-379a551bb65f",
+                "internalClassId": 1015,
+                "description": "Dutch Gable",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "224f98d3-b853-542a-8b18-e1e46e3a8200",
+                "internalClassId": 1016,
+                "description": "Flat (Deprecated)",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7ac62320-52f3-5301-94c5-7adf6b93a3b8",
+                "internalClassId": 1018,
+                "description": "Shed",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "4bb630b9-f9eb-5f95-85b8-f0c6caf16e9b",
+                "internalClassId": 1019,
+                "description": "Gambrel",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "89582082-e5b8-5853-bc94-3a0392cab98a",
+                "internalClassId": 1020,
+                "description": "Turret",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1234ea84-e334-5c58-88a9-6554be3dfc05",
+                "internalClassId": 1173,
+                "description": "Parapet",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7eb3b1b6-0d75-5b1f-b41c-b14146ff0c54",
+                "internalClassId": 1174,
+                "description": "Mansard",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "924afbab-aae6-5c26-92e8-9173e4320495",
+                "internalClassId": 1176,
+                "description": "Jerkinhead",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "e92bc8a2-9fa3-5094-b3b6-2881d94642ab",
+                "internalClassId": 1178,
+                "description": "Quonset",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "09b925d2-df1d-599b-89f1-3ffd39df791e",
+                "internalClassId": 1180,
+                "description": "Bowstring Truss",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1ab60ef7-e770-5ab6-995e-124676b2be11",
+                "internalClassId": 1191,
+                "description": "Flat",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    },
+    {
+        "classId": "7ab56e15-d5d4-51bb-92bd-69e910e82e56",
+        "internalClassId": 5,
+        "description": "Roof overhang attributes",
+        "components": [
+            {
+                "classId": "8e9448bd-4669-5f46-b8f0-840fee25c34c",
+                "internalClassId": 1045,
+                "description": "Tree Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "042a1d14-4a23-50dc-aabb-befc9645af3b",
+                "internalClassId": 1084,
+                "description": "Leaf-off Tree Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "38c4dd92-868c-582a-a4d5-537c88dcec75",
+                "internalClassId": 1085,
+                "description": "Low Vegetation (0.5m-2m) Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "fcbb15ea-93e5-587c-8941-246353817741",
+                "internalClassId": 1086,
+                "description": "Very Low Vegetation (<0.5m) Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "1ef797a5-8057-5e8b-a24d-dc7cd8f1fa7b",
+                "internalClassId": 1087,
+                "description": "Power Line Overhang",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    },
+    {
+        "classId": "39072960-5582-52af-9051-4bc8625ff9ba",
+        "internalClassId": 7,
+        "description": "Roof 3d attributes",
+        "has3dAttributes": false
+    },
+    {
+        "classId": "3065525d-3f14-5b9d-8c4c-077f1ad5c694",
+        "internalClassId": 10,
+        "description": "Roof Condition",
+        "components": [
+            {
+                "classId": "f907e625-26b3-59db-a806-d41f62ce1f1b",
+                "internalClassId": 1049,
+                "description": "Structural Damage",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "abb1f304-ce01-527b-b799-cbfd07551b2c",
+                "internalClassId": 1050,
+                "description": "Roof with Temporary Repair",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "f41e02b0-adc0-5b46-ac95-8c59aa9fe317",
+                "internalClassId": 1051,
+                "description": "Roof Ponding",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "526496bf-7344-5024-82d7-77ceb671feb4",
+                "internalClassId": 1052,
+                "description": "Roof Rusting",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "cfa8951a-4c29-54de-ae98-e5f804c305e3",
+                "internalClassId": 1053,
+                "description": "Tile or Shingle Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "dec855e2-ae6f-56b5-9cbb-f9967ff8ca12",
+                "internalClassId": 1079,
+                "description": "Missing Roof Tile or Shingle",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "7218eb36-0d36-5b53-a2fe-6e99c7d950bc",
+                "internalClassId": 1080,
+                "description": "Roof with Permanent Repair",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "f55813f9-a39d-571d-9688-8d3f76aa35b9",
+                "internalClassId": 1081,
+                "description": "Zinc Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "8ab218a7-8173-5f1e-a5cb-bb2cd386a73e",
+                "internalClassId": 1139,
+                "description": "Roof Debris",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "2905ba1c-6d96-58bc-9b1b-5911b3ead023",
+                "internalClassId": 1140,
+                "description": "Exposed Roof Deck",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "82b4547b-b8c0-5e9a-84c2-5c7564b4586c",
+                "internalClassId": 1141,
+                "description": "Missing Asphalt shingles",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "94944057-968c-5df3-828b-285091b7e266",
+                "internalClassId": 1142,
+                "description": "Active Ponding",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "319f552f-f4b7-520d-9b16-c8abb394b043",
+                "internalClassId": 1144,
+                "description": "Roof Staining",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "97a6f930-82ae-55f2-b856-635e2250af29",
+                "internalClassId": 1146,
+                "description": "Worn Shingles",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "2322ca41-5d3d-5782-b2b7-1a2ffd0c4b78",
+                "internalClassId": 1147,
+                "description": "Exposed Underlayment",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            },
+            {
+                "classId": "8b30838b-af41-5d1d-bdbd-29e682fe3b00",
+                "internalClassId": 1149,
+                "description": "Roof Patching",
+                "confidence": null,
+                "areaSqm": 0,
+                "areaSqft": 0,
+                "ratio": 0
+            }
+        ]
+    }
+]

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 from pathlib import Path
 from typing import List, Optional, Union
@@ -379,90 +380,113 @@ def filter_features_in_parcels(
     gdf = gdf.reset_index().set_index(AOI_ID_COLUMN_NAME)
 
     # Get all of the structural damage composite features
-    all_damage_composite_rows = gdf[gdf["class_id"] == CLASS_1186_STRUCTURAL_DAMAGE]
-    # If there are any structural damage composite features and their clipped area is greater than 0
-    if len(all_damage_composite_rows) > 0 and all_damage_composite_rows["clipped_area_sqm"].sum() > 0:
-        # Get all of the roofs in the same AOI as the structural damage composite features
-        # (need to reset the aoi index since it is not unique here)
-        roof_rows = (
-            gdf[(gdf["class_id"] == ROOF_ID) & (gdf.index.isin(all_damage_composite_rows.index))]
-            .reset_index()
-            .set_index(["aoi_id", "feature_id"])
-        )
+    all_damage_gdf = gdf[gdf["class_id"] == CLASS_1186_STRUCTURAL_DAMAGE]
 
-        # Get all of the parent building_lifecycle of the structural damage composite features
-        lifecycle_rows = (
-            gdf[gdf["feature_id"].isin(all_damage_composite_rows["parent_id"])]
-            .reset_index()
-            .set_index(["aoi_id", "feature_id"])
-        )
+    # Iterate over the AOIs with structural damage composite features
+    for aoi_id in all_damage_gdf.index.unique():
+        # Get the structural damage composite features in this AOI
+        aoi_damage_gdf = all_damage_gdf.loc[aoi_id]
 
-        for (
-            aoi_id,
-            lifecycle_feature_id,
-        ), lifecycle_row in lifecycle_rows.iterrows():
-            # Filter roof rows to include only those with the same AOI ID
-            aoi_roof_rows = roof_rows.loc[aoi_id].copy()
+        # Skip this AOI if the total structrual damage area is 0
+        if aoi_damage_gdf["clipped_area_sqm"].sum() == 0:
+            continue
 
-            # Calculate intersection areas for each roof row with the building lifecycle
+        # Filter for only the features in this AOI
+        # NOTE: This was needed just in case some features span multiple AOIs
+        aoi_gdf = gdf.loc[aoi_id]
+        aoi_roof_gdf = aoi_gdf[aoi_gdf["class_id"] == ROOF_ID]
+
+        # Get the building lifecycle features in this AOI with structural damage composite children
+        lifecycle_gdf = aoi_gdf[aoi_gdf["feature_id"].isin(aoi_damage_gdf["parent_id"])]
+
+        # Iterate over the building lifecycle features with structural damage composite children
+        for lifecycle_row in lifecycle_gdf.itertuples():
+            # Get the structural damage composite features that are children of this building lifecycle feature
+            damage_gdf = aoi_damage_gdf[aoi_damage_gdf["parent_id"] == lifecycle_row.feature_id]
+
+            # Get the roofs that intersect with this building lifecycle feature
             # Reproject both roof rows and building lifecycle rows to a projected CRS (EPSG:3857) for the intersection
             lifecycle_geometry = gpd.GeoSeries(lifecycle_row.geometry, crs="EPSG:4326")
-            aoi_roof_rows["intersection_area"] = (
-                aoi_roof_rows["geometry"]
-                .to_crs("EPSG:3857")
-                .apply(lambda roof_geometry: roof_geometry.intersection(lifecycle_geometry.to_crs("EPSG:3857")).area)
-            )
+            aoi_roof_gdf_3857 = aoi_roof_gdf.to_crs("EPSG:3857")
+            lifecycle_geometry_3857 = lifecycle_geometry.to_crs("EPSG:3857").unary_union
+            intersecting_roof_gdf = aoi_roof_gdf[aoi_roof_gdf_3857["geometry"].intersects(lifecycle_geometry_3857)]
 
-            # Filter rows with non-zero intersection areas (all rows with any intersection)
-            intersecting_aoi_roof_rows = aoi_roof_rows[aoi_roof_rows["intersection_area"] > 0]
-
-            # If there are no roof rows that intersect, then skip this building lifecycle
-            if intersecting_aoi_roof_rows.empty:
-                continue
-
-            # Find the roof row with the largest intersection area with the building lifecycle
-            max_intersection_idx = intersecting_aoi_roof_rows["intersection_area"].idxmax()
-            max_intersection_roof_row = intersecting_aoi_roof_rows.loc[max_intersection_idx]
-
-            # Get the other intersecting roof rows besides the one with the largest intersection
-            other_intersecting_aoi_roof_rows = intersecting_aoi_roof_rows[
-                intersecting_aoi_roof_rows.index != max_intersection_idx
-            ]
-
-            # Replace the max roof feature_id, geometry, and areas with the building lifecycle feature_id, geometry, and areas
-            columns_to_update = [
-                "geometry",
-                "area_sqm",
-                "area_sqft",
-                "clipped_area_sqm",
-                "clipped_area_sqft",
-                "unclipped_area_sqm",
-                "unclipped_area_sqft",
-            ]
-            max_roof_feature_id = max_intersection_roof_row.name
-            max_roof_mask = (gdf.index == aoi_id) & (gdf["feature_id"] == max_roof_feature_id)
-            gdf.loc[max_roof_mask, columns_to_update] = lifecycle_row[columns_to_update].values
-            # Update feature_id so we can get the RSI score corresponding to the building lifecycle feature in the retro pipeline
-            gdf.loc[max_roof_mask, "feature_id"] = lifecycle_feature_id
-
-            # Change the parent ID of all child features of all intersecting roofs to the building lifecycle feature ID
-            intersecting_aoi_roof_feature_ids = intersecting_aoi_roof_rows.index.get_level_values("feature_id")
-            gdf.loc[gdf["parent_id"].isin(intersecting_aoi_roof_feature_ids), "parent_id"] = lifecycle_feature_id
-
-            # Remove this building lifecycle from the gdf
-            gdf = gdf[
-                ~(
-                    (gdf.index == aoi_id)
-                    & (gdf["feature_id"] == lifecycle_feature_id)
-                    & (gdf["class_id"] == BUILDING_LIFECYCLE_ID)
+            if intersecting_roof_gdf.empty:
+                # If there are no roof rows that intersect
+                roof_covers_damage = False
+            else:
+                # Do these intersecting roofs fully contain the structural damage composite features inside of their geometries?
+                roof_covers_damage = (
+                    intersecting_roof_gdf["geometry"]
+                    .to_crs("EPSG:3857")
+                    .unary_union.contains(damage_gdf["geometry"].to_crs("EPSG:3857").unary_union)
                 )
-            ]
 
-            # Remove the other intersecting roof rows from the gdf besides the one with the largest intersection that we replaced with the building lifecycle
-            other_intersecting_aoi_roof_feature_ids = other_intersecting_aoi_roof_rows.index.get_level_values(
-                "feature_id"
-            )
-            gdf = gdf[~((gdf.index == aoi_id) & (gdf["feature_id"].isin(other_intersecting_aoi_roof_feature_ids)))]
+            # If the roofs fully cover the structural damage composite features, then we will use the roof geometries
+            # and not the building lifecycle geometries since they look better.
+            # We just need to update the roof structural damage attributes so the rollup gets calculated correctly
+            if roof_covers_damage:
+                # Iterate over the roofs
+                for roof_row in intersecting_roof_gdf.itertuples():
+                    # Get the structural damage composite features that intersect with this roof
+                    roof_geometry = gpd.GeoSeries(roof_row.geometry, crs="EPSG:4326").to_crs("EPSG:3857").iloc[0]
+                    intersecting_damage_gdf = damage_gdf[
+                        damage_gdf["geometry"].to_crs("EPSG:3857").intersects(roof_geometry)
+                    ]
+
+                    # Change the parent ID of these structural damage composite features to the roof feature ID
+                    # NOTE: This will allow for the attributes to get calculated correctly in the rollup
+                    gdf.loc[
+                        (gdf.index == aoi_id) & (gdf["feature_id"].isin(intersecting_damage_gdf["feature_id"])),
+                        "parent_id",
+                    ] = roof_row.feature_id
+
+                # Remove this building lifecycle to avoid confusion downstream
+                gdf = gdf[
+                    ~(
+                        (gdf.index == aoi_id)
+                        & (gdf["feature_id"] == lifecycle_row.feature_id)
+                        & (gdf["class_id"] == BUILDING_LIFECYCLE_ID)
+                    )
+                ]
+            else:
+                # If the roofs do not fully cover the structural damage composite features, then we will replace the
+                # the roof features with the building lifecycle feature
+
+                # Update the building lifecycle feature to be a roof feature
+                lifecycle_mask = (gdf.index == aoi_id) & (gdf["feature_id"] == lifecycle_row.feature_id)
+                gdf.loc[lifecycle_mask, "class_id"] = ROOF_ID
+                gdf.loc[lifecycle_mask, "internal_class_id"] = 1002
+                gdf.loc[lifecycle_mask, "description"] = "Roof"
+
+                if intersecting_roof_gdf.empty:
+                    # If there are no roofs that intersect, then manually create the roof attributes with just the structural damage
+                    # NOTE: Just needs a placeholder so the component can be updated in the next step for the rollup
+
+                    # Read in the empty roof attributes from a json file
+                    current_dir = Path(__file__).parent
+                    roof_attributes_file_path = current_dir / "empty_roof_attributes.json"
+                    with open(roof_attributes_file_path) as f:
+                        empty_roof_attributes = json.load(f)
+                    # Copy the empty roof attributes over to the building lifecycle feature
+                    empty_roof_attributes_series = pd.Series([empty_roof_attributes], name="attributes")
+                    gdf.loc[lifecycle_mask, "attributes"] = empty_roof_attributes_series
+                else:
+                    # Copy the roof attributes from one of the roofs over to the building lifecycle feature
+                    # NOTE: Doesn't matter which one we copy over as these will get updated in the next step
+                    # NOTE: Index (aoi_id is not unique at this point so need to use nlargest)
+                    largest_intersecting_roof = intersecting_roof_gdf.nlargest(1, "clipped_area_sqm")
+                    gdf.loc[lifecycle_mask, "attributes"] = largest_intersecting_roof["attributes"]
+
+                    # Update the parent ID of all intersecting roof child features to the building lifecycle feature ID
+                    # NOTE: This is needed so that the rollup gets calculated correctly
+                    intersecting_roof_feature_ids = intersecting_roof_gdf["feature_id"]
+                    gdf.loc[gdf["parent_id"].isin(intersecting_roof_feature_ids), "parent_id"] = (
+                        lifecycle_row.feature_id
+                    )
+
+                    # Remove all of the intersecting roof features (these have been replaced by the building lifecycle feature)
+                    gdf = gdf[~((gdf.index == aoi_id) & (gdf["feature_id"].isin(intersecting_roof_feature_ids)))]
 
     # Get all of the features that have attributes
     features_with_attributes_df = gdf[gdf["attributes"].astype(bool)]


### PR DESCRIPTION
I needed to completely rewrite the logic for handling the case of structural damage and building lifecycle. In particular, the main two edge cases that this PR addresses beyond the previous PR are:
1. When there is structural damage composite, but the roof geometries completely cover the structural damage geometries
2. When there is structural damage composite on building lifecycle geometries, but there is no roof geometries intersecting the building lifecycle geometry

NOTE: Again, this is a specific hack for the insurance retro pipeline and will not be merged into main.