### PR TITLE
[INDS-2071] Per-AOI null-out for unreturnable classes at resolved system version

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -98,7 +98,7 @@ from nmaipy.feature_attributes import (
 )
 from nmaipy.parcels import (
     build_parent_lookup,
-    class_scoped_column_prefixes,
+    class_column_names,
     extract_rsi_from_feature,
     link_roofs_to_buildings,
     resolve_footprint_rsi,
@@ -3607,17 +3607,19 @@ class NearmapAIExporter(BaseExporter):
 
             # Drop class-scoped columns that are 100% NaN. These correspond to
             # classes that were unreturnable at every AOI's system_version (via
-            # per-AOI null-out in parcel_rollup). Guarded by class-name prefix
-            # match so user input columns and metadata aren't affected.
+            # per-AOI null-out in parcel_rollup). The candidate set is the
+            # authoritative class_id → columns mapping from feature_attributes()
+            # with empty input — not a prefix heuristic — so user input columns
+            # and metadata are never considered for pruning even if all-NaN.
             if len(data) > 0:
-                class_prefixes = class_scoped_column_prefixes(classes_df)
-                if class_prefixes:
-                    all_nan_class_cols = [
-                        c for c in data.columns
-                        if c.startswith(class_prefixes) and data[c].isna().all()
-                    ]
-                    if all_nan_class_cols:
-                        data = data.drop(columns=all_nan_class_cols)
+                class_cols_by_id = class_column_names(classes_df, self.country, self.primary_decision)
+                candidate_cols = set().union(*class_cols_by_id.values()) if class_cols_by_id else set()
+                all_nan_class_cols = [
+                    c for c in data.columns
+                    if c in candidate_cols and data[c].isna().all()
+                ]
+                if all_nan_class_cols:
+                    data = data.drop(columns=all_nan_class_cols)
 
             if "geometry" in data.columns:
                 if not isinstance(data.geometry, gpd.GeoSeries):

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -98,6 +98,7 @@ from nmaipy.feature_attributes import (
 )
 from nmaipy.parcels import (
     build_parent_lookup,
+    class_scoped_column_prefixes,
     extract_rsi_from_feature,
     link_roofs_to_buildings,
     resolve_footprint_rsi,
@@ -2918,6 +2919,8 @@ class NearmapAIExporter(BaseExporter):
                     country=self.country,
                     primary_decision=self.primary_decision,
                     api_metadata=api_metadata,
+                    alpha=self.alpha,
+                    beta=self.beta,
                 )
                 if chunk_id == _profile_chunk:
                     _pr.disable()
@@ -3398,6 +3401,15 @@ class NearmapAIExporter(BaseExporter):
         # Filter out deprecated classes from rollups
         classes_df = classes_df[~classes_df.index.isin(DEPRECATED_CLASS_IDS)]
 
+        # Snapshot the classes (incl. availability) used for this export, as a
+        # reproducibility record. Downstream per-AOI null-out is derived from this.
+        storage.write_json(
+            storage.join_path(self.final_path, "classes_availability.json"),
+            classes_df.to_dict(orient="index"),
+            indent=2,
+            default=str,
+        )
+
         # Add Roof Instance class to classes_df when roof_age is enabled
         # This allows parcel_rollup to generate rollup columns for roof instances
         if self.roof_age:
@@ -3592,6 +3604,21 @@ class NearmapAIExporter(BaseExporter):
                     message=".*concatenation with empty or all-NA.*",
                 )
                 data = pd.concat(data) if data else pd.DataFrame()
+
+            # Drop class-scoped columns that are 100% NaN. These correspond to
+            # classes that were unreturnable at every AOI's system_version (via
+            # per-AOI null-out in parcel_rollup). Guarded by class-name prefix
+            # match so user input columns and metadata aren't affected.
+            if len(data) > 0:
+                class_prefixes = class_scoped_column_prefixes(classes_df)
+                if class_prefixes:
+                    all_nan_class_cols = [
+                        c for c in data.columns
+                        if c.startswith(class_prefixes) and data[c].isna().all()
+                    ]
+                    if all_nan_class_cols:
+                        data = data.drop(columns=all_nan_class_cols)
+
             if "geometry" in data.columns:
                 if not isinstance(data.geometry, gpd.GeoSeries):
                     data["geometry"] = gpd.GeoSeries.from_wkt(data.geometry)

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -71,6 +71,41 @@ AIFeatureAPIGridError = APIGridError
 AIFeatureAPIRequestSizeError = APIRequestSizeError
 
 
+def is_class_returnable_at_version(
+    availability,
+    system_version: Optional[str],
+    alpha: bool = False,
+    beta: bool = False,
+) -> bool:
+    """Decide whether a class can return features at a specific system version.
+
+    Interprets the `availability` list from /classes.json — each entry is a
+    {systemVersion, perspective, status} dict where status is one of
+    "prod", "alpha", "beta". A class is returnable at `system_version` if any
+    matching entry's status is "prod", or "alpha" when `alpha=True`, or
+    "beta" when `beta=True`.
+
+    Fails open (returns True) when `system_version` is missing or the
+    availability shape is unrecognized — preferring phantom columns over
+    silent drops.
+    """
+    if not system_version or not isinstance(availability, list):
+        return True
+    for entry in availability:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("systemVersion") != system_version:
+            continue
+        status = entry.get("status")
+        if status == "prod":
+            return True
+        if status == "alpha" and alpha:
+            return True
+        if status == "beta" and beta:
+            return True
+    return False
+
+
 class FeatureApi(GriddedApiClient):
     """
     Client for the Nearmap AI Feature API.

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -89,7 +89,7 @@ def is_class_returnable_at_version(
     availability shape is unrecognized — preferring phantom columns over
     silent drops.
     """
