### PR TITLE
[INDS-2058] Flatten modelInputFeatures into output columns

### DIFF
--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -56,6 +56,7 @@ INCLUDE_FIELD_MAPPINGS = {
     },
     "hurricaneScore": {
         "snake_key": "hurricane_score",
+        "model_input_prefix": "hurricane_vulnerability_model_input",
         "fields": {
             "vulnerabilityScore": "hurricane_vulnerability_score",
             "vulnerabilityProbability": "hurricane_vulnerability_probability",
@@ -64,6 +65,7 @@ INCLUDE_FIELD_MAPPINGS = {
     },
     "windScore": {
         "snake_key": "wind_score",
+        "model_input_prefix": "wind_vulnerability_model_input",
         "fields": {
             "vulnerabilityScore": "wind_vulnerability_score",
             "vulnerabilityProbability": "wind_vulnerability_probability",
@@ -75,6 +77,7 @@ INCLUDE_FIELD_MAPPINGS = {
     },
     "hailScore": {
         "snake_key": "hail_score",
+        "model_input_prefix": "hail_vulnerability_model_input",
         "fields": {
             "vulnerabilityScore": "hail_vulnerability_score",
             "vulnerabilityProbability": "hail_vulnerability_probability",
@@ -86,6 +89,7 @@ INCLUDE_FIELD_MAPPINGS = {
     },
     "wildfireScore": {
         "snake_key": "wildfire_score",
+        "model_input_prefix": "wildfire_vulnerability_model_input",
         "fields": {
             "vulnerabilityScore": "wildfire_vulnerability_score",
             "vulnerabilityProbability": "wildfire_vulnerability_probability",
@@ -95,6 +99,7 @@ INCLUDE_FIELD_MAPPINGS = {
     },
     "windHailRiskScore": {
         "snake_key": "wind_hail_risk_score",
+        "model_input_prefix": "wind_hail_risk_model_input",
         "fields": {
             "riskScore": "wind_hail_risk_score",
             "riskRateFactor": "wind_hail_risk_rate_factor",
@@ -159,6 +164,27 @@ def _parse_include_param(val):
         except (json.JSONDecodeError, TypeError):
             return None
     return None
+
+
+def _flatten_include_params(feature: dict, flattened: dict) -> None:
+    """Extract include parameters (scores, RSI) and their modelInputFeatures into flattened dict."""
+    for camel_key, config in INCLUDE_FIELD_MAPPINGS.items():
+        raw = feature.get(camel_key) or feature.get(config["snake_key"])
+        data = _parse_include_param(raw)
+        if not data:
+            continue
+        for api_field, output_col in config["fields"].items():
+            if api_field in data:
+                flattened[output_col] = data[api_field]
+        for key in ("modelVersion",):
+            if key in data:
+                flattened[f"{config['snake_key']}_{stringcase.snakecase(key)}"] = data[key]
+        model_input_prefix = config.get("model_input_prefix")
+        if model_input_prefix is not None:
+            model_input = data.get("modelInputFeatures")
+            if isinstance(model_input, dict):
+                for mif_key, mif_value in model_input.items():
+                    flattened[f"{model_input_prefix}_{stringcase.snakecase(mif_key)}"] = mif_value
 
 
 def _get_feature_value(feature, key):
@@ -543,18 +569,7 @@ def flatten_roof_attributes(
 
     # Handle components and other attributes
     for roof in roofs:
-        # Flatten include parameters (RSI, scores) via INCLUDE_FIELD_MAPPINGS table
-        for camel_key, config in INCLUDE_FIELD_MAPPINGS.items():
-            raw = roof.get(camel_key) or roof.get(config["snake_key"])
-            data = _parse_include_param(raw)
-            if not data:
-                continue
-            for api_field, output_col in config["fields"].items():
-                if api_field in data:
-                    flattened[output_col] = data[api_field]
-            for key in ("modelVersion",):
-                if key in data:
-                    flattened[f"{config['snake_key']}_{stringcase.snakecase(key)}"] = data[key]
+        _flatten_include_params(roof, flattened)
 
         # Defensible space has zone-based nesting — handle separately
         defensible_raw = roof.get("defensibleSpace") or roof.get("defensible_space")
@@ -713,6 +728,8 @@ def flatten_building_lifecycle_damage_attributes(
     flattened = {}
 
     for building_lifecycle in building_lifecycles:
+        _flatten_include_params(building_lifecycle, flattened)
+
         # Get damage data from top-level damage field
         damage_data = building_lifecycle.get("damage")
 

--- a/tests/test_hurricane_score.py
+++ b/tests/test_hurricane_score.py
@@ -180,9 +180,14 @@ def test_hurricane_score_with_real_data(roof_with_hurricane_score):
         == roof_with_hurricane_score["hurricaneScore"]["vulnerabilityRateFactor"]
     )
 
-    # Verify modelInputFeatures are NOT flattened
-    assert "hurricane_model_flat_present" not in result
-    assert "hurricane_model_shingle_present" not in result
+    # Verify modelInputFeatures ARE flattened
+    mif = roof_with_hurricane_score["hurricaneScore"].get("modelInputFeatures", {})
+    for camel_key, expected_value in mif.items():
+        import stringcase
+
+        col = f"hurricane_vulnerability_model_input_{stringcase.snakecase(camel_key)}"
+        assert col in result, f"Expected column {col} not found"
+        assert result[col] == expected_value
 
 
 def test_hurricane_score_different_values(all_roofs_with_hurricane_score):

--- a/tests/test_wind_hail_wildfire_scores.py
+++ b/tests/test_wind_hail_wildfire_scores.py
@@ -82,6 +82,9 @@ class TestWindScore:
         assert result["wind_risk_score"] == 3
         assert result["wind_risk_rate_factor"] == 0.83
         assert result["wind_fema_annual_frequency"] == 5.125
+        # modelInputFeatures
+        assert result["wind_vulnerability_model_input_pitched_roof_present"] == 1
+        assert result["wind_vulnerability_model_input_metal_present"] == 0
 
     def test_wind_score_snake_case(self):
         """Test that snake_case field name works."""
@@ -124,6 +127,9 @@ class TestHailScore:
         assert result["hail_risk_score"] == 4
         assert result["hail_risk_rate_factor"] == 0.53
         assert result["hail_fema_annual_frequency"] == 4.125
+        # modelInputFeatures
+        assert result["hail_vulnerability_model_input_flat_present"] == 0
+        assert result["hail_vulnerability_model_input_shingle_present"] == 1
 
     def test_hail_score_snake_case(self):
         """Test that snake_case field name works."""
@@ -164,6 +170,9 @@ class TestWildfireScore:
         assert result["wildfire_vulnerability_probability"] == 0.919
         assert result["wildfire_vulnerability_rate_factor"] == 1.06
         assert result["wildfire_fema_annual_frequency"] == 0
+        # modelInputFeatures
+        assert result["wildfire_vulnerability_model_input_fire_resistant_material_present"] == 0
+        assert result["wildfire_vulnerability_model_input_roof_debris_ratio"] == 0
 
     def test_wildfire_score_snake_case(self):
         """Test that snake_case field name works."""
@@ -201,6 +210,9 @@ class TestWindHailRiskScore:
 
         assert result["wind_hail_risk_score"] == 4
         assert result["wind_hail_risk_rate_factor"] == 0.58
+        # modelInputFeatures
+        assert result["wind_hail_risk_model_input_wind_risk_score"] == 3
+        assert result["wind_hail_risk_model_input_hail_risk_score"] == 4
 
     def test_wind_hail_risk_score_snake_case(self):
         """Test that snake_case field name works."""


### PR DESCRIPTION
## Summary

- Extracts `modelInputFeatures` from score include parameters (hurricaneScore, windScore, hailScore, wildfireScore, windHailRiskScore) into flattened output columns
- Column naming: `{peril}_vulnerability_model_input_{snake_case(key)}` — e.g. `hurricane_vulnerability_model_input_flat_present`, `wind_vulnerability_model_input_pitched_roof_present`
- Dynamic extraction: any keys in the `modelInputFeatures` dict are automatically flattened, no hardcoded key list
- Refactored include param extraction into shared `_flatten_include_params()` helper, called from both `flatten_roof_attributes()` and `flatten_building_lifecycle_damage_attributes()` (scores can appear on BL features in rare cases)

New columns appear automatically in all output files:
- **rollup.csv**: `primary_roof_{peril}_vulnerability_model_input_{key}`
- **roof.csv**: `{peril}_vulnerability_model_input_{key}`
- **building.csv**: `primary_child_roof_{peril}_vulnerability_model_input_{key}`
- **building_lifecycle.csv**: via child roof linkage + direct BL scores

31 new columns total across 5 perils (hurricane: 10, wind: 8, wildfire: 7, hail: 4, wind+hail risk: 2).

## Test plan

- [x] Unit tests pass — `test_hurricane_score.py`, `test_wind_hail_wildfire_scores.py` (22 passed)
- [x] End-to-end export verified against live API with `test_parcels_2.csv` (100 US parcels)
- [x] Confirmed model_input columns present in rollup.csv, roof.csv, building.csv
- [x] EDA on distributions: 0 nulls at feature level, 3% nulls at rollup level (parcels without primary roof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)