### PR TITLE
[INDS-2035] Add pool condition attributes to rollup and per-class outputs

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1611,12 +1611,13 @@ def _compute_feature_class_data(
 
     # --- Section E2: Pool condition attributes ---
     if class_id == POOL_ID:
-        pool_batch = []
-        for _, row in class_features.iterrows():
-            attrs = flatten_pool_attributes([row], country=country)
-            pool_batch.append(attrs)
-        if pool_batch:
-            df_parts.append(pd.DataFrame(pool_batch, index=range(n_rows)))
+        try:
+            pool_records = _dataframe_to_records_with_index(class_features)
+            pool_batch = [flatten_pool_attributes(row, country=country) for row in pool_records]
+            if pool_batch:
+                df_parts.append(pd.DataFrame(pool_batch, index=range(n_rows)))
+        except Exception:
+            logger.error("Could not flatten pool attributes", exc_info=True)
 
     # --- Section F: Mapbrowser link ---
     # Uses geometry centroid for location and survey_date/installation_date for date

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -75,6 +75,7 @@ from nmaipy.constants import (
     METERS_TO_FEET,
     PARALLEL_READ_WORKERS,
     PER_CLASS_FILE_CLASS_IDS,
+    POOL_ID,
     PRIMARY_FEATURE_COLUMN_TO_CLASS,
     ROOF_AGE_PREFIX_COLUMNS,
     ROOF_ID,
@@ -93,6 +94,7 @@ from nmaipy.feature_attributes import (
     calculate_roof_age_years,
     convert_bool_columns_to_yn,
     flatten_building_attributes,
+    flatten_pool_attributes,
     flatten_roof_attributes,
     is_resolved_score_column,
 )
@@ -741,6 +743,8 @@ def _compute_all_per_class_data(
     roof_attrs_cache_chunk = None
 
     roof_to_building_lookup = {}
+    roofs_linked_chunk = None
+    buildings_linked_chunk = None
     has_dependent = any(c in chunk_class_ids for c in dependent_class_ids)
     if has_dependent:
         if ROOF_ID in chunk_class_ids:
@@ -757,8 +761,6 @@ def _compute_all_per_class_data(
         # Roof's API parent_id points to Building(Deprecated) which is filtered out;
         # the correct path to BL is Roof →(IoU)→ Building(New) →(parent_id)→ BL.
         # Results are reused in _compute_feature_class_data for Building(New) class output.
-        roofs_linked_chunk = None
-        buildings_linked_chunk = None
         if len(roof_features_chunk) > 0 and BUILDING_NEW_ID in chunk_class_ids:
             building_new_chunk = chunk_gdf[chunk_gdf["class_id"] == BUILDING_NEW_ID]
             if len(building_new_chunk) > 0:
@@ -1606,6 +1608,15 @@ def _compute_feature_class_data(
                         df_parts.append(pd.DataFrame(score_batch, index=range(n_rows)))
         except Exception:
             logger.error("Could not link roofs to building lifecycles", exc_info=True)
+
+    # --- Section E2: Pool condition attributes ---
+    if class_id == POOL_ID:
+        pool_batch = []
+        for _, row in class_features.iterrows():
+            attrs = flatten_pool_attributes([row], country=country)
+            pool_batch.append(attrs)
+        if pool_batch:
+            df_parts.append(pd.DataFrame(pool_batch, index=range(n_rows)))
 
     # --- Section F: Mapbrowser link ---
     # Uses geometry centroid for location and survey_date/installation_date for date

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -945,3 +945,29 @@ def flatten_roof_instance_attributes(
     if age_years is not None:
         flattened[f"{prefix}roof_age_years_as_of_date"] = age_years
     return flattened
+
+
+def flatten_pool_attributes(pools: List[dict], country: str) -> dict:
+    """Flatten pool condition attributes from Feature API into per-component columns."""
+    flattened = {}
+    for pool in pools:
+        attributes = pool.get("attributes")
+        if attributes and isinstance(attributes, str):
+            try:
+                attributes = json.loads(attributes)
+            except (json.JSONDecodeError, TypeError):
+                attributes = []
+        for attribute in attributes or []:
+            if "components" not in attribute:
+                continue
+            for component in attribute["components"]:
+                name = component["description"].lower().replace(" ", "_")
+                flattened[f"{name}_present"] = TRUE_STRING if component["areaSqm"] > 0 else FALSE_STRING
+                if country in IMPERIAL_COUNTRIES:
+                    flattened[f"{name}_area_sqft"] = component["areaSqft"]
+                else:
+                    flattened[f"{name}_area_sqm"] = component["areaSqm"]
+                flattened[f"{name}_confidence"] = component["confidence"]
+                if "ratio" in component:
+                    flattened[f"{name}_ratio"] = component["ratio"]
+    return flattened

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -947,27 +947,30 @@ def flatten_roof_instance_attributes(
     return flattened
 
 
-def flatten_pool_attributes(pools: List[dict], country: str) -> dict:
-    """Flatten pool condition attributes from Feature API into per-component columns."""
+def flatten_pool_attributes(pool, country: str) -> dict:
+    """Flatten pool condition attributes from a single pool feature into per-component columns.
+
+    Accepts a dict or pd.Series feature row. The per-class swimming_pool export iterates
+    pool features one-at-a-time; the rollup passes the primary pool only.
+    """
     flattened = {}
-    for pool in pools:
-        attributes = pool.get("attributes")
-        if attributes and isinstance(attributes, str):
-            try:
-                attributes = json.loads(attributes)
-            except (json.JSONDecodeError, TypeError):
-                attributes = []
-        for attribute in attributes or []:
-            if "components" not in attribute:
-                continue
-            for component in attribute["components"]:
-                name = component["description"].lower().replace(" ", "_")
-                flattened[f"{name}_present"] = TRUE_STRING if component["areaSqm"] > 0 else FALSE_STRING
-                if country in IMPERIAL_COUNTRIES:
-                    flattened[f"{name}_area_sqft"] = component["areaSqft"]
-                else:
-                    flattened[f"{name}_area_sqm"] = component["areaSqm"]
-                flattened[f"{name}_confidence"] = component["confidence"]
-                if "ratio" in component:
-                    flattened[f"{name}_ratio"] = component["ratio"]
+    attributes = pool.get("attributes")
+    if attributes and isinstance(attributes, str):
+        try:
+            attributes = json.loads(attributes)
+        except (json.JSONDecodeError, TypeError):
+            attributes = []
+    for attribute in attributes or []:
+        if "components" not in attribute:
+            continue
+        for component in attribute["components"]:
+            name = component["description"].lower().replace(" ", "_")
+            flattened[f"{name}_present"] = TRUE_STRING if component["areaSqm"] > 0 else FALSE_STRING
+            if country in IMPERIAL_COUNTRIES:
+                flattened[f"{name}_area_sqft"] = component["areaSqft"]
+            else:
+                flattened[f"{name}_area_sqm"] = component["areaSqm"]
+            flattened[f"{name}_confidence"] = component["confidence"]
+            if "ratio" in component:
+                flattened[f"{name}_ratio"] = component["ratio"]
     return flattened

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -1135,7 +1135,7 @@ def feature_attributes(
                         continue
                     parcel[f"primary_{name}_" + str(key)] = val
             if class_id == POOL_ID:
-                primary_attributes = flatten_pool_attributes([primary_feature], country=country)
+                primary_attributes = flatten_pool_attributes(primary_feature, country=country)
                 for key, val in primary_attributes.items():
                     parcel[f"primary_{name}_" + str(key)] = val
 

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -35,6 +35,7 @@ from nmaipy.constants import (
     LAT_PRIMARY_COL_NAME,
     LON_PRIMARY_COL_NAME,
     MIN_ROOF_INSTANCE_IOU_THRESHOLD,
+    POOL_ID,
     ROOF_ID,
     ROOF_INSTANCE_CLASS_ID,
     SQUARED_METERS_TO_SQUARED_FEET,
@@ -55,6 +56,7 @@ from nmaipy.feature_attributes import (
     _parse_include_param,
     flatten_building_attributes,
     flatten_building_lifecycle_damage_attributes,
+    flatten_pool_attributes,
     flatten_roof_attributes,
     flatten_roof_instance_attributes,
     is_resolved_score_column,
@@ -1131,6 +1133,10 @@ def feature_attributes(
                 for key, val in primary_attributes.items():
                     if is_resolved_score_column(key) or key in RSI_OUTPUT_COLUMNS:
                         continue
+                    parcel[f"primary_{name}_" + str(key)] = val
+            if class_id == POOL_ID:
+                primary_attributes = flatten_pool_attributes([primary_feature], country=country)
+                for key, val in primary_attributes.items():
                     parcel[f"primary_{name}_" + str(key)] = val
 
             if class_id == BUILDING_LIFECYCLE_ID:

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import sys
@@ -2156,6 +2157,84 @@ class TestResolveScoresWithBLFallback:
     def test_primary_none_falls_back_to_bl(self):
         result = parcels.resolve_scores_with_bl_fallback(None, self._bl_with_scores(), country="us")
         assert result["hurricane_vulnerability_score"] == 2
+
+
+@pytest.fixture(scope="module")
+def pool_feature_with_components(data_directory: Path):
+    """Real pool feature row from test_features_2_all_packs.csv with 5 Pool Condition components.
+
+    The fixture has one detected component (Above Ground Swimming Pool, areaSqm=18.1)
+    and four non-detected ones (Unmaintained, In lanai, Covered, Empty) with areaSqm=0.
+    """
+    filepath = data_directory / "test_features_2_all_packs.csv"
+    if not filepath.exists():
+        pytest.skip("test_features_2_all_packs.csv not generated yet")
+    df = pd.read_csv(filepath)
+    df["attributes"] = df["attributes"].apply(lambda d: ast.literal_eval(d) if isinstance(d, str) else d)
+    pools = df[df["class_id"] == POOL_ID]
+    return pools.iloc[0].to_dict()
+
+
+class TestFlattenPoolAttributes:
+    """Unit tests for feature_attributes.flatten_pool_attributes — real-fixture-driven."""
+
+    def test_emits_all_five_component_columns(self, pool_feature_with_components):
+        result = parcels.flatten_pool_attributes(pool_feature_with_components, country="us")
+        expected_components = [
+            "unmaintained_swimming_pool",
+            "in_lanai_swimming_pool",
+            "covered_swimming_pool",
+            "empty_swimming_pool",
+            "above_ground_swimming_pool",
+        ]
+        for comp in expected_components:
+            assert f"{comp}_present" in result, f"missing {comp}_present"
+            assert f"{comp}_area_sqft" in result, f"missing {comp}_area_sqft"
+            assert f"{comp}_confidence" in result, f"missing {comp}_confidence"
+            assert f"{comp}_ratio" in result, f"missing {comp}_ratio"
+
+    def test_detected_component_has_real_values(self, pool_feature_with_components):
+        """Above-ground pool is the only detected component in this fixture."""
+        result = parcels.flatten_pool_attributes(pool_feature_with_components, country="us")
+        assert result["above_ground_swimming_pool_present"] == "Y"
+        assert result["above_ground_swimming_pool_area_sqft"] == 195
+        assert result["above_ground_swimming_pool_confidence"] == pytest.approx(0.854, abs=1e-3)
+        assert result["above_ground_swimming_pool_ratio"] == pytest.approx(0.823, abs=1e-3)
+
+    def test_zero_area_components_marked_absent(self, pool_feature_with_components):
+        result = parcels.flatten_pool_attributes(pool_feature_with_components, country="us")
+        for comp in [
+            "unmaintained_swimming_pool",
+            "in_lanai_swimming_pool",
+            "covered_swimming_pool",
+            "empty_swimming_pool",
+        ]:
+            assert result[f"{comp}_present"] == "N"
+            assert result[f"{comp}_area_sqft"] == 0
+
+    def test_metric_country_uses_sqm(self, pool_feature_with_components):
+        result = parcels.flatten_pool_attributes(pool_feature_with_components, country="au")
+        assert "above_ground_swimming_pool_area_sqm" in result
+        assert "above_ground_swimming_pool_area_sqft" not in result
+        assert result["above_ground_swimming_pool_area_sqm"] == pytest.approx(18.1, abs=0.1)
+
+    def test_attributes_as_json_string(self, pool_feature_with_components):
+        """Exporter sometimes serialises attributes to JSON; the helper must round-trip."""
+        pool_with_str_attrs = dict(pool_feature_with_components)
+        pool_with_str_attrs["attributes"] = json.dumps(pool_feature_with_components["attributes"])
+        result = parcels.flatten_pool_attributes(pool_with_str_attrs, country="us")
+        assert result["above_ground_swimming_pool_present"] == "Y"
+
+    def test_pandas_series_input(self, pool_feature_with_components):
+        series = pd.Series(pool_feature_with_components)
+        result = parcels.flatten_pool_attributes(series, country="us")
+        assert result["above_ground_swimming_pool_present"] == "Y"
+
+    def test_feature_without_attributes_returns_empty(self):
+        assert parcels.flatten_pool_attributes({"feature_id": "x"}, country="us") == {}
+
+    def test_feature_with_empty_attributes_list_returns_empty(self):
+        assert parcels.flatten_pool_attributes({"attributes": []}, country="us") == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Re-opened onto current \`main\` from the closed umbrella PR #152. Original merged as #150 into the umbrella branch on 2026-04-17 (mlopeman + Claude); cherry-picked here via \`git cherry-pick -m 1 f9c09fe\`. One conflict resolved in \`parcels.py\` — the BL filter used the old \`_RESOLVED_PREFIXES\` tuple; kept main's newer \`is_resolved_score_column(key) or key in RSI_OUTPUT_COLUMNS\` guard (from PR #159) and appended the new POOL_ID branch from #150 beside it.

### Feature: pool condition flattening
- Flattens Pool Condition API attributes (unmaintained, in lanai, covered, empty, above ground) into per-component columns: \`_present\`, \`_area_sqft\`/\`_sqm\`, \`_confidence\`, \`_ratio\`
- Columns appear in rollup as \`primary_swimming_pool_{component}_{field}\` and in per-class \`swimming_pool.csv\`/\`.parquet\`
- \`feature_attributes.py\`: new \`flatten_pool_attributes()\` helper
- \`parcels.py\`: new POOL_ID branch after BL in \`feature_attributes()\` calling the helper
- \`exporter.py\`: flatten pool attributes in per-class swimming_pool export

### Bundled bug fix
Fixes a pre-existing bug where \`roofs_linked_chunk\` / \`buildings_linked_chunk\` were uninitialized in \`_compute_all_per_class_data\`, causing per-class export to silently fail for non-building class selections (e.g. pool-only exports).

## Test plan

- [x] \`pytest -m "not live_api"\` — 446 passed
- [ ] End-to-end: \`--packs pool --save-features\` — rollup has 20 pool condition columns (5 components × 4 fields), per-class \`swimming_pool.csv\` generated with matching columns (carried over from #150)
- [ ] Verify with Florida parcels (higher in-lanai prevalence) for broader component coverage (unchecked in #150, worth running before 4.7.0 release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)