### PR TITLE
[TRO-4313] Respawn worker processes after each chunk to prevent memory accumulation

### DIFF
--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -383,7 +383,7 @@ class BaseExporter(ABC):
         try:
             for attempt in range(max_retries):
                 try:
-                    with ProcessPoolExecutor(max_workers=self.processes, mp_context=mp_context) as executor:
+                    with ProcessPoolExecutor(max_workers=self.processes, mp_context=mp_context, max_tasks_per_child=1) as executor:
                         try:
                             # Submit all chunks
                             # Track warmup start time to gradually ramp up concurrency


### PR DESCRIPTION
## Summary

One-line fix: `ProcessPoolExecutor(..., max_tasks_per_child=1)` at [base_exporter.py:386](nmaipy/base_exporter.py#L386).

ProcessPoolExecutor reuses worker processes across chunks by default. Over hundreds of chunks in a large export, individual workers accumulate memory from geopandas/shapely objects, gridding state, and Python memory fragmentation that `gc.collect()` alone cannot reclaim. Active symptom: worker group at ~324/349 GB at chunk 113/261 of a live 1.3M-request export.

Setting `max_tasks_per_child=1` forces each worker to exit after processing one chunk, returning all memory to the OS. A fresh worker is spawned to replace it.

## Behaviour — verified empirically

Per-worker respawn is **asynchronous**, not batch-synchronous. Fast workers respawn and pick up new chunks while slow workers are still processing — no pool-wide barrier. Test with 2 workers, 6 tasks, mixed fast/slow durations confirmed:

- 6 unique PIDs across 6 tasks (every worker dies after its one task)
- Fast worker respawned and started its next task ~60ms after finishing, while the slow worker in the other slot was still running its first task
- No batch barrier across workers

## Overhead

Spawn cost under `spawn` mp_context with nmaipy's imports: roughly 1–3 seconds per worker process. For a chunk taking minutes of API calls, this is well under 1% wall-clock overhead, and it's further masked by being parallelisable across workers. Trivially worthwhile vs. OOM crashes on large exports.

## Origin

Cherry-picked from #152 (author: @mlopeman), landed standalone against main so it can ship surgically without the rest of that PR's bundled changes.

## Test plan

- [x] `pytest -m "not live_api"` — 426 passed, 12 skipped.
- [x] Empirical behaviour test (described above) confirming per-worker, non-batched respawn.