-    if not system_version or not isinstance(availability, list):
+    if not isinstance(system_version, str) or not system_version or not isinstance(availability, list):
         return True
     for entry in availability:
         if not isinstance(entry, dict):

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -68,7 +68,7 @@ __all__ = [
     "extract_rsi_from_feature",
     "resolve_footprint_rsi",
     "calculate_child_feature_attributes",
-    "class_scoped_column_prefixes",
+    "class_column_names",
     # Also re-export flattening functions for backwards compatibility
     "flatten_building_attributes",
     "flatten_building_lifecycle_damage_attributes",
@@ -77,20 +77,38 @@ __all__ = [
 ]
 
 
-def class_scoped_column_prefixes(classes_df: pd.DataFrame) -> tuple:
-    """Column-name prefixes that identify rollup columns scoped to a specific class.
+def class_column_names(
+    classes_df: pd.DataFrame, country: str, primary_decision: str = "largest_intersection"
+) -> dict:
+    """Authoritative mapping from class_id to the set of rollup column names
+    emitted by `feature_attributes()` for that class.
 
-    Derived from each class's programmatic name (`description.lower().replace(" ", "_")`) —
-    matches the naming convention used throughout `feature_attributes()` for baseline
-    and attribute-flattened columns. Consumers use this to safely distinguish
-    class-scoped columns from user input / metadata columns.
+    Built by running `feature_attributes()` once per class with an empty
+    features GeoDataFrame. Captures baseline columns (present/count/area/
+    confidence/primary_*) per class_id without relying on name-prefix heuristics.
+    Attribute-flattened columns (e.g. `roof_material_tile_*`) are intentionally
+    not captured — they're only emitted when features exist for the class, so
+    they're absent from the rollup entirely when a class is unqueryable.
     """
-    prefixes = []
-    for desc in classes_df["description"]:
-        name = desc.lower().replace(" ", "_")
-        prefixes.append(f"{name}_")
-        prefixes.append(f"primary_{name}_")
-    return tuple(prefixes)
+    mu = MeasurementUnits(country)
+    area_units = mu.area_units()
+    area_name = f"area_{area_units}"
+    empty_gdf = gpd.GeoDataFrame(
+        [],
+        columns=["class_id", area_name, f"clipped_{area_name}", f"unclipped_{area_name}"],
+    )
+    result = {}
+    for class_id in classes_df.index:
+        single_class = classes_df.loc[[class_id]]
+        baseline = feature_attributes(
+            empty_gdf,
+            single_class,
+            country=country,
+            parcel_geom=None,
+            primary_decision=primary_decision,
+        )
+        result[class_id] = set(baseline.keys())
+    return result
 
 
 def _compute_iou(geom_a, geom_b) -> float:
@@ -1285,41 +1303,29 @@ def parcel_rollup(
             # Per-AOI per-version returnability: only applies when metadata carries
             # the system_version column and classes carry availability. Roof age and
             # other synthetic class subsets may not have either — fail-open then.
+            # Typical chunks have 1-2 distinct system_versions across AOIs, so we
+            # compute the unreturnable class set per unique version and then fan out.
             if (
                 len(meta_df) > 0
                 and "system_version" in meta_df.columns
                 and "availability" in meta_classes.columns
             ):
                 avail_by_class = meta_classes["availability"].to_dict()
+                unique_svs = set(meta_df["system_version"].dropna().unique())
+                unreturnable_by_sv = {
+                    sv: {
+                        cid for cid, avail in avail_by_class.items()
+                        if not is_class_returnable_at_version(avail, sv, alpha=alpha, beta=beta)
+                    }
+                    for sv in unique_svs
+                }
                 for aoi_id, sv in meta_df["system_version"].items():
-                    for class_id, avail in avail_by_class.items():
-                        if not is_class_returnable_at_version(avail, sv, alpha=alpha, beta=beta):
-                            null_classes_by_aoi.setdefault(aoi_id, set()).add(class_id)
+                    unreturnable = unreturnable_by_sv.get(sv)
+                    if unreturnable:
+                        null_classes_by_aoi.setdefault(aoi_id, set()).update(unreturnable)
         # Only compute baseline columns if at least one AOI needs nullification
         if null_classes_by_aoi:
-            # Discover exact baseline column names per class by running
-            # feature_attributes() with empty data. This avoids prefix matching
-            # and uses feature_attributes() itself as the source of truth.
-            area_name = f"area_{area_units}"
-            empty_gdf = gpd.GeoDataFrame(
-                [],
-                columns=[
-                    "class_id",
-                    area_name,
-                    f"clipped_{area_name}",
-                    f"unclipped_{area_name}",
-                ],
-            )
-            for class_id in classes_df.index:
-                single_class = classes_df.loc[[class_id]]
-                baseline = feature_attributes(
-                    empty_gdf,
-                    single_class,
-                    country=country,
-                    parcel_geom=None,
-                    primary_decision=primary_decision,
-                )
-                _class_baseline_columns[class_id] = set(baseline.keys())
+            _class_baseline_columns = class_column_names(classes_df, country, primary_decision)
 
     assert parcels_gdf.index.name == AOI_ID_COLUMN_NAME
 

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -39,6 +39,7 @@ from nmaipy.constants import (
     SQUARED_METERS_TO_SQUARED_FEET,
     MeasurementUnits,
 )
+from nmaipy.feature_api import is_class_returnable_at_version
 from nmaipy.feature_attributes import (
     FALSE_STRING,
     TRUE_STRING,
@@ -67,12 +68,29 @@ __all__ = [
     "extract_rsi_from_feature",
     "resolve_footprint_rsi",
     "calculate_child_feature_attributes",
+    "class_scoped_column_prefixes",
     # Also re-export flattening functions for backwards compatibility
     "flatten_building_attributes",
     "flatten_building_lifecycle_damage_attributes",
     "flatten_roof_attributes",
     "flatten_roof_instance_attributes",
 ]
+
+
+def class_scoped_column_prefixes(classes_df: pd.DataFrame) -> tuple:
+    """Column-name prefixes that identify rollup columns scoped to a specific class.
+
+    Derived from each class's programmatic name (`description.lower().replace(" ", "_")`) —
+    matches the naming convention used throughout `feature_attributes()` for baseline
+    and attribute-flattened columns. Consumers use this to safely distinguish
+    class-scoped columns from user input / metadata columns.
+    """
+    prefixes = []
+    for desc in classes_df["description"]:
+        name = desc.lower().replace(" ", "_")
+        prefixes.append(f"{name}_")
+        prefixes.append(f"primary_{name}_")
+    return tuple(prefixes)
 
 
 def _compute_iou(geom_a, geom_b) -> float:
@@ -822,8 +840,9 @@ def feature_attributes(
         else:
             roof_kind_features = class_features_gdf
 
-        # Add attributes that apply to all feature classes
-        # TODO: This sets a column to "N" even if it's not possible to return it with the query (e.g. alpha/beta attribute permissions, or version issues). Need to filter out columns that pertain to this. Need to parse "availability" column in classes_df and determine what system version this row is.
+        # Add attributes that apply to all feature classes.
+        # Per-AOI null-out for classes unreturnable at the AOI's actual system_version
+        # is handled in parcel_rollup() via null_classes_by_aoi after this dict is built.
         # For roof instances, use filtered features (roof kind only) for count
         features_for_count = roof_kind_features if class_id == ROOF_INSTANCE_CLASS_ID else class_features_gdf
         parcel[f"{name}_present"] = TRUE_STRING if len(features_for_count) > 0 else FALSE_STRING
@@ -1213,6 +1232,8 @@ def parcel_rollup(
     country: str,
     primary_decision: str,
     api_metadata: list = None,
+    alpha: bool = False,
+    beta: bool = False,
 ):
     """
     Summarize feature data to parcel attributes.
@@ -1228,7 +1249,13 @@ def parcel_rollup(
             for successful AOIs) with the classes_df subset that API covers.
             For AOIs missing from a metadata_df, columns for those classes are set
             to null — indicating "no observational data" rather than "checked and
-            found nothing."
+            found nothing." For AOIs present in metadata_df, the same null-out is
+            applied per-class when the class isn't returnable at that AOI's actual
+            `system_version` under the active alpha/beta flags — distinguishing
+            "not queryable here" from "queried and found zero."
+        alpha: Whether the query was made with --alpha. Passed to
+            is_class_returnable_at_version() for per-AOI class null-out.
+        beta: Whether the query was made with --beta. Same usage as `alpha`.
 
     Returns:
         Parcel rollup DataFrame
@@ -1237,8 +1264,12 @@ def parcel_rollup(
     area_units = mu.area_units()
 
     # Pre-compute which classes should be nulled per AOI based on API metadata.
-    # For each (metadata_df, classes_subset) pair, AOIs missing from metadata_df
-    # had that API fail — their columns for those classes should be null.
+    # Two sources of null-out, both emitting NaN (not "N") to mean "no observational data":
+    #   1. Failed AOIs: AOIs missing from metadata_df had that API fail —
+    #      null out all classes the API covers.
+    #   2. Successful AOIs: for each AOI's actual resolved system_version,
+    #      null out classes whose availability shows they aren't returnable
+    #      under the active alpha/beta flags at that exact version.
     null_classes_by_aoi = {}
     _class_baseline_columns = {}
     if api_metadata:
@@ -1250,6 +1281,20 @@ def parcel_rollup(
                 class_ids = set(meta_classes.index)
                 for aoi_id in failed_aois:
                     null_classes_by_aoi.setdefault(aoi_id, set()).update(class_ids)
+
+            # Per-AOI per-version returnability: only applies when metadata carries
+            # the system_version column and classes carry availability. Roof age and
+            # other synthetic class subsets may not have either — fail-open then.
+            if (
+                len(meta_df) > 0
+                and "system_version" in meta_df.columns
+                and "availability" in meta_classes.columns
+            ):
+                avail_by_class = meta_classes["availability"].to_dict()
+                for aoi_id, sv in meta_df["system_version"].items():
+                    for class_id, avail in avail_by_class.items():
+                        if not is_class_returnable_at_version(avail, sv, alpha=alpha, beta=beta):
+                            null_classes_by_aoi.setdefault(aoi_id, set()).add(class_id)
         # Only compute baseline columns if at least one AOI needs nullification
         if null_classes_by_aoi:
             # Discover exact baseline column names per class by running

--- a/tests/data/classes_availability_sample.json
+++ b/tests/data/classes_availability_sample.json
@@ -1,0 +1,4282 @@
+{
+  "classes": [
+    {
+      "id": "00b83b22-a1a5-5268-99fb-62c3c3554d1d",
+      "description": "Raised Car Park",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "00f385f3-683b-52d4-953e-02e86f2e89c7",
+      "description": "Unmaintained Swimming Pool",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "027835c1-443c-55aa-940f-26b474cea277",
+      "description": "Pool Condition",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "0339726f-081e-5a6e-b9a9-42d95c1b5c8a",
+      "description": "Swimming Pool",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "042a1d14-4a23-50dc-aabb-befc9645af3b",
+      "description": "Leaf-off Tree Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "046ba67f-ca1e-5801-bb1c-bfcafea2d796",
+      "description": "Residential Satellite Dish",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "09b925d2-df1d-599b-89f1-3ffd39df791e",
+      "description": "Bowstring Truss",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "09ed6bf9-182a-5c79-ae59-f5531181d298",
+      "description": "Clay Tile",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "0ad1355f-5dfd-403b-8b8b-b7d8ed95731f",
+      "description": "Natural (soft)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "122abf34-b8d7-5c81-b353-69c518f13688",
+      "description": "Junk and Wreckage Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "1234ea84-e334-5c58-88a9-6554be3dfc05",
+      "description": "Parapet",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "1878ccf6-46ec-55a7-a20b-0cf658afb755",
+      "description": "Building",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_grove-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "19029055-9962-588e-b7a9-227a82d20869",
+      "description": "Letters and Numbers",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "1948fc2b-40cb-5107-b095-339b77a6ef57",
+      "description": "Miscellaneous Roof Object",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "19e49dad-4228-554e-9f5e-c2e37b2e11d9",
+      "description": "Building 3d attributes",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_grove-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "1ab60ef7-e770-5ab6-995e-124676b2be11",
+      "description": "Flat",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "1ce5ce00-9970-5673-b76e-31713a7012ca",
+      "description": "Wooden Pallet",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "1ea715ed-5166-55e3-a342-96a78e238633",
+      "description": "Linear",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "1ef797a5-8057-5e8b-a24d-dc7cd8f1fa7b",
+      "description": "Power Line Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "20a58db2-bc02-531d-98f5-451f88ce1fed",
+      "description": "Roof types",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "224f98d3-b853-542a-8b18-e1e46e3a8200",
+      "description": "Flat (Deprecated)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "2322ca41-5d3d-5782-b2b7-1a2ffd0c4b78",
+      "description": "Exposed Underlayment",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "23faf093-7cdc-5c6a-accb-131ac39638b5",
+      "description": "Trailer",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "266bdc07-1c54-5d55-abb1-fab053645071",
+      "description": "Tarpaulin/Shade Cloth",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "2780fa70-7713-437c-ad98-656b8a5cc4f2",
+      "description": "Low Vegetation (0.5m-2m)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "2905ba1c-6d96-58bc-9b1b-5911b3ead023",
+      "description": "Exposed Roof Deck",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "290897be-078b-4948-97aa-755289a67a29",
+      "description": "Concrete Slab",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "2a41d66b-91ef-5b51-8737-a53e8751dff7",
+      "description": "Vent",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "2e0bd9e3-3b67-4990-84dc-1b4812fdd02b",
+      "description": "Water Body",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3065525d-3f14-5b9d-8c4c-077f1ad5c694",
+      "description": "Roof Condition",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3076accc-81e1-5a69-b570-d275b1cf420c",
+      "description": "Shipping Container",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "30fc0c55-2b61-569f-b424-44082987ecb9",
+      "description": "Medium and High Vegetation with Woody Vegetation",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "319f552f-f4b7-520d-9b16-c8abb394b043",
+      "description": "Roof Staining",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "32d1fa98-85f3-578c-8348-31d966f636a6",
+      "description": "Patio Furniture",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3534a1fc-2e12-51a7-b2dc-1c850bc69fc1",
+      "description": "Building with Structural Damage",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3563c8f1-e81e-52c7-bd56-eaa937010403",
+      "description": "Built Up",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3680e1b8-8ae1-5a15-8ec7-820078ef3298",
+      "description": "Solar Panel",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3719eb40-d6d1-5071-bbe6-379a551bb65f",
+      "description": "Dutch Gable",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "372fb6c1-a3ab-5019-ba0f-489ed12079de",
+      "description": "Road (Driveable Surface)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "383930f1-d866-5aa3-9f97-553311f3162d",
+      "description": "PVC/TPO",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "38c4dd92-868c-582a-a4d5-537c88dcec75",
+      "description": "Low Vegetation (0.5m-2m) Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "39072960-5582-52af-9051-4bc8625ff9ba",
+      "description": "Roof 3d attributes",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3de89e9f-5e2f-5715-8b2b-fba35d536507",
+      "description": "Pole type",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "3f5a737e-6d56-538a-ac26-f2934bbbb695",
+      "description": "Skylight",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "405efaad-4b79-585d-88d8-43ae5fbb6f05",
+      "description": "Yard Debris",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4424186a-0b42-5608-a5a0-d4432695c260",
+      "description": "Metal",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4558c4fb-3ddf-549d-b2d2-471384be23d1",
+      "description": "Ballasted",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "46f2f9ce-8c0f-50df-a9e0-4c2026dd3f95",
+      "description": "Pole",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4794d3ec-0ee7-5def-ad56-f82ff7639bce",
+      "description": "Building Under Construction",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4aec3d8a-da20-5fcd-a868-6c19d2772b2e",
+      "description": "Driveway",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4bb630b9-f9eb-5f95-85b8-f0c6caf16e9b",
+      "description": "Gambrel",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "4bbf8dbd-cc81-5773-961f-0121101422be",
+      "description": "Shingle",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "516fdfd5-0be9-59fe-b849-92faef8ef26e",
+      "description": "Tile",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "526496bf-7344-5024-82d7-77ceb671feb4",
+      "description": "Roof Rusting",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "52e19d7b-2032-55be-a529-3682579e797e",
+      "description": "Building Damage Rating",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "FooFighters:A.1-1.0",
+          "perspective": "FooFighters",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "582f5f70-5a21-50b8-a764-5824f8af5c94",
+      "description": "Power Pole",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "584188c4-4f77-5724-a782-f13865ab0dbc",
+      "description": "Building Structural Loss",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "59c6e27e-6ef2-5b5c-90e7-31cfca78c0c2",
+      "description": "Gable",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "5a370e2f-e881-5cca-8284-bb0fb683ff14",
+      "description": "Pedestrian Crossing",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "5b556adb-2160-53f9-9bdd-b2be9ab58f51",
+      "description": "Atmospheric Occlusion - Translucent",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "5c50f05d-b158-5cf1-ad0b-e231bde9615c",
+      "description": "Roof Walkway",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "62a0958e-2139-5688-a776-b88c6049d50e",
+      "description": "Boat",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "64db6ea0-7248-53f5-b6a6-6ed733c5f9b8",
+      "description": "EPDM",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "661b420c-afb8-541f-be6a-dc7a7b11de53",
+      "description": "Disintegrated Pavement",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "6832955f-89c6-5cfd-874d-40c22aead943",
+      "description": "Vegetation Debris",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "68dc5061-5842-4a17-8073-e278a91b607d",
+      "description": "Lawn Grass",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "6a2c2adb-0914-56b3-8a2d-871b803a0dd7",
+      "description": "Construction Crane",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "7218eb36-0d36-5b53-a2fe-6e99c7d950bc",
+      "description": "Roof with Permanent Repair",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "741b512f-a4a9-5107-a301-a0d1a7094783",
+      "description": "HVAC",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "753621ee-0b9f-515e-9bcf-ea40b96612ab",
+      "description": "Trampoline",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "75efd1e7-c253-59f0-b3aa-95f9c17efa93",
+      "description": "Wheeled Construction Vehicles",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "7741703d-4ce4-54e1-a9ee-05a0a1851137",
+      "description": "Playground",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "7ab56e15-d5d4-51bb-92bd-69e910e82e56",
+      "description": "Roof overhang attributes",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "7eb3b1b6-0d75-5b1f-b41c-b14146ff0c54",
+      "description": "Mansard",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "82b4547b-b8c0-5e9a-84c2-5c7564b4586c",
+      "description": "Missing Asphalt shingles",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "8337e0e1-e171-5292-89cc-99c0da2a4fe4",
+      "description": "Car",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "8723980d-3c83-5971-92e6-30bfb7452999",
+      "description": "STOP Marking",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "87437e20-d9f5-57e1-8b87-4a9c81ec3b65",
+      "description": "Mod-Bit",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "89582082-e5b8-5853-bc94-3a0392cab98a",
+      "description": "Turret",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "89c7d478-58de-56bd-96d2-e71e27a36905",
+      "description": "Roof material",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "8ab218a7-8173-5f1e-a5cb-bb2cd386a73e",
+      "description": "Roof Debris",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "8b30838b-af41-5d1d-bdbd-29e682fe3b00",
+      "description": "Roof Patching",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "8e9448bd-4669-5f46-b8f0-840fee25c34c",
+      "description": "Tree Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "91987430-6739-5e16-b92f-b830dd7d52a6",
+      "description": "Building lifecycle",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "FooFighters:A.1-1.0",
+          "perspective": "FooFighters",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "FooFighters",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "924afbab-aae6-5c26-92e8-9173e4320495",
+      "description": "Jerkinhead",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "93f172b5-c544-538f-93dc-8129fe77e0d4",
+      "description": "Block Character",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "94944057-968c-5df3-828b-285091b7e266",
+      "description": "Active Ponding",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "97a1f8a8-7cf2-4e81-82b4-753ee225d9ed",
+      "description": "Asphalt",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "97a6f930-82ae-55f2-b856-635e2250af29",
+      "description": "Worn Shingles",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "9992c50b-59cb-57dd-90ee-9b5dfac7d3f5",
+      "description": "Duct",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "9f5a766e-a1ab-59ff-9b34-f127d6a717ef",
+      "description": "Fire Pit",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "9fc4c92e-4405-573e-bce6-102b74ab89a3",
+      "description": "Wood Shake",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "a0471613-1dfa-5936-960e-f128c083001b",
+      "description": "Vegetation Debris Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "a2a81381-13c6-57dc-a967-af696e45f6c7",
+      "description": "Construction Site",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "a2e4ae39-8a61-5515-9d18-8900aa6e6072",
+      "description": "Building (Deprecated)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "a4d3705f-1a20-5322-8fc6-687c01cebdc8",
+      "description": "Block Symbol",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "a7d921b7-393c-4121-b317-e9cda3e4c19b",
+      "description": "Very Low Vegetation (<0.5m)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "aaf425d3-74b3-5efe-8e50-dc3f902ed431",
+      "description": "Painted Lane",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ab2df18b-cdda-5be9-b5ee-a2dac5b4d9a1",
+      "description": "Heavy Machinery",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "abb1f304-ce01-527b-b799-cbfd07551b2c",
+      "description": "Roof with Temporary Repair",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ac0a5f75-d8aa-554c-8a43-cee9684ef9e9",
+      "description": "Hip",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "b084f3a7-6bb5-580c-849a-0467e3919a7d",
+      "description": "Circular Manhole Covers",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "b0abb555-7936-5829-acee-c33f40e00cf4",
+      "description": "Hard Surface",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "b1c2f04b-78ca-5dbc-bf9b-74291c1e39f6",
+      "description": "Damaged Asphalt",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "b22e2f48-de58-53be-84ae-d56181f737fe",
+      "description": "Residential TV Antenna Base",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "b2573072-b3a5-5f7c-973f-06b7649665ff",
+      "description": "Roof Coating",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "b64ecdb0-6810-5c70-835c-9e2a5f2a4d84",
+      "description": "Silo",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ba7c0d7d-d355-56f0-ab69-2a96720bf7b7",
+      "description": "Roof Equipment",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c0224852-4310-57dd-95fe-42bff1c0a3f0",
+      "description": "Structural Damage Composite",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c08255a4-ba9f-562b-932c-ff76f2faeeeb",
+      "description": "Roof",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c1143023-135b-54fd-9a07-8de0ff55de51",
+      "description": "Solar Hot Water",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c16cd5a7-bddf-5457-93d5-d70bb6d971a7",
+      "description": "Light Pole Base",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "c2d289f4-be5a-50f7-a186-12a065e5178a",
+      "description": "Power Line",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "c46e75a6-7b3c-5910-9f3f-742dd668025b",
+      "description": "Building Damage by Tree",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c54e38d6-866f-592c-bb9c-c68044ed43c9",
+      "description": "Residential Chimney",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c67497c5-76af-5cd2-a5c7-473cca0f6597",
+      "description": "Translucent Roofing",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "c81ff488-2693-5812-89d6-1b9e7950b308",
+      "description": "Pipe",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ca05232f-96db-5aa7-a3a0-f5aa4be12153",
+      "description": "Tennis Court",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "cd15ea0b-a0f6-58b6-9a63-480654ff506c",
+      "description": "Dormer Window",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "cd2e38aa-fc98-5bd4-b83e-0f614b48e334",
+      "description": "Significantly Stained Pavement",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "cd47dfd1-2c24-543c-89fd-7677b2cc100b",
+      "description": "Leaf-off Vegetation",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "beta"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "cdc50dcc-e522-5361-8f02-4e30673311bb",
+      "description": "Slate",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "cfa8951a-4c29-54de-ae98-e5f804c305e3",
+      "description": "Tile or Shingle Staining",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "d24c3212-e089-5b0b-a5f8-58d7e1da0a0d",
+      "description": "Wooden Decking",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "d997550f-5630-5d07-aa07-13182e7caae5",
+      "description": "Tyres",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "dc834996-1c8f-5d0a-a215-2fc0bf9260a5",
+      "description": "Grain Bin",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "dd1e6ef5-8227-492a-b02f-adcf660d06d0",
+      "description": "Natural (hard)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "dec855e2-ae6f-56b5-9cbb-f9967ff8ca12",
+      "description": "Missing Roof Tile or Shingle",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "dfd8181b-80c9-4234-9d05-0eef927e3aca",
+      "description": "Medium and High Vegetation (>2m)",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "e125a77b-3790-578a-be5a-9b7223030513",
+      "description": "Cracked Pavement",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "e92bc8a2-9fa3-5094-b3b6-2881d94642ab",
+      "description": "Quonset",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "eaa83113-44b3-505e-9515-ba8a8d403dd4",
+      "description": "Woody Vegetation",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ec5542e4-83a7-53c4-ae2f-dc5b534cc1ba",
+      "description": "Nonwooden Construction Material",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ed1ea29d-cd2c-55a9-8737-13018a9bb741",
+      "description": "A/C Condenser Unit",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "ef761921-727e-50bb-9f2a-988becf09796",
+      "description": "Dumpster",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f14c1581-66e6-5cf1-a051-2298ad165d28",
+      "description": "Low confidence roof condition",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f2c37940-5fc2-5d2c-94fa-d131f6e200a2",
+      "description": "Arrow",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f41e02b0-adc0-5b46-ac95-8c59aa9fe317",
+      "description": "Roof Ponding",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f4b78dad-c2c0-5236-8eb1-3266ed468604",
+      "description": "Natural Pervious Surface",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f5070c73-66ca-5cb1-9744-2629a27533ce",
+      "description": "All-in Vegetation",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        }
+      ]
+    },
+    {
+      "id": "f55813f9-a39d-571d-9688-8d3f76aa35b9",
+      "description": "Zinc Staining",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f5efb75e-22bb-5b53-93f1-892501868627",
+      "description": "Building pitch",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_grove-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f7628feb-6d70-50ee-bbfd-053b4e685e8f",
+      "description": "Ground height",
+      "type": "Attribute",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_grove-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "TrueOrtho",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f8abc8e3-6af3-5a1d-9a8e-1793419455bb",
+      "description": "Junk and Wreckage",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "f907e625-26b3-59db-a806-d41f62ce1f1b",
+      "description": "Structural Damage",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen4-building_storm-2.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen4-lightning_bolt-1.3",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "fcbb15ea-93e5-587c-8941-246353817741",
+      "description": "Very Low Vegetation (<0.5m) Overhang",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "fd050fb5-8008-57ab-a3fc-fb09c4aa7b68",
+      "description": "Repaired Pavement",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "fd149017-c3a1-54a2-b6e4-88f5d5ab9c59",
+      "description": "Atmospheric Occlusion - Opaque",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen5-tranquil_pool-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-tranquil_sea-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen5-urban_atlas-1.0",
+          "perspective": "Vert",
+          "status": "alpha"
+        },
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    },
+    {
+      "id": "fd6754fb-11eb-5fb3-9971-23a129099970",
+      "description": "Greenhouse",
+      "type": "Feature",
+      "availability": [
+        {
+          "systemVersion": "gen6-glowing_lantern-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        },
+        {
+          "systemVersion": "gen6-glowing_moon-1.0",
+          "perspective": "Vert",
+          "status": "prod"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_class_availability.py
+++ b/tests/test_class_availability.py
@@ -1,0 +1,146 @@
+"""Tests for per-version class returnability used to null out rollup columns.
+
+Availability fixtures are loaded from a real `/classes.json` payload cached at
+`tests/data/classes_availability_sample.json`. This is intentionally live data
+rather than hand-constructed mocks — future API shape changes should surface
+here as test failures, which is informative. Regenerate via the
+`test_gen_classes_availability_sample` generator below (uncomment the skip).
+
+A few synthetic fixtures remain only for cases not currently observed in real
+data — e.g. a class with both alpha and beta statuses at the same
+systemVersion. Those are marked as hypothetical.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from nmaipy.feature_api import FeatureApi, is_class_returnable_at_version
+
+CLASSES_SAMPLE_PATH = Path(__file__).parent / "data" / "classes_availability_sample.json"
+
+
+@pytest.mark.skip("Comment out this line if you wish to regen the test data")
+@pytest.mark.live_api
+def test_gen_classes_availability_sample():
+    """Fetch a fresh /classes.json snapshot and overwrite the cached sample.
+
+    Matches the `test_gen_data_*` pattern elsewhere in the suite — not run by
+    default; uncomment the skip when the cached sample needs refreshing
+    (e.g. after a catalog change broke downstream assertions).
+    """
+    api = FeatureApi()
+    df = api.get_feature_classes()
+    api.cleanup()
+    # Reconstruct a minimal payload of the shape /classes.json returns. Only
+    # the fields we actually consume are preserved — keeps the fixture small
+    # and resistant to incidental schema churn.
+    classes = [
+        {
+            "id": class_id,
+            "description": row["description"],
+            "type": row.get("type", "Feature"),
+            "availability": row.get("availability") or [],
+        }
+        for class_id, row in df.iterrows()
+    ]
+    CLASSES_SAMPLE_PATH.write_text(json.dumps({"classes": classes}, indent=2))
+    assert CLASSES_SAMPLE_PATH.exists()
+
+
+@pytest.fixture(scope="module")
+def real_classes():
+    """Real /classes.json payload — maps class description to availability list."""
+    data = json.loads(CLASSES_SAMPLE_PATH.read_text())
+    return {c["description"]: c.get("availability") or [] for c in data["classes"] if c.get("type") == "Feature"}
+
+
+class TestRealClassesProdAndAlpha:
+    """Exercise `is_class_returnable_at_version` against real availability data.
+    These assertions reflect the catalog state at the time the sample was cached;
+    they'll break if a class's gating changes, which is intentional.
+    """
+
+    def test_swimming_pool_prod_at_gen6(self, real_classes):
+        # Swimming Pool is prod under gen6 → returnable regardless of flags.
+        avail = real_classes["Swimming Pool"]
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0") is True
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0", alpha=False, beta=False) is True
+
+    def test_hvac_alpha_only_in_gen6(self, real_classes):
+        # HVAC is alpha at both gen6-glowing_lantern and gen6-glowing_moon.
+        avail = real_classes["HVAC"]
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0", alpha=False) is False
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0", alpha=True) is True
+        # Beta flag alone does not unlock an alpha-gated class.
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0", alpha=False, beta=True) is False
+
+    def test_power_pole_absent_from_gen6(self, real_classes):
+        # Power Pole exists only in gen4 — absent at gen6 regardless of flags.
+        avail = real_classes["Power Pole"]
+        assert is_class_returnable_at_version(avail, "gen6-glowing_moon-1.0", alpha=True, beta=True) is False
+        # But available at gen4 with --alpha.
+        assert is_class_returnable_at_version(avail, "gen4-building_storm-2.3", alpha=True) is True
+        assert is_class_returnable_at_version(avail, "gen4-building_storm-2.3", alpha=False) is False
+
+    def test_wrong_exact_version_within_same_gen(self, real_classes):
+        # Class's gen6 entry is for glowing_moon; querying an unlisted gen6
+        # sub-version (gen6-nonexistent-1.0) is an exact-match miss — not
+        # returnable even with all flags set.
+        avail = real_classes["HVAC"]
+        assert is_class_returnable_at_version(avail, "gen6-nonexistent-1.0", alpha=True, beta=True) is False
+
+
+class TestHypotheticalMixedStatuses:
+    """Edge cases not currently observed in /classes.json but valid per the API
+    contract (a class can in principle carry multiple status entries under the
+    same exact systemVersion during a promotion). These guard the logic without
+    relying on a shape the API doesn't produce today.
+    """
+
+    def test_alpha_and_beta_at_same_version_respects_alpha_flag(self):
+        # Regression guard: a prefix-based predecessor dropped this case due to
+        # beta-first priority, ignoring that alpha=True satisfied the alpha entry.
+        availability = [
+            {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "alpha"},
+            {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "beta"},
+        ]
+        assert is_class_returnable_at_version(availability, "gen6-glowing_moon-1.0", alpha=True, beta=False) is True
+        assert is_class_returnable_at_version(availability, "gen6-glowing_moon-1.0", alpha=False, beta=True) is True
+        assert is_class_returnable_at_version(availability, "gen6-glowing_moon-1.0", alpha=False, beta=False) is False
+
+    def test_prod_and_alpha_at_same_version_resolves_to_returnable(self):
+        # Prod access always wins regardless of additional alpha entries.
+        availability = [
+            {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "alpha"},
+            {"systemVersion": "gen6-glowing_moon-1.0", "perspective": "Vert", "status": "prod"},
+        ]
+        assert is_class_returnable_at_version(availability, "gen6-glowing_moon-1.0") is True
+
+
+class TestFailOpen:
+    """Fail-open behaviour for malformed / missing inputs — prefers phantom
+    columns to silent drops."""
+
+    def test_none_system_version_is_returnable(self, real_classes):
+        assert is_class_returnable_at_version(real_classes["HVAC"], None, alpha=False) is True
+
+    def test_empty_system_version_is_returnable(self, real_classes):
+        assert is_class_returnable_at_version(real_classes["HVAC"], "") is True
+
+    def test_non_list_availability_is_returnable(self):
+        assert is_class_returnable_at_version(None, "gen6-glowing_moon-1.0") is True
+        assert is_class_returnable_at_version({"gen6": "alpha"}, "gen6-glowing_moon-1.0") is True
+        assert is_class_returnable_at_version("garbage", "gen6-glowing_moon-1.0") is True
+
+    def test_malformed_entries_skipped(self):
+        availability = [
+            "not a dict",
+            {"status": "prod"},  # no systemVersion — skipped
+            {"systemVersion": "gen6-glowing_moon-1.0", "status": "prod"},  # valid
+        ]
+        assert is_class_returnable_at_version(availability, "gen6-glowing_moon-1.0") is True
+
+    def test_empty_availability_list_is_absent(self):
+        # Empty list is not fail-open: it's a legitimate assertion of no availability.
+        assert is_class_returnable_at_version([], "gen6-glowing_moon-1.0") is False

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -1837,6 +1837,207 @@ class TestApiMetadataInRollup:
             assert row["roof_instance_count"] == 1, f"{aoi}: roof_instance_count should be 1"
 
 
+class TestPerVersionAvailabilityNullOut:
+    """Rollup null-out driven by per-AOI system_version + class availability."""
+
+    # Two realistic system versions used across tests
+    SV_MOON = "gen6-glowing_moon-1.0"
+    SV_LANTERN = "gen6-glowing_lantern-1.0"
+
+    @pytest.fixture
+    def parcels_gdf(self):
+        return gpd.GeoDataFrame(
+            {AOI_ID_COLUMN_NAME: ["aoi_moon", "aoi_lantern"]},
+            geometry=[box(0, 0, 0.001, 0.001), box(0.01, 0.01, 0.011, 0.011)],
+            crs=API_CRS,
+        ).set_index(AOI_ID_COLUMN_NAME)
+
+    @pytest.fixture
+    def classes_df_prod_moon_alpha_lantern(self):
+        """Pool class is prod under glowing_moon but alpha under glowing_lantern."""
+        return pd.DataFrame(
+            {
+                "description": ["Swimming Pool"],
+                "availability": [
+                    [
+                        {"systemVersion": self.SV_MOON, "perspective": "Vert", "status": "prod"},
+                        {"systemVersion": self.SV_LANTERN, "perspective": "Vert", "status": "alpha"},
+                    ]
+                ],
+            },
+            index=[POOL_ID],
+        )
+
+    @pytest.fixture
+    def empty_features(self):
+        """Empty features GeoDataFrame with required schema."""
+        gdf = gpd.GeoDataFrame(
+            {"class_id": pd.Series(dtype=str)},
+            geometry=[],
+            crs=API_CRS,
+        )
+        gdf.index.name = AOI_ID_COLUMN_NAME
+        return gdf
+
+    def test_alpha_gated_aoi_has_null_columns(self, parcels_gdf, classes_df_prod_moon_alpha_lantern, empty_features):
+        """AOI that resolves to an alpha-gated version (alpha flag off) → class columns null."""
+        meta = pd.DataFrame(
+            {"system_version": [self.SV_MOON, self.SV_LANTERN]},
+            index=pd.Index(["aoi_moon", "aoi_lantern"], name=AOI_ID_COLUMN_NAME),
+        )
+        api_metadata = [(meta, classes_df_prod_moon_alpha_lantern)]
+
+        rollup = parcels.parcel_rollup(
+            parcels_gdf,
+            empty_features,
+            classes_df_prod_moon_alpha_lantern,
+            country="us",
+            primary_decision="largest_intersection",
+            api_metadata=api_metadata,
+            alpha=False,
+            beta=False,
+        )
+
+        # AOI on glowing_moon: class is prod → vacant-lot defaults (N / 0)
+        assert rollup.loc["aoi_moon", "swimming_pool_present"] == "N"
+        assert rollup.loc["aoi_moon", "swimming_pool_count"] == 0
+
+        # AOI on glowing_lantern: class is alpha, alpha=False → null (not queryable)
+        assert pd.isna(rollup.loc["aoi_lantern", "swimming_pool_present"])
+        assert pd.isna(rollup.loc["aoi_lantern", "swimming_pool_count"])
+
+    def test_alpha_flag_on_makes_both_aois_visible(
+        self, parcels_gdf, classes_df_prod_moon_alpha_lantern, empty_features
+    ):
+        """With --alpha set, both AOIs see the class (one prod, one alpha-with-flag)."""
+        meta = pd.DataFrame(
+            {"system_version": [self.SV_MOON, self.SV_LANTERN]},
+            index=pd.Index(["aoi_moon", "aoi_lantern"], name=AOI_ID_COLUMN_NAME),
+        )
+        api_metadata = [(meta, classes_df_prod_moon_alpha_lantern)]
+
+        rollup = parcels.parcel_rollup(
+            parcels_gdf,
+            empty_features,
+            classes_df_prod_moon_alpha_lantern,
+            country="us",
+            primary_decision="largest_intersection",
+            api_metadata=api_metadata,
+            alpha=True,
+            beta=False,
+        )
+
+        # Both AOIs: returnable → vacant-lot defaults, not null
+        assert rollup.loc["aoi_moon", "swimming_pool_present"] == "N"
+        assert rollup.loc["aoi_lantern", "swimming_pool_present"] == "N"
+
+    def test_class_absent_from_version_is_nulled(self, parcels_gdf, empty_features):
+        """Class only in gen4 → AOIs on gen6 get null (no flag will help)."""
+        classes_df = pd.DataFrame(
+            {
+                "description": ["Power Pole"],
+                "availability": [
+                    [{"systemVersion": "gen4-building_storm-2.3", "perspective": "Vert", "status": "alpha"}]
+                ],
+            },
+            index=[POOL_ID],  # reusing POOL_ID as placeholder; class_id is opaque here
+        )
+        meta = pd.DataFrame(
+            {"system_version": [self.SV_MOON, self.SV_LANTERN]},
+            index=pd.Index(["aoi_moon", "aoi_lantern"], name=AOI_ID_COLUMN_NAME),
+        )
+
+        rollup = parcels.parcel_rollup(
+            parcels_gdf,
+            empty_features,
+            classes_df,
+            country="us",
+            primary_decision="largest_intersection",
+            api_metadata=[(meta, classes_df)],
+            alpha=True,
+            beta=True,
+        )
+        # Availability absent at both system versions — both nulled out regardless of flags
+        assert pd.isna(rollup.loc["aoi_moon", "power_pole_present"])
+        assert pd.isna(rollup.loc["aoi_lantern", "power_pole_present"])
+
+    def test_missing_availability_fails_open(self, parcels_gdf, empty_features):
+        """classes_df without 'availability' column → no per-version null-out applied."""
+        classes_df = pd.DataFrame(
+            {"description": ["Swimming Pool"]},
+            index=[POOL_ID],
+        )
+        meta = pd.DataFrame(
+            {"system_version": [self.SV_MOON, self.SV_LANTERN]},
+            index=pd.Index(["aoi_moon", "aoi_lantern"], name=AOI_ID_COLUMN_NAME),
+        )
+
+        rollup = parcels.parcel_rollup(
+            parcels_gdf,
+            empty_features,
+            classes_df,
+            country="us",
+            primary_decision="largest_intersection",
+            api_metadata=[(meta, classes_df)],
+            alpha=False,
+            beta=False,
+        )
+        # No availability data → no null-out → vacant-lot defaults
+        assert rollup.loc["aoi_moon", "swimming_pool_present"] == "N"
+        assert rollup.loc["aoi_lantern", "swimming_pool_present"] == "N"
+
+
+class TestClassScopedColumnPrefixes:
+    """Helper used by the final-stage column prune in exporter.py."""
+
+    def test_basic_prefixes(self):
+        classes_df = pd.DataFrame(
+            {"description": ["Swimming Pool", "HVAC"]},
+            index=["id1", "id2"],
+        )
+        prefixes = parcels.class_scoped_column_prefixes(classes_df)
+        assert "swimming_pool_" in prefixes
+        assert "primary_swimming_pool_" in prefixes
+        assert "hvac_" in prefixes
+        assert "primary_hvac_" in prefixes
+
+    def test_column_prune_behavior(self):
+        """Simulate the exporter.py prune step on a rollup DataFrame."""
+        classes_df = pd.DataFrame(
+            {"description": ["Swimming Pool", "HVAC"]},
+            index=["id1", "id2"],
+        )
+        prefixes = parcels.class_scoped_column_prefixes(classes_df)
+
+        df = pd.DataFrame(
+            {
+                # Class-scoped, all NaN → should be pruned
+                "hvac_present": [None, None],
+                "hvac_count": [None, None],
+                "primary_hvac_area_sqm": [None, None],
+                # Class-scoped, populated → should stay
+                "swimming_pool_present": ["N", "Y"],
+                "swimming_pool_count": [0, 1],
+                # User input column that happens to be NaN → must stay (not class-scoped)
+                "my_user_col": [None, None],
+                # Metadata → stays
+                "mesh_date": ["2024-01-01", "2024-02-01"],
+            }
+        )
+        # Mimic the prune logic from exporter.py
+        all_nan_class_cols = [
+            c for c in df.columns if c.startswith(prefixes) and df[c].isna().all()
+        ]
+        pruned = df.drop(columns=all_nan_class_cols)
+
+        assert "hvac_present" not in pruned.columns
+        assert "hvac_count" not in pruned.columns
+        assert "primary_hvac_area_sqm" not in pruned.columns
+        assert "swimming_pool_present" in pruned.columns
+        assert "my_user_col" in pruned.columns
+        assert "mesh_date" in pruned.columns
+
+
 if __name__ == "__main__":
     current_file = os.path.abspath(__file__)
     sys.exit(pytest.main([current_file]))

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -1987,54 +1987,67 @@ class TestPerVersionAvailabilityNullOut:
         assert rollup.loc["aoi_lantern", "swimming_pool_present"] == "N"
 
 
-class TestClassScopedColumnPrefixes:
-    """Helper used by the final-stage column prune in exporter.py."""
+class TestClassColumnNames:
+    """Helper used by both parcel_rollup null-out and the final-stage column
+    prune in exporter.py to map class_id → rollup column names authoritatively."""
 
-    def test_basic_prefixes(self):
+    def test_expected_baseline_columns_emitted(self):
+        # Use a real class whose column names we know (pool).
         classes_df = pd.DataFrame(
-            {"description": ["Swimming Pool", "HVAC"]},
-            index=["id1", "id2"],
+            {"description": ["Swimming Pool"]},
+            index=[POOL_ID],
         )
-        prefixes = parcels.class_scoped_column_prefixes(classes_df)
-        assert "swimming_pool_" in prefixes
-        assert "primary_swimming_pool_" in prefixes
-        assert "hvac_" in prefixes
-        assert "primary_hvac_" in prefixes
+        cols_by_id = parcels.class_column_names(classes_df, country="us")
+        pool_cols = cols_by_id[POOL_ID]
+        # Every class gets baseline present/count/area/confidence columns.
+        assert "swimming_pool_present" in pool_cols
+        assert "swimming_pool_count" in pool_cols
+        assert "swimming_pool_total_area_sqft" in pool_cols
+        assert "swimming_pool_confidence" in pool_cols
+
+    def test_user_input_column_never_marked_class_scoped(self):
+        # A user input column named e.g. "swimming_pool_owner" must NOT be in the
+        # authoritative set just because its name shares a prefix with a class.
+        classes_df = pd.DataFrame(
+            {"description": ["Swimming Pool"]},
+            index=[POOL_ID],
+        )
+        cols_by_id = parcels.class_column_names(classes_df, country="us")
+        all_class_cols = set().union(*cols_by_id.values())
+        assert "swimming_pool_owner" not in all_class_cols
+        assert "my_arbitrary_column" not in all_class_cols
 
     def test_column_prune_behavior(self):
-        """Simulate the exporter.py prune step on a rollup DataFrame."""
+        """Simulate the exporter.py prune step on a rollup DataFrame — verifies
+        that a user input column with a class-prefix name is not pruned even
+        if all-NaN, because the candidate set is class-id-authoritative."""
         classes_df = pd.DataFrame(
-            {"description": ["Swimming Pool", "HVAC"]},
-            index=["id1", "id2"],
+            {"description": ["Swimming Pool"]},
+            index=[POOL_ID],
         )
-        prefixes = parcels.class_scoped_column_prefixes(classes_df)
+        cols_by_id = parcels.class_column_names(classes_df, country="us")
+        candidate_cols = set().union(*cols_by_id.values())
 
         df = pd.DataFrame(
             {
-                # Class-scoped, all NaN → should be pruned
-                "hvac_present": [None, None],
-                "hvac_count": [None, None],
-                "primary_hvac_area_sqm": [None, None],
-                # Class-scoped, populated → should stay
-                "swimming_pool_present": ["N", "Y"],
-                "swimming_pool_count": [0, 1],
-                # User input column that happens to be NaN → must stay (not class-scoped)
-                "my_user_col": [None, None],
+                # Authoritative class-scoped column, all NaN → should be pruned
+                "swimming_pool_present": [None, None],
+                "swimming_pool_count": [None, None],
+                # User input column that happens to start with a class name AND
+                # is all NaN → must stay, because it's not in the authoritative set.
+                "swimming_pool_owner": [None, None],
                 # Metadata → stays
                 "mesh_date": ["2024-01-01", "2024-02-01"],
             }
         )
-        # Mimic the prune logic from exporter.py
         all_nan_class_cols = [
-            c for c in df.columns if c.startswith(prefixes) and df[c].isna().all()
+            c for c in df.columns if c in candidate_cols and df[c].isna().all()
         ]
         pruned = df.drop(columns=all_nan_class_cols)
 
-        assert "hvac_present" not in pruned.columns
-        assert "hvac_count" not in pruned.columns
-        assert "primary_hvac_area_sqm" not in pruned.columns
-        assert "swimming_pool_present" in pruned.columns
-        assert "my_user_col" in pruned.columns
+        assert "swimming_pool_present" not in pruned.columns
+        assert "swimming_pool_count" not in pruned.columns
+        assert "swimming_pool_owner" in pruned.columns  # user input preserved
         assert "mesh_date" in pruned.columns
 
 


### PR DESCRIPTION
## Summary

The rollup was emitting "N" (False) for classes the API would never return at an AOI's resolved system version due to class availability. This made it impossible to distinguish between a true "not found" negative result, and missing data for a row. The issue was rare, mainly impacting alpha and beta columns where availability depends on API flags.

The decision is now made **per-row** using the exact `system_version` the API returned in the response metadata, checked against each class's `availability` entries from `/classes.json`. Classes not returnable at a given AOI's version under the active `--alpha`/`--beta` flags get their columns nulled via the existing `null_classes_by_aoi` mechanism in `parcel_rollup()`.

After all chunks are concatenated, any class-scoped columns that ended up 100% NaN across the whole rollup are dropped. The candidate set is the authoritative `class_id → column names` mapping (from `feature_attributes()` with empty input) — not a name-prefix heuristic — so user input columns can't be pruned by accident.

A `classes_availability.json` snapshot is written to the export output as a reproducibility record, locked for the duration of the export.

## Obsoletes #151

See the discussion on [#151](https://github.com/nearmap/nmaipy/pull/151) for background on what prompted this.

## Test plan

- [x] New unit tests in `tests/test_class_availability.py` (11 passed, 1 gen-data skipped) — driven from a cached real `/classes.json` payload at `tests/data/classes_availability_sample.json`, regenerated via the included generator test (standard `test_gen_data_*` pattern).
- [x] New integration tests in `tests/test_parcels.py::TestPerVersionAvailabilityNullOut` and `::TestClassColumnNames` — covering mixed-version rollups and the authoritative column-set prune (incl. a regression guarding against user input columns being pruned when they share a class-name prefix).
- [x] Full non-live suite: 426 passed, 12 skipped, 56 deselected.
- [x] E2E against `tests/data/test_parcels_2.csv` (100 NJ parcels) with `--packs commercial_roof_objects`:
  - No `--alpha`: `hvac_*` and `miscellaneous_roof_object_*` columns absent from rollup ✓
  - With `--alpha`: same columns present and populated (5/100 AOIs detected HVAC) ✓
- [x] E2E `--packs utilities --alpha`: gen6-absent `power_pole_*` / `light_pole_base_*` dropped; gen6-prod `pole_*` retained ✓