### PR TITLE
[INDS-2071] Filter alpha-gated / non-prod classes

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -89,7 +89,7 @@ from nmaipy.constants import (
     UNTIL_COL_NAME,
     _write_class_descriptions,
 )
-from nmaipy.feature_api import FeatureApi
+from nmaipy.feature_api import FeatureApi, class_returnable_status
 from nmaipy.feature_attributes import (
     FALSE_STRING,
     TRUE_STRING,
@@ -3517,7 +3517,7 @@ class NearmapAIExporter(BaseExporter):
         # Note: chunk_path and final_path created by BaseExporter
 
         # Get classes
-        feature_api = FeatureApi(
+        feature_api_kwargs = dict(
             api_key=self.api_key(),
             alpha=self.alpha,
             beta=self.beta,
@@ -3525,6 +3525,10 @@ class NearmapAIExporter(BaseExporter):
             only3d=self.only3d,
             parcel_mode=self.parcel_mode,
         )
+        if self.system_version_prefix is not None:
+            feature_api_kwargs["system_version_prefix"] = self.system_version_prefix
+        feature_api = FeatureApi(**feature_api_kwargs)
+        effective_sv_prefix = feature_api.system_version_prefix
         try:
             if self.packs is not None:
                 classes_df = feature_api.get_feature_classes(self.packs)
@@ -3550,6 +3554,41 @@ class NearmapAIExporter(BaseExporter):
 
         # Filter out deprecated classes from rollups
         classes_df = classes_df[~classes_df.index.isin(DEPRECATED_CLASS_IDS)]
+
+        # Filter classes unreturnable under the active system version — prevents
+        # zero-filled rollup columns for classes the API silently excludes
+        # (alpha/beta-gated without the corresponding flag, or absent entirely
+        # from the active system version).
+        if "availability" in classes_df.columns:
+            statuses = classes_df["availability"].apply(
+                lambda av: class_returnable_status(av, effective_sv_prefix, self.alpha, self.beta)
+            )
+            drop_alpha = statuses == "alpha_gated"
+            drop_beta = statuses == "beta_gated"
+            drop_absent = statuses == "absent"
+            to_drop = drop_alpha | drop_beta | drop_absent
+
+            sv = effective_sv_prefix or "default"
+            if drop_alpha.any():
+                names = sorted(classes_df.loc[drop_alpha, "description"].tolist())
+                self.logger.warning(
+                    f"Dropping {len(names)} alpha-gated class(es) from rollup (system version "
+                    f"{sv}, pass --alpha to include): {names}"
+                )
+            if drop_beta.any():
+                names = sorted(classes_df.loc[drop_beta, "description"].tolist())
+                self.logger.warning(
+                    f"Dropping {len(names)} beta-gated class(es) from rollup (system version "
+                    f"{sv}, pass --beta to include): {names}"
+                )
+            if drop_absent.any():
+                names = sorted(classes_df.loc[drop_absent, "description"].tolist())
+                self.logger.warning(
+                    f"Dropping {len(names)} class(es) with no availability under system version "
+                    f"{sv} (--alpha/--beta will not help; remove from --packs/--classes or change "
+                    f"--system-version-prefix): {names}"
+                )
+            classes_df = classes_df.loc[~to_drop]
 
         # Add Roof Instance class to classes_df when roof_age is enabled
         # This allows parcel_rollup to generate rollup columns for roof instances

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -71,6 +71,48 @@ AIFeatureAPIGridError = APIGridError
 AIFeatureAPIRequestSizeError = APIRequestSizeError
 
 
+def class_returnable_status(
+    availability,
+    system_version_prefix: Optional[str],
+    alpha: bool = False,
+    beta: bool = False,
+) -> str:
+    """Determine whether a class will return features under the active system version.
+
+    Interprets the `availability` field from classes.json (a list of
+    {systemVersion, perspective, status} entries) and returns one of:
+      - "returnable"  : class has a returnable entry under the active prefix
+      - "alpha_gated" : only alpha entries match the prefix, alpha flag off
+      - "beta_gated"  : only beta entries (no prod/alpha) match the prefix, beta flag off
+      - "absent"      : no entries match the prefix at all
+      - "unknown"     : availability shape unrecognized or no prefix supplied — fail-open
+
+    An entry counts as returnable when its status is:
+      - "prod" (always)
+      - "alpha" if alpha=True
+      - "beta"  if beta=True
+    """
+    if not system_version_prefix or not isinstance(availability, list):
+        return "unknown"
+
+    matching = [
+        e for e in availability
+        if isinstance(e, dict) and isinstance(e.get("systemVersion"), str)
+        and e["systemVersion"].startswith(system_version_prefix)
+    ]
+    if not matching:
+        return "absent"
+
+    statuses = {e.get("status") for e in matching}
+    if "prod" in statuses:
+        return "returnable"
+    if "beta" in statuses:
+        return "returnable" if beta else "beta_gated"
+    if "alpha" in statuses:
+        return "returnable" if alpha else "alpha_gated"
+    return "unknown"
+
+
 class FeatureApi(GriddedApiClient):
     """
     Client for the Nearmap AI Feature API.

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -897,7 +897,6 @@ def feature_attributes(
             roof_kind_features = class_features_gdf
 
         # Add attributes that apply to all feature classes
-        # TODO: This sets a column to "N" even if it's not possible to return it with the query (e.g. alpha/beta attribute permissions, or version issues). Need to filter out columns that pertain to this. Need to parse "availability" column in classes_df and determine what system version this row is.
         # For roof instances, use filtered features (roof kind only) for count
         features_for_count = roof_kind_features if class_id == ROOF_INSTANCE_CLASS_ID else class_features_gdf
         parcel[f"{name}_present"] = TRUE_STRING if len(features_for_count) > 0 else FALSE_STRING

--- a/tests/test_class_availability.py
+++ b/tests/test_class_availability.py
@@ -1,0 +1,91 @@
+"""Tests for classifying and filtering feature classes by availability under the active system version."""
+import pytest
+
+from nmaipy.feature_api import class_returnable_status
+
+
+# Availability fixture shapes observed from classes.json. Each availability value
+# is a list of {systemVersion, perspective, status} entries, where status is one
+# of "prod", "alpha", "beta".
+HVAC_AVAILABILITY = [
+    {"systemVersion": "gen6-glowing_lantern-1.0", "perspective": "Vert", "status": "alpha"},
+    {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "alpha"},
+]
+
+POWER_POLE_AVAILABILITY = [
+    {"systemVersion": "gen4-building_storm-2.3", "perspective": "Vert", "status": "alpha"},
+    {"systemVersion": "gen4-lightning_bolt-1.3", "perspective": "Vert", "status": "alpha"},
+]
+
+SWIMMING_POOL_AVAILABILITY = [
+    {"systemVersion": "gen4-building_storm-2.3", "perspective": "Vert", "status": "prod"},
+    {"systemVersion": "gen5-tranquil_sea-1.0", "perspective": "Vert", "status": "prod"},
+    {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "prod"},
+]
+
+BETA_ONLY_GEN6 = [
+    {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "beta"},
+]
+
+MIXED_PROD_ALPHA_GEN6 = [
+    {"systemVersion": "gen6-glowing_lantern-1.0", "perspective": "Vert", "status": "alpha"},
+    {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "prod"},
+]
+
+
+class TestClassReturnableStatus:
+    def test_alpha_gated_without_flag(self):
+        assert class_returnable_status(HVAC_AVAILABILITY, "gen6-", alpha=False) == "alpha_gated"
+
+    def test_alpha_gated_with_flag_is_returnable(self):
+        assert class_returnable_status(HVAC_AVAILABILITY, "gen6-", alpha=True) == "returnable"
+
+    def test_beta_gated_without_flag(self):
+        assert class_returnable_status(BETA_ONLY_GEN6, "gen6-", beta=False) == "beta_gated"
+
+    def test_beta_gated_with_flag_is_returnable(self):
+        assert class_returnable_status(BETA_ONLY_GEN6, "gen6-", beta=True) == "returnable"
+
+    def test_absent_from_gen6(self):
+        # Power Pole has only gen4 entries — no gen6 availability at any tier.
+        assert class_returnable_status(POWER_POLE_AVAILABILITY, "gen6-", alpha=True, beta=True) == "absent"
+
+    def test_absent_still_absent_regardless_of_flags(self):
+        assert class_returnable_status(POWER_POLE_AVAILABILITY, "gen6-") == "absent"
+
+    def test_ga_class_returnable(self):
+        assert class_returnable_status(SWIMMING_POOL_AVAILABILITY, "gen6-") == "returnable"
+
+    def test_prefix_switches_classification(self):
+        # Power Pole is absent in gen6 but returnable (as alpha) in gen4 with --alpha.
+        assert class_returnable_status(POWER_POLE_AVAILABILITY, "gen4-", alpha=True) == "returnable"
+        assert class_returnable_status(POWER_POLE_AVAILABILITY, "gen4-", alpha=False) == "alpha_gated"
+
+    def test_mixed_statuses_prod_wins(self):
+        # If any entry under the prefix is prod, the class is returnable.
+        assert class_returnable_status(MIXED_PROD_ALPHA_GEN6, "gen6-") == "returnable"
+
+    def test_none_prefix_is_unknown(self):
+        assert class_returnable_status(HVAC_AVAILABILITY, None) == "unknown"
+
+    def test_empty_prefix_is_unknown(self):
+        assert class_returnable_status(HVAC_AVAILABILITY, "") == "unknown"
+
+    def test_non_list_availability_is_unknown(self):
+        assert class_returnable_status(None, "gen6-") == "unknown"
+        assert class_returnable_status({"gen6": "alpha"}, "gen6-") == "unknown"
+
+    def test_malformed_entries_ignored(self):
+        # Entries that aren't dicts or lack a string systemVersion are skipped.
+        availability = [
+            "not a dict",
+            {"perspective": "Vert", "status": "prod"},  # no systemVersion
+            {"systemVersion": 42, "status": "prod"},  # non-string systemVersion
+            {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "prod"},
+        ]
+        assert class_returnable_status(availability, "gen6-") == "returnable"
+
+    def test_missing_status_falls_through(self):
+        # Entry matches prefix but has no recognized status — returns "unknown".
+        availability = [{"systemVersion": "gen6-glowing_moon-1.0", "status": "unknown_tier"}]
+        assert class_returnable_status(availability, "gen6-") == "unknown"


### PR DESCRIPTION
## Summary

Fixes [INDS-2071](INDS-2071_bug_report_alpha_classes.md). nmaipy was emitting rollup columns filled with zeros for classes the API would never return under the active system version, making "not queryable" indistinguishable from "not detected." In the recent 4M-location claims-modeling run this produced ~30 phantom columns before HVAC was spotted as suspicious.

Two flavors now filtered out of `classes_df` before rollup (with a warning):

- **Alpha/beta-gated** in the active system version (e.g. `HVAC`, `Miscellaneous Roof Object` in gen6) — dropped unless `--alpha`/`--beta` is set.
- **Absent from the active system version** entirely (e.g. `Power Pole`, `Light Pole Base` on gen6, which exist only as subcomponents of `Pole`'s `Pole type` attribute) — dropped regardless of flags.

Detection parses the `availability` list already returned by `classes.json`, so new gated/removed classes are handled automatically. Unknown schema shapes fail open (keep the class) to avoid silent regressions.

Out of scope: flattening gen6 `Pole type.components` into per-type columns (`pole_power_pole_count`, etc.) — separate feature per bug report.

## Test plan

- [x] `pytest tests/test_class_availability.py` — 14 new unit tests covering alpha/beta gating, absent classes, prefix switching, mixed prod/alpha statuses, fail-open on unknown shapes
- [x] `pytest -m "not live_api"` — full non-live suite passes (427 passed, 12 skipped)
- [x] E2E without `--alpha` on `commercial_roof_objects`: warning logged, `hvac_*` and `miscellaneous_roof_object_*` columns absent from rollup; other classes in the pack retained
- [x] E2E with `--alpha` on same pack: no warning, HVAC columns present
- [x] E2E on `utilities` pack with `--alpha`: `power_pole_*` and `light_pole_base_*` dropped with "no availability" warning; `pole_*` (the gen6 parent class) retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[INDS-2071]: https://nearmap.atlassian.net/browse/INDS-2071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