### PR TITLE
[TRO-4323] Fix ArrowInvalid when writing errors_df with gridded geometry

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.0a1"
+__version__ = "5.0.0a2"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -199,6 +199,20 @@ def _read_parquet_chunks_parallel(
     return results
 
 
+def _write_errors_parquet(errors_df: pd.DataFrame, outfile: str) -> None:
+    """
+    Write an errors dataframe to parquet, promoting to GeoDataFrame when a geometry column is present.
+
+    Gridding attaches grid-cell geometry to error rows (see FeatureApi._attempt_gridding), so
+    errors_df may contain raw shapely geometries that pandas to_parquet cannot serialize.
+    """
+    if "geometry" in errors_df.columns and len(errors_df) > 0:
+        errors_gdf = gpd.GeoDataFrame(errors_df, geometry="geometry", crs=API_CRS)
+        storage.write_parquet(errors_gdf, outfile)
+    else:
+        storage.write_parquet(errors_df, outfile)
+
+
 def _add_is_primary_column(
     features_gdf: gpd.GeoDataFrame,
     rollup_df: pd.DataFrame,
@@ -2831,7 +2845,7 @@ class NearmapAIExporter(BaseExporter):
 
             # If all Feature API requests failed and no roof age data, save errors and return
             if len(feature_api_errors_df) == len(aoi_gdf) and len(roof_age_gdf) == 0:
-                storage.write_parquet(feature_api_errors_df, outfile_errors)
+                _write_errors_parquet(feature_api_errors_df, outfile_errors)
                 if len(roof_age_errors_df) > 0:
                     storage.write_parquet(roof_age_errors_df, outfile_roof_age_errors)
                 chunk_end_time = datetime.now(timezone.utc).isoformat()
@@ -3061,13 +3075,7 @@ class NearmapAIExporter(BaseExporter):
                 f"Chunk {chunk_id}: Writing {len(final_df)} rows for rollups and {len(errors_df)} for errors."
             )
             try:
-                # Convert errors_df to GeoDataFrame if it has geometry (from failed grid squares)
-                # This ensures proper geoparquet output that can be read in GIS software
-                if "geometry" in errors_df.columns and len(errors_df) > 0:
-                    errors_gdf = gpd.GeoDataFrame(errors_df, geometry="geometry", crs=API_CRS)
-                    storage.write_parquet(errors_gdf, outfile_errors)
-                else:
-                    storage.write_parquet(errors_df, outfile_errors)
+                _write_errors_parquet(errors_df, outfile_errors)
             except Exception as e:
                 self.logger.error(
                     f"Chunk {chunk_id}: Failed writing errors_df ({len(errors_df)} rows) to {outfile_errors}."

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -13,6 +13,7 @@ import pytest
 
 from nmaipy.constants import (
     AOI_ID_COLUMN_NAME,
+    API_CRS,
     BUILDING_NEW_ID,
     FEATURE_CLASS_DESCRIPTIONS,
     PER_CLASS_FILE_CLASS_IDS,
@@ -25,6 +26,7 @@ from nmaipy.exporter import (
     _per_class_chunk_regexes,
     _read_parquet_chunks_parallel,
     _unify_and_concat_tables,
+    _write_errors_parquet,
 )
 from nmaipy.feature_api import FeatureApi
 
@@ -612,6 +614,72 @@ class TestReadParquetChunksParallel:
         assert len(summary) == 1, f"Expected one summary message, got: {info_messages}"
         assert "1 failed" in summary[0]
         assert "1 empty" in summary[0]
+
+
+class TestWriteErrorsParquet:
+    """Tests for _write_errors_parquet.
+
+    Regression for a crash seen in production: gridding attaches shapely Polygons to the
+    errors dataframe, and the early-return "all AOIs errored" path in process_chunk wrote
+    that dataframe via plain pandas to_parquet, which fails with ArrowInvalid on shapely types.
+    """
+
+    def test_plain_errors_roundtrip(self, tmp_path):
+        errors_df = pd.DataFrame(
+            {
+                AOI_ID_COLUMN_NAME: ["a", "b"],
+                "status_code": [404, 500],
+                "message": ["not found", "internal"],
+            }
+        ).set_index(AOI_ID_COLUMN_NAME)
+        outfile = tmp_path / "feature_api_errors.parquet"
+
+        _write_errors_parquet(errors_df, str(outfile))
+
+        assert outfile.exists()
+        read_back = pd.read_parquet(outfile)
+        assert len(read_back) == 2
+        assert set(read_back["status_code"]) == {404, 500}
+
+    def test_errors_with_geometry_roundtrip(self, tmp_path):
+        from shapely.geometry import Polygon
+
+        poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        poly2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
+        errors_df = pd.DataFrame(
+            {
+                AOI_ID_COLUMN_NAME: ["a", "b"],
+                "status_code": [500, 504],
+                "message": ["grid cell failed", "grid cell timeout"],
+                "geometry": [poly1, poly2],
+            }
+        ).set_index(AOI_ID_COLUMN_NAME)
+        outfile = tmp_path / "feature_api_errors.parquet"
+
+        _write_errors_parquet(errors_df, str(outfile))
+
+        assert outfile.exists()
+        read_back = gpd.read_parquet(outfile)
+        assert isinstance(read_back, gpd.GeoDataFrame)
+        assert len(read_back) == 2
+        assert read_back.crs == API_CRS
+        assert read_back.geometry.iloc[0].equals(poly1)
+        assert read_back.geometry.iloc[1].equals(poly2)
+
+    def test_empty_errors_with_geometry_column(self, tmp_path):
+        errors_df = gpd.GeoDataFrame(
+            {
+                AOI_ID_COLUMN_NAME: pd.Series([], dtype="object"),
+                "status_code": pd.Series([], dtype="int64"),
+                "message": pd.Series([], dtype="object"),
+            },
+            geometry=gpd.GeoSeries([], crs=API_CRS),
+        ).set_index(AOI_ID_COLUMN_NAME)
+        outfile = tmp_path / "feature_api_errors.parquet"
+
+        _write_errors_parquet(errors_df, str(outfile))
+
+        assert outfile.exists()
 
 
 class TestPerClassFileWhitelist:


### PR DESCRIPTION
## Summary
- In `process_chunk`, the "all AOIs errored" early-return path wrote the raw pandas `feature_api_errors_df` via `storage.write_parquet`, which delegates to `pandas.to_parquet` / pyarrow. When gridding had attached shapely `Polygon`s to error rows, pyarrow crashed with `ArrowInvalid: Could not convert <POLYGON ...> with type Polygon`, killing the whole export. The normal-success write had the geometry-promotion guard; the early-return path did not.
- Extract a single `_write_errors_parquet` helper (promotes to `GeoDataFrame` with `API_CRS` when a `geometry` column is present) and use it at both write sites so the two paths can't drift again.
- Bumps to `5.0.0a2`.

## Context
Triggered in production on a 1.3M-parcel AU export with `only_3d=True`, nmaipy 4.6.3. `only_3d=True` makes the "all AOIs errored in this chunk" condition much more common (many AOIs lack a gen6 survey → 404s), and the gridding path adds grid-cell geometry to errors — so the collision is practically guaranteed at scale. Export crashed on chunk 0031 (~6% in) with the stack ending at `storage.py:322 data.to_parquet(f, **kwargs)`.

## Test plan
- [x] New `TestWriteErrorsParquet` in `tests/test_exporter.py` with three cases:
  - plain errors (no geometry) roundtrips as plain parquet
  - errors with shapely Polygons roundtrips as geoparquet preserving geometry + CRS (this one reproduces the production crash pre-fix)
  - empty errors with geometry column doesn't crash
- [x] `pytest tests/test_exporter.py -m "not live_api"` — 42 passed
- [ ] Downstream: bump `ai-offline-export-pipelines` nmaipy pin to `5.0.0a2` in a follow-up PR after release