### PR TITLE
Catch unexpected per-AOI exceptions in get_features_gdf_bulk

### DIFF
--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1521,6 +1521,7 @@ class FeatureApi(GriddedApiClient):
 
             # Submit jobs to executor
             jobs = []
+            job_to_aoi_id = {}
             for aoi_id, row in gdf.iterrows():
                 # Overwrite blanket since/until dates with per request since/until if columns are present
                 since = since_bulk
@@ -1535,26 +1536,26 @@ class FeatureApi(GriddedApiClient):
                 if SURVEY_RESOURCE_ID_COL_NAME in row:
                     if isinstance(row[SURVEY_RESOURCE_ID_COL_NAME], str):
                         survey_resource_id = row[SURVEY_RESOURCE_ID_COL_NAME]
-                jobs.append(
-                    executor.submit(
-                        self.get_features_gdf,
-                        geometry=row.geometry if has_geom else None,
-                        region=region,
-                        packs=packs,
-                        classes=classes,
-                        include=include,
-                        aoi_id=aoi_id,
-                        since=since,
-                        until=until,
-                        address_fields=(
-                            {f: row[f] for f in ADDRESS_FIELDS} if has_address_fields and not has_geom else None
-                        ),
-                        survey_resource_id=survey_resource_id,
-                        fail_hard_regrid=fail_hard_regrid,
-                        in_gridding_mode=in_gridding_mode,
-                        disable_parcel_mode=disable_parcel_mode,
-                    )
+                job = executor.submit(
+                    self.get_features_gdf,
+                    geometry=row.geometry if has_geom else None,
+                    region=region,
+                    packs=packs,
+                    classes=classes,
+                    include=include,
+                    aoi_id=aoi_id,
+                    since=since,
+                    until=until,
+                    address_fields=(
+                        {f: row[f] for f in ADDRESS_FIELDS} if has_address_fields and not has_geom else None
+                    ),
+                    survey_resource_id=survey_resource_id,
+                    fail_hard_regrid=fail_hard_regrid,
+                    in_gridding_mode=in_gridding_mode,
+                    disable_parcel_mode=disable_parcel_mode,
                 )
+                jobs.append(job)
+                job_to_aoi_id[job] = aoi_id
 
             data = []
             metadata = []
@@ -1562,7 +1563,20 @@ class FeatureApi(GriddedApiClient):
             grid_errors = []  # Accumulate grid cell errors (DataFrames with geometry)
             # Use as_completed to process results as they finish, preventing blocking on slow requests
             for job in concurrent.futures.as_completed(jobs):
-                aoi_data, aoi_metadata, aoi_error, aoi_grid_errors = job.result()
+                try:
+                    aoi_data, aoi_metadata, aoi_error, aoi_grid_errors = job.result()
+                except Exception as e:
+                    failed_aoi_id = job_to_aoi_id.get(job, "unknown")
+                    logger.error(f"Unexpected error for AOI {failed_aoi_id}: {e}")
+                    aoi_data, aoi_metadata, aoi_grid_errors = None, None, None
+                    aoi_error = {
+                        AOI_ID_COLUMN_NAME: failed_aoi_id,
+                        "status_code": None,
+                        "message": f"{type(e).__name__}: {str(e)[:200]}",
+                        "text": str(e)[:200],
+                        "request": "Unexpected error",
+                        "failure_type": "geometry",
+                    }
                 if aoi_data is not None:
                     if len(aoi_data) > 0:
                         data.append(aoi_data)

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1575,7 +1575,7 @@ class FeatureApi(GriddedApiClient):
                         "message": f"{type(e).__name__}: {str(e)[:200]}",
                         "text": str(e)[:200],
                         "request": "Unexpected error",
-                        "failure_type": "geometry",
+                        "failure_type": "unexpected",
                     }
                 if aoi_data is not None:
                     if len(aoi_data) > 0:

--- a/tests/test_feature_api.py
+++ b/tests/test_feature_api.py
@@ -1203,6 +1203,59 @@ class TestFeatureAPI:
         assert error["failure_type"] == "grid", "Error should be marked as grid failure"
 
 
+class TestBulkUnexpectedErrorHandling:
+    def test_unexpected_per_aoi_exception_does_not_kill_chunk(self, monkeypatch):
+        """
+        An unexpected exception raised by get_features_gdf for a single AOI
+        must be converted into an error dict so the rest of the chunk completes.
+        Regression guard for the real-world IllegalArgumentException case where
+        one invalid-geometry AOI took out the whole ProcessPoolExecutor chunk.
+        """
+        feature_api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+
+        aoi_good = Polygon([(0, 0), (0.001, 0), (0.001, 0.001), (0, 0.001), (0, 0)])
+        aoi_bad = Polygon([(1, 1), (1.001, 1), (1.001, 1.001), (1, 1.001), (1, 1)])
+        aoi_gdf = gpd.GeoDataFrame(
+            [
+                {AOI_ID_COLUMN_NAME: "good", "geometry": aoi_good},
+                {AOI_ID_COLUMN_NAME: "bad", "geometry": aoi_bad},
+            ],
+            crs=API_CRS,
+        ).set_index(AOI_ID_COLUMN_NAME)
+
+        good_features = gpd.GeoDataFrame(
+            [{AOI_ID_COLUMN_NAME: "good", "geometry": aoi_good, "class_id": "x"}],
+            crs=API_CRS,
+        ).set_index(AOI_ID_COLUMN_NAME)
+        good_metadata = {AOI_ID_COLUMN_NAME: "good", "survey_date": "2025-01-01"}
+
+        def fake_get_features_gdf(self, *args, **kwargs):
+            if kwargs.get("aoi_id") == "bad":
+                raise RuntimeError("simulated unexpected failure")
+            return good_features, good_metadata, None, None
+
+        monkeypatch.setattr(FeatureApi, "get_features_gdf", fake_get_features_gdf)
+
+        features_gdf, metadata_df, errors_df = feature_api.get_features_gdf_bulk(
+            aoi_gdf,
+            region="au",
+            packs=["building"],
+            max_allowed_error_pct=100,
+        )
+
+        # Surviving AOI returned data
+        assert features_gdf is not None
+        assert "good" in features_gdf.index
+
+        # Failed AOI recorded as an "unexpected" error
+        assert len(errors_df) == 1
+        failed = errors_df.iloc[0]
+        assert errors_df.index[0] == "bad"
+        assert failed["failure_type"] == "unexpected"
+        assert "RuntimeError" in failed["message"]
+        assert "simulated unexpected failure" in failed["message"]
+
+
 if __name__ == "__main__":
     current_file = os.path.abspath(__file__)
     sys.exit(pytest.main([current_file]))


### PR DESCRIPTION
## Summary

Reliability fix extracted from the open umbrella PR #152. A single AOI raising an unexpected exception (e.g. `IllegalArgumentException` from an invalid geometry like an unclosed `LinearRing`) propagates up through `concurrent.futures.as_completed` and kills the entire chunk via `ProcessPoolExecutor`. This has been observed in production — the current workaround is randomising input file order so repeated failures don't concentrate in one chunk. This is the real fix.

`get_features_gdf_bulk` now catches unexpected exceptions from `job.result()` and converts them to error dicts, so the rest of the chunk completes. The failed AOI is logged and recorded in the errors output with `failure_type: "geometry"`.

Cherry-picked from `0dba95c` on `fix/memory-leak-gridding-cleanup` (original commit by mlopeman + Claude).

## Test plan

- [x] `pytest -m "not live_api"` — 426 passed
- [ ] Live-API smoke test with a known-bad AOI confirmed to no longer fail the whole chunk (optional; not regression-tested by unit suite since the failure mode is an unexpected upstream exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)