### PR TITLE
[TRO-4339] Gate is_primary and fidelity in per-class exports by class membership

### DIFF
--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -304,6 +304,14 @@ PRIMARY_FEATURE_COLUMN_TO_CLASS = {
     "primary_roof_instance_feature_id": ROOF_INSTANCE_CLASS_ID,
 }
 
+# Class IDs whose per-class exports should expose `is_primary`.
+# Derived from PRIMARY_FEATURE_COLUMN_TO_CLASS so the two stay in lockstep.
+PRIMARY_FEATURE_CLASS_IDS = frozenset(PRIMARY_FEATURE_COLUMN_TO_CLASS.values())
+
+# Class IDs for which the Feature API populates a top-level `fidelity` field.
+# Roof instances (Roof Age API) use `trust_score` instead of fidelity.
+CLASSES_WITH_FIDELITY = frozenset(BUILDING_STYLE_CLASS_IDS) - {ROOF_INSTANCE_CLASS_ID}
+
 # Human-readable descriptions for feature classes, loaded from class_descriptions.json.
 # This file is auto-refreshed from the live Feature API during export runs.
 # To manually refresh: python -c "from nmaipy.constants import refresh_class_descriptions; refresh_class_descriptions()"

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -63,6 +63,7 @@ from nmaipy.constants import (
     BUILDING_LIFECYCLE_ID,
     BUILDING_NEW_ID,
     BUILDING_STYLE_CLASS_IDS,
+    CLASSES_WITH_FIDELITY,
     DEFAULT_URL_ROOT,
     DEPRECATED_CLASS_IDS,
     FEATURE_CLASS_DESCRIPTIONS,
@@ -76,6 +77,7 @@ from nmaipy.constants import (
     PARALLEL_READ_WORKERS,
     PER_CLASS_FILE_CLASS_IDS,
     POOL_ID,
+    PRIMARY_FEATURE_CLASS_IDS,
     PRIMARY_FEATURE_COLUMN_TO_CLASS,
     ROOF_AGE_PREFIX_COLUMNS,
     ROOF_ID,
@@ -961,17 +963,28 @@ def _compute_feature_class_data(
     initial_batch["description"] = class_description
     added_cols.add("description")
 
-    # Add is_primary column if present (only for classes with primary selection)
-    if "is_primary" in class_features.columns and "is_primary" not in added_cols:
+    # is_primary is only meaningful for classes that participate in primary
+    # feature selection — without this gate, non-primary classes (e.g. solar)
+    # inherit an all-False column from the chunk-level GDF after pd.concat.
+    if (
+        "is_primary" in class_features.columns
+        and class_id in PRIMARY_FEATURE_CLASS_IDS
+        and "is_primary" not in added_cols
+    ):
         initial_batch["is_primary"] = class_features["is_primary"].values
         added_cols.add("is_primary")
 
-    # Roof instances don't have confidence/fidelity (they have trust_score instead)
-    # Only add confidence and fidelity for non-roof-instance classes
+    # Confidence is universal across Feature API classes; roof instances use
+    # trust_score instead.
     if class_id != ROOF_INSTANCE_CLASS_ID:
         if "confidence" in class_features.columns:
             initial_batch["confidence"] = class_features["confidence"].values
             added_cols.add("confidence")
+
+    # Fidelity is API-populated only on structural building/roof classes
+    # (see CLASSES_WITH_FIDELITY in constants.py). Other classes inherit a
+    # NaN-filled fidelity column from the chunk-level pd.concat.
+    if class_id in CLASSES_WITH_FIDELITY:
         if "fidelity" in class_features.columns:
             initial_batch["fidelity"] = class_features["fidelity"].values
             added_cols.add("fidelity")

--- a/tests/test_integration_rollup_features.py
+++ b/tests/test_integration_rollup_features.py
@@ -431,25 +431,41 @@ def test_parquet_deserialization_of_include_params(integration_test_dir):
 @pytest.mark.slow
 def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_features):
     """
-    Integration test to verify is_primary column in per-class feature exports.
+    Integration test for is_primary and fidelity columns in per-class exports.
 
-    This test verifies:
-    1. is_primary column exists in per-class CSV files
-    2. is_primary column exists in per-class GeoParquet files
-    3. is_primary column is boolean type
-    4. Primary features in per-class exports match primary_*_feature_id columns in rollup
+    Both columns are emitted by the per-class assembler only for classes where
+    they are meaningful:
+
+    - `is_primary` — only for classes that participate in primary feature
+      selection (PRIMARY_FEATURE_CLASS_IDS).
+    - `fidelity` — only for structural building/roof classes that the Feature
+      API populates the field on (CLASSES_WITH_FIDELITY).
+
+    The gating is verified for whichever classes happen to appear in the test
+    output (the small fixed AOI may not yield every requested class). For
+    deterministic gating coverage that doesn't depend on API feature density,
+    see the unit test in tests/test_per_class_export_gating.py.
+
+    Also cross-verifies that features marked is_primary match the
+    primary_*_feature_id IDs in the rollup. Per-class outputs use Y/N strings
+    for boolean columns (see convert_bool_columns_to_yn).
     """
-    from nmaipy.constants import PRIMARY_FEATURE_COLUMN_TO_CLASS
+    from nmaipy.constants import (
+        CLASSES_WITH_FIDELITY,
+        PRIMARY_FEATURE_CLASS_IDS,
+        PRIMARY_FEATURE_COLUMN_TO_CLASS,
+    )
 
-    # Run exporter with class_level_files=True to generate per-class exports
     exporter = AOIExporter(
         aoi_file=str(test_aoi_with_features),
         output_dir=str(integration_test_dir),
         country="us",
-        packs=["building", "roof_char"],
+        # solar is included to exercise a non-primary, non-fidelity class when
+        # the AOI happens to contain solar panels.
+        packs=["building", "roof_char", "solar"],
         save_features=True,
         save_buildings=True,
-        class_level_files=True,  # Enable per-class exports
+        class_level_files=True,
         no_cache=True,
         processes=1,
     )
@@ -458,8 +474,6 @@ def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_fea
 
     final_dir = integration_test_dir / "final"
 
-    # 1. Check per-class CSV files have is_primary column
-    # Find all per-class CSV files (exclude rollup, buildings, and stats files)
     exclude_patterns = [
         "rollup",
         "buildings",
@@ -468,56 +482,69 @@ def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_fea
         "roof_age_errors",
     ]
     per_class_csvs = [f for f in final_dir.glob("*.csv") if not any(pattern in f.name for pattern in exclude_patterns)]
-
     assert len(per_class_csvs) > 0, f"Should have per-class CSV files. Files in final: {list(final_dir.glob('*'))}"
 
-    for csv_path in per_class_csvs:
-        class_df = pd.read_csv(csv_path)
-        assert (
-            "is_primary" in class_df.columns
-        ), f"Per-class CSV {csv_path.name} should have is_primary column. Columns: {class_df.columns.tolist()}"
-
-    # 2. Check per-class GeoParquet files have is_primary column
     per_class_parquets = [f for f in final_dir.glob("*_features.parquet") if f.name != "features.parquet"]
-
     assert (
         len(per_class_parquets) > 0
     ), f"Should have per-class GeoParquet files. Files in final: {list(final_dir.glob('*'))}"
 
+    def _expect_columns(df, file_name: str):
+        # `class_id` is always populated by the per-class assembler, so use it
+        # as the authoritative class identifier rather than parsing the filename.
+        if "class_id" not in df.columns or len(df) == 0:
+            return
+        class_id = df["class_id"].iloc[0]
+
+        should_have_is_primary = class_id in PRIMARY_FEATURE_CLASS_IDS
+        assert ("is_primary" in df.columns) == should_have_is_primary, (
+            f"{file_name} (class_id={class_id}): expected is_primary "
+            f"{'present' if should_have_is_primary else 'absent'}, got columns {df.columns.tolist()}"
+        )
+        if should_have_is_primary:
+            assert set(df["is_primary"].dropna().unique()) <= {
+                "Y",
+                "N",
+            }, f"{file_name}: is_primary should be Y/N, got {df['is_primary'].unique()}"
+
+        should_have_fidelity = class_id in CLASSES_WITH_FIDELITY
+        assert ("fidelity" in df.columns) == should_have_fidelity, (
+            f"{file_name} (class_id={class_id}): expected fidelity "
+            f"{'present' if should_have_fidelity else 'absent'}, got columns {df.columns.tolist()}"
+        )
+
+    for csv_path in per_class_csvs:
+        class_df = pd.read_csv(csv_path)
+        _expect_columns(class_df, csv_path.name)
+
     for parquet_path in per_class_parquets:
         class_gdf = gpd.read_parquet(parquet_path)
-        assert (
-            "is_primary" in class_gdf.columns
-        ), f"Per-class parquet {parquet_path.name} should have is_primary column. Columns: {class_gdf.columns.tolist()}"
-        assert set(class_gdf["is_primary"].dropna().unique()) <= {
-            "Y",
-            "N",
-        }, f"is_primary in {parquet_path.name} should contain only Y/N, got {class_gdf['is_primary'].unique()}"
+        _expect_columns(class_gdf, parquet_path.name)
 
-    # 3. Cross-verify: primary features in per-class parquets match rollup data
+    # Cross-verify: primary features in per-class parquets match rollup IDs.
     rollup_file = final_dir / "buildings.csv"
     if rollup_file.exists():
         rollup_df = pd.read_csv(rollup_file, index_col="aoi_id")
-
-        # For each primary feature column in rollup, verify matching is_primary=True in per-class exports
         for col_name, class_id in PRIMARY_FEATURE_COLUMN_TO_CLASS.items():
-            if col_name in rollup_df.columns:
-                # Get primary feature IDs from rollup (non-null values)
-                primary_ids = rollup_df[col_name].dropna().astype(str).tolist()
-
-                if primary_ids:
-                    # Find the per-class parquet for this class
-                    for parquet_path in per_class_parquets:
-                        class_gdf = gpd.read_parquet(parquet_path)
-                        if "class_id" in class_gdf.columns:
-                            class_features = class_gdf[class_gdf["class_id"] == class_id]
-                            if len(class_features) > 0:
-                                # Check that primary features are marked correctly
-                                primary_features = class_features[class_features["is_primary"] == "Y"]
-                                primary_feature_ids = primary_features["feature_id"].astype(str).tolist()
-
-                                # Verify at least some primary IDs match
-                                matching = set(primary_ids) & set(primary_feature_ids)
+            if col_name not in rollup_df.columns:
+                continue
+            primary_ids = rollup_df[col_name].dropna().astype(str).tolist()
+            if not primary_ids:
+                continue
+            for parquet_path in per_class_parquets:
+                class_gdf = gpd.read_parquet(parquet_path)
+                if "class_id" not in class_gdf.columns:
+                    continue
+                class_features = class_gdf[class_gdf["class_id"] == class_id]
+                if len(class_features) == 0 or "is_primary" not in class_features.columns:
+                    continue
+                primary_features = class_features[class_features["is_primary"] == "Y"]
+                primary_feature_ids = primary_features["feature_id"].astype(str).tolist()
+                assert set(primary_ids) & set(primary_feature_ids), (
+                    f"{parquet_path.name} (class_id={class_id}): no rollup primary IDs "
+                    f"({primary_ids[:3]}...) matched is_primary=Y rows "
+                    f"({primary_feature_ids[:3]}...)."
+                )
 
 
 @pytest.fixture

--- a/tests/test_per_class_export_gating.py
+++ b/tests/test_per_class_export_gating.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for the per-class export column gating logic.
+
+`is_primary` is gated on `class_id in PRIMARY_FEATURE_CLASS_IDS` and `fidelity`
+is gated on `class_id in CLASSES_WITH_FIDELITY` in `_compute_feature_class_data`.
+Without these gates, the chunk-level `pd.concat` of features across classes
+would leak NaN-filled `is_primary` / `fidelity` columns into per-class exports
+where they don't apply (e.g. solar, pools).
+
+These tests construct a minimal cross-class chunk_gdf and verify the gating
+deterministically, independent of API content.
+"""
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import box
+
+from nmaipy.constants import (
+    AOI_ID_COLUMN_NAME,
+    API_CRS,
+    BUILDING_NEW_ID,
+    CLASSES_WITH_FIDELITY,
+    POOL_ID,
+    PRIMARY_FEATURE_CLASS_IDS,
+    ROOF_ID,
+    SOLAR_ID,
+)
+from nmaipy.exporter import _add_is_primary_column, _compute_all_per_class_data
+
+
+def _row(*, feature_id, class_id, description, x, y, fidelity=None, confidence=0.9):
+    return {
+        AOI_ID_COLUMN_NAME: "aoi-1",
+        "feature_id": feature_id,
+        "class_id": class_id,
+        "description": description,
+        "confidence": confidence,
+        "fidelity": fidelity,
+        "geometry": box(x, y, x + 0.0005, y + 0.0005),
+        "area_sqm": 100.0,
+        "clipped_area_sqm": 100.0,
+        "unclipped_area_sqm": 100.0,
+        "area_sqft": 1076.0,
+        "clipped_area_sqft": 1076.0,
+        "unclipped_area_sqft": 1076.0,
+        "parent_id": None,
+        "survey_date": "2024-01-01",
+        "mesh_date": "2024-01-01",
+    }
+
+
+@pytest.fixture
+def cross_class_chunk_gdf():
+    """Synthetic chunk-level GDF with one feature per class.
+
+    Mirrors the shape of `final_features_df` after upstream pd.concat: every
+    row carries every column (with None where the API didn't populate the
+    field for that class). Solar/pool rows have None in `fidelity`, roof and
+    building rows have a real value.
+    """
+    rows = [
+        _row(
+            feature_id="roof-1",
+            class_id=ROOF_ID,
+            description="Roof",
+            x=-111.8905,
+            y=40.7610,
+            fidelity=0.85,
+        ),
+        _row(
+            feature_id="building-1",
+            class_id=BUILDING_NEW_ID,
+            description="Building",
+            x=-111.8905,
+            y=40.7611,
+            fidelity=0.95,
+        ),
+        _row(
+            feature_id="pool-1",
+            class_id=POOL_ID,
+            description="Swimming Pool",
+            x=-111.8905,
+            y=40.7612,
+            fidelity=None,
+        ),
+        _row(
+            feature_id="solar-1",
+            class_id=SOLAR_ID,
+            description="Solar Panel",
+            x=-111.8905,
+            y=40.7613,
+            fidelity=None,
+        ),
+    ]
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry", crs=API_CRS)
+    return gdf
+
+
+@pytest.fixture
+def primary_ids_df():
+    """Synthetic rollup primary IDs covering all PRIMARY_FEATURE_CLASS_IDS members."""
+    return pd.DataFrame(
+        {
+            "primary_roof_feature_id": ["roof-1"],
+            "primary_building_feature_id": ["building-1"],
+            "primary_swimming_pool_feature_id": ["pool-1"],
+        },
+        index=pd.Index(["aoi-1"], name=AOI_ID_COLUMN_NAME),
+    )
+
+
+def test_solar_per_class_export_omits_is_primary_and_fidelity(cross_class_chunk_gdf, primary_ids_df):
+    chunk_gdf = _add_is_primary_column(cross_class_chunk_gdf.copy(), primary_ids_df)
+    assert "is_primary" in chunk_gdf.columns
+
+    results = _compute_all_per_class_data(
+        chunk_gdf=chunk_gdf,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[SOLAR_ID],
+    )
+    assert SOLAR_ID in results
+
+    tabular_cols = set(results[SOLAR_ID]["tabular"].column_names)
+    geo_cols = set(results[SOLAR_ID]["geo"].column_names)
+
+    assert SOLAR_ID not in PRIMARY_FEATURE_CLASS_IDS
+    assert SOLAR_ID not in CLASSES_WITH_FIDELITY
+    assert "is_primary" not in tabular_cols
+    assert "is_primary" not in geo_cols
+    assert "fidelity" not in tabular_cols
+    assert "fidelity" not in geo_cols
+
+
+def test_pool_per_class_export_has_is_primary_but_no_fidelity(cross_class_chunk_gdf, primary_ids_df):
+    chunk_gdf = _add_is_primary_column(cross_class_chunk_gdf.copy(), primary_ids_df)
+
+    results = _compute_all_per_class_data(
+        chunk_gdf=chunk_gdf,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[POOL_ID],
+    )
+    assert POOL_ID in results
+
+    tabular_cols = set(results[POOL_ID]["tabular"].column_names)
+    geo_cols = set(results[POOL_ID]["geo"].column_names)
+
+    assert POOL_ID in PRIMARY_FEATURE_CLASS_IDS
+    assert POOL_ID not in CLASSES_WITH_FIDELITY
+    assert "is_primary" in tabular_cols
+    assert "is_primary" in geo_cols
+    assert "fidelity" not in tabular_cols
+    assert "fidelity" not in geo_cols
+
+
+def test_roof_per_class_export_has_both_is_primary_and_fidelity(cross_class_chunk_gdf, primary_ids_df):
+    chunk_gdf = _add_is_primary_column(cross_class_chunk_gdf.copy(), primary_ids_df)
+
+    results = _compute_all_per_class_data(
+        chunk_gdf=chunk_gdf,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[ROOF_ID],
+    )
+    assert ROOF_ID in results
+
+    tabular_cols = set(results[ROOF_ID]["tabular"].column_names)
+    geo_cols = set(results[ROOF_ID]["geo"].column_names)
+
+    assert ROOF_ID in PRIMARY_FEATURE_CLASS_IDS
+    assert ROOF_ID in CLASSES_WITH_FIDELITY
+    assert "is_primary" in tabular_cols
+    assert "is_primary" in geo_cols
+    assert "fidelity" in tabular_cols
+    assert "fidelity" in geo_cols
+
+
+def test_building_per_class_export_has_both_columns(cross_class_chunk_gdf, primary_ids_df):
+    chunk_gdf = _add_is_primary_column(cross_class_chunk_gdf.copy(), primary_ids_df)
+
+    results = _compute_all_per_class_data(
+        chunk_gdf=chunk_gdf,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[BUILDING_NEW_ID],
+    )
+    assert BUILDING_NEW_ID in results
+
+    tabular_cols = set(results[BUILDING_NEW_ID]["tabular"].column_names)
+
+    assert BUILDING_NEW_ID in PRIMARY_FEATURE_CLASS_IDS
+    assert BUILDING_NEW_ID in CLASSES_WITH_FIDELITY
+    assert "is_primary" in tabular_cols
+    assert "fidelity" in tabular_cols


### PR DESCRIPTION
## Summary

- Per-class export files (e.g. `solar_panel.parquet`, `swimming_pool.parquet`) were emitting `is_primary` (always `"N"`) and `fidelity` (NaN) for classes that don't actually participate in those features.
- Root cause: upstream `pd.concat` of features across classes leaves every row carrying the union of all columns, and the per-class assembler in `_compute_feature_class_data` forwarded the columns based only on column presence, not on class membership.
- Adds two whitelist gates:
  - `is_primary` → `class_id in PRIMARY_FEATURE_CLASS_IDS` (derived from existing `PRIMARY_FEATURE_COLUMN_TO_CLASS`).
  - `fidelity` → `class_id in CLASSES_WITH_FIDELITY` (derived from `BUILDING_STYLE_CLASS_IDS - {ROOF_INSTANCE_CLASS_ID}`; empirically validated against cached API payloads in `tests/data/*.json`).
  - `confidence` gating unchanged — universal across Feature API classes, only roof instances use `trust_score`.

## Effect on outputs

| Per-class file | `is_primary` | `fidelity` |
|---|---|---|
| `building.{csv,parquet}`, `roof.{csv,parquet}` | ✅ | ✅ |
| `swimming_pool.{csv,parquet}` | ✅ | ❌ (was leaking) |
| `solar_panel.{csv,parquet}` | ❌ (was leaking) | ❌ (was leaking) |
| `roof_instance.{csv,parquet}` | ✅ | ❌ (uses `trust_score`) |

The combined main `features.parquet` is unchanged (it's written before `_add_is_primary_column` runs and is class-agnostic by design).

## Test plan

- [x] New deterministic unit tests in `tests/test_per_class_export_gating.py` covering solar (neither column), pool (is_primary only), roof (both), building (both).
- [x] Existing `test_is_primary_in_per_class_exports` integration test extended to also verify `fidelity` gating, with the vacuous Y/N assertion replaced by a real check, and the previously-discarded cross-verify match assertion now actually asserted.
- [x] Full non-live, non-slow suite: 456 passed, 11 skipped.
- [x] Slow live-API integration test passes against real API output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)