### PR TITLE
[INDS-2035] Add pool condition attributes to rollup and per-class outputs

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -77,6 +77,7 @@ from nmaipy.constants import (
     METERS_TO_FEET,
     PARALLEL_READ_WORKERS,
     PER_CLASS_FILE_CLASS_IDS,
+    POOL_ID,
     PRIMARY_FEATURE_COLUMN_TO_CLASS,
     ROOF_AGE_PREFIX_COLUMNS,
     ROOF_ID,
@@ -95,6 +96,7 @@ from nmaipy.feature_attributes import (
     calculate_roof_age_years,
     convert_bool_columns_to_yn,
     flatten_building_attributes,
+    flatten_pool_attributes,
     flatten_roof_attributes,
 )
 from nmaipy.parcels import (
@@ -746,6 +748,8 @@ def _compute_all_per_class_data(
     roof_attrs_cache_chunk = None
 
     roof_to_building_lookup = {}
+    roofs_linked_chunk = None
+    buildings_linked_chunk = None
     has_dependent = any(c in chunk_class_ids for c in dependent_class_ids)
     if has_dependent:
         if ROOF_ID in chunk_class_ids:
@@ -762,8 +766,6 @@ def _compute_all_per_class_data(
         # Roof's API parent_id points to Building(Deprecated) which is filtered out;
         # the correct path to BL is Roof →(IoU)→ Building(New) →(parent_id)→ BL.
         # Results are reused in _compute_feature_class_data for Building(New) class output.
-        roofs_linked_chunk = None
-        buildings_linked_chunk = None
         if len(roof_features_chunk) > 0 and BUILDING_NEW_ID in chunk_class_ids:
             building_new_chunk = chunk_gdf[chunk_gdf["class_id"] == BUILDING_NEW_ID]
             if len(building_new_chunk) > 0:
@@ -1626,6 +1628,15 @@ def _compute_feature_class_data(
                         df_parts.append(pd.DataFrame(score_batch, index=range(n_rows)))
         except Exception:
             logger.error("Could not link roofs to building lifecycles", exc_info=True)
+
+    # --- Section E2: Pool condition attributes ---
+    if class_id == POOL_ID:
+        pool_batch = []
+        for _, row in class_features.iterrows():
+            attrs = flatten_pool_attributes([row], country=country)
+            pool_batch.append(attrs)
+        if pool_batch:
+            df_parts.append(pd.DataFrame(pool_batch, index=range(n_rows)))
 
     # --- Section F: Mapbrowser link ---
     # Uses geometry centroid for location and survey_date/installation_date for date

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -871,3 +871,29 @@ def flatten_roof_instance_attributes(
     if age_years is not None:
         flattened[f"{prefix}roof_age_years_as_of_date"] = age_years
     return flattened
+
+
+def flatten_pool_attributes(pools: List[dict], country: str) -> dict:
+    """Flatten pool condition attributes from Feature API into per-component columns."""
+    flattened = {}
+    for pool in pools:
+        attributes = pool.get("attributes")
+        if attributes and isinstance(attributes, str):
+            try:
+                attributes = json.loads(attributes)
+            except (json.JSONDecodeError, TypeError):
+                attributes = []
+        for attribute in attributes or []:
+            if "components" not in attribute:
+                continue
+            for component in attribute["components"]:
+                name = component["description"].lower().replace(" ", "_")
+                flattened[f"{name}_present"] = TRUE_STRING if component["areaSqm"] > 0 else FALSE_STRING
+                if country in IMPERIAL_COUNTRIES:
+                    flattened[f"{name}_area_sqft"] = component["areaSqft"]
+                else:
+                    flattened[f"{name}_area_sqm"] = component["areaSqm"]
+                flattened[f"{name}_confidence"] = component["confidence"]
+                if "ratio" in component:
+                    flattened[f"{name}_ratio"] = component["ratio"]
+    return flattened

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -35,6 +35,7 @@ from nmaipy.constants import (
     LAT_PRIMARY_COL_NAME,
     LON_PRIMARY_COL_NAME,
     MIN_ROOF_INSTANCE_IOU_THRESHOLD,
+    POOL_ID,
     ROOF_ID,
     ROOF_INSTANCE_CLASS_ID,
     SQUARED_METERS_TO_SQUARED_FEET,
@@ -49,6 +50,7 @@ from nmaipy.feature_attributes import (
     _parse_include_param,
     flatten_building_attributes,
     flatten_building_lifecycle_damage_attributes,
+    flatten_pool_attributes,
     flatten_roof_attributes,
     flatten_roof_instance_attributes,
 )
@@ -1102,6 +1104,10 @@ def feature_attributes(
                 for key, val in primary_attributes.items():
                     if not any(key.startswith(p) for p in _RESOLVED_PREFIXES):
                         parcel[f"primary_{name}_" + str(key)] = val
+            if class_id == POOL_ID:
+                primary_attributes = flatten_pool_attributes([primary_feature], country=country)
+                for key, val in primary_attributes.items():
+                    parcel[f"primary_{name}_" + str(key)] = val
 
             if class_id == BUILDING_LIFECYCLE_ID:
                 # Add aggregated damage across whole parcel, weighted by building lifecycle area


### PR DESCRIPTION
## Summary

- Flattens Pool Condition API attributes (unmaintained, in lanai, covered, empty, above ground) into per-component columns: `_present`, `_area_sqft`/`_sqm`, `_confidence`, `_ratio`
- Columns appear in both rollup (`primary_swimming_pool_{component}_{field}`) and per-class `swimming_pool.csv`/`.parquet` files
- Fixes pre-existing bug where `roofs_linked_chunk`/`buildings_linked_chunk` were uninitialized in `_compute_all_per_class_data`, causing per-class export to silently fail for non-building classes (e.g. pool-only exports)

## Test plan
- [x] `pytest -m "not live_api"` — 413 passed
- [x] End-to-end: `--packs pool --save-features` — rollup has 20 pool condition columns (5 components × 4 fields), per-class `swimming_pool.csv` generated with matching columns
- [ ] Verify with Florida parcels (higher in-lanai prevalence) for broader component coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)