### PR TITLE
[TRO-4098] Skip rebuild when README.md exists; atomic README write

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.0b1"
+__version__ = "5.0.0b2"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -3482,6 +3482,23 @@ class NearmapAIExporter(BaseExporter):
         self.logger.info(f"nmaipy version: {__version__}")
         self.logger.debug("Starting parcel rollup")
 
+        # Fast path: README.md is the very last file written by a successful
+        # run (post-consolidation, post-per-class merge, post error files).
+        # Its presence implies every other final/ artifact was successfully
+        # produced. Skip the entire pipeline — including chunk re-reading,
+        # rollup/feature consolidation, and per-class merging — and return.
+        # To force a rebuild from cached chunks, delete final/README.md
+        # before re-invoking. Atomic write in ReadmeGenerator guarantees the
+        # file only ever exists with full content; no torn-write false signal.
+        readme_path = storage.join_path(self.final_path, "README.md")
+        if storage.file_exists(readme_path):
+            self.logger.info(
+                f"Prior run already complete: README.md present at {readme_path}. "
+                "Skipping all processing. Delete this file to force a rebuild "
+                "from cached chunks."
+            )
+            return
+
         # Process a single AOI file
         aoi_path = self.aoi_file
         self.logger.info(f"Processing AOI file {aoi_path}")

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2104,6 +2104,28 @@ def cleanup_thread_sessions(executor):
                         pass
 
 
+# Export-config keys whose values do not affect output content. Differences in
+# these keys between a previously-completed run and the current run do NOT
+# invalidate the README.md "fully complete" sentinel — they're either pure
+# performance / ergonomics knobs (processes, threads, chunk_size, log_level),
+# infrastructure paths that don't change row-level results (cache_dir,
+# compress_cache), or API-cache controls that operate beneath the chunk-cache
+# layer the fast-path actually depends on (no_cache, overwrite_cache: chunks
+# are reused regardless).
+_CONFIG_KEYS_NOT_AFFECTING_OUTPUT = frozenset(
+    {
+        "processes",
+        "threads",
+        "chunk_size",
+        "log_level",
+        "cache_dir",
+        "compress_cache",
+        "no_cache",
+        "overwrite_cache",
+    }
+)
+
+
 class NearmapAIExporter(BaseExporter):
     """
     Unified exporter for Nearmap AI data from Feature API and Roof Age API.
@@ -2226,49 +2248,102 @@ class NearmapAIExporter(BaseExporter):
 
         # Note: logger already configured by BaseExporter
 
+        # Capture any previously-saved export config BEFORE _save_config below
+        # overwrites it. The fast-path in _run_inner uses this to decide whether
+        # an existing README.md sentinel was produced by an export with the
+        # same output-affecting parameters as this run.
+        self._previous_config_params = self._read_existing_config_params()
+
+        # Build config params for save + fast-path comparison.
+        config_params = {
+            "aoi_file": str(aoi_file),
+            "packs": packs,
+            "classes": classes,
+            "include": include,
+            "primary_decision": primary_decision,
+            "aoi_grid_min_pct": aoi_grid_min_pct,
+            "aoi_grid_inexact": aoi_grid_inexact,
+            "aoi_grid_cell_size": aoi_grid_cell_size,
+            "processes": processes,
+            "threads": threads,
+            "chunk_size": chunk_size,
+            "include_parcel_geometry": include_parcel_geometry,
+            "save_features": save_features,
+            "save_buildings": save_buildings,
+            "tabular_file_format": tabular_file_format,
+            "cache_dir": str(cache_dir) if cache_dir else None,
+            "no_cache": no_cache,
+            "overwrite_cache": overwrite_cache,
+            "compress_cache": compress_cache,
+            "country": country,
+            "alpha": alpha,
+            "beta": beta,
+            "prerelease": prerelease,
+            "only3d": only3d,
+            "since": since,
+            "until": until,
+            "url_root": url_root,
+            "system_version_prefix": system_version_prefix,
+            "system_version": system_version,
+            "parcel_mode": parcel_mode,
+            "rapid": rapid,
+            "order": order,
+            "exclude_tiles_with_occlusion": exclude_tiles_with_occlusion,
+            "roof_age": self.roof_age,  # Use validated value
+            "roof_age_dataset": self.roof_age_dataset,
+            "roof_age_resource_id": self.roof_age_resource_id,
+            "class_level_files": class_level_files,
+            "max_retries": max_retries,
+        }
+        # Round-trip through JSON now (with default=str) so the in-memory copy
+        # used for fast-path comparison matches the on-disk shape — same
+        # str-coercion of Path objects, list-not-tuple, etc.
+        self._current_config_params = json.loads(json.dumps(config_params, default=str))
+
         # Save export configuration at start (before processing begins)
-        self._save_config(
-            {
-                "aoi_file": str(aoi_file),
-                "packs": packs,
-                "classes": classes,
-                "include": include,
-                "primary_decision": primary_decision,
-                "aoi_grid_min_pct": aoi_grid_min_pct,
-                "aoi_grid_inexact": aoi_grid_inexact,
-                "aoi_grid_cell_size": aoi_grid_cell_size,
-                "processes": processes,
-                "threads": threads,
-                "chunk_size": chunk_size,
-                "include_parcel_geometry": include_parcel_geometry,
-                "save_features": save_features,
-                "save_buildings": save_buildings,
-                "tabular_file_format": tabular_file_format,
-                "cache_dir": str(cache_dir) if cache_dir else None,
-                "no_cache": no_cache,
-                "overwrite_cache": overwrite_cache,
-                "compress_cache": compress_cache,
-                "country": country,
-                "alpha": alpha,
-                "beta": beta,
-                "prerelease": prerelease,
-                "only3d": only3d,
-                "since": since,
-                "until": until,
-                "url_root": url_root,
-                "system_version_prefix": system_version_prefix,
-                "system_version": system_version,
-                "parcel_mode": parcel_mode,
-                "rapid": rapid,
-                "order": order,
-                "exclude_tiles_with_occlusion": exclude_tiles_with_occlusion,
-                "roof_age": self.roof_age,  # Use validated value
-                "roof_age_dataset": self.roof_age_dataset,
-                "roof_age_resource_id": self.roof_age_resource_id,
-                "class_level_files": class_level_files,
-                "max_retries": max_retries,
-            }
-        )
+        self._save_config(config_params)
+
+    def _read_existing_config_params(self):
+        """Read the parameters block of any previously-saved export_config.json.
+
+        Returns the `parameters` dict, or None if no readable previous config
+        exists. Called from __init__ BEFORE _save_config overwrites the file
+        on disk, so the fast-path in _run_inner can compare current params
+        against the params that produced any pre-existing README.md.
+        """
+        prev_path = storage.join_path(self.final_path, "export_config.json")
+        if not storage.file_exists(prev_path):
+            return None
+        try:
+            prev = storage.read_json(prev_path)
+        except Exception as e:
+            self.logger.debug(f"Could not read previous export_config.json: {e}")
+            return None
+        if not isinstance(prev, dict):
+            return None
+        params = prev.get("parameters")
+        return params if isinstance(params, dict) else None
+
+    def _config_diff_for_fast_path(self):
+        """Return list of (key, previous_value, current_value) tuples for params
+        that differ between the previously-saved run and this run, ignoring
+        keys in _CONFIG_KEYS_NOT_AFFECTING_OUTPUT.
+
+        Returns empty list when no previous config is available — preserves the
+        baseline "README presence alone is the sentinel" behaviour for exports
+        that pre-date this comparison logic.
+        """
+        if self._previous_config_params is None:
+            return []
+        cur = self._current_config_params
+        prev = self._previous_config_params
+        diff = []
+        for key in sorted(set(cur.keys()) | set(prev.keys())):
+            if key in _CONFIG_KEYS_NOT_AFFECTING_OUTPUT:
+                continue
+            if cur.get(key) != prev.get(key):
+                diff.append((key, prev.get(key), cur.get(key)))
+        return diff
 
     def api_key(self) -> str:
         # Use provided API key if available, otherwise fall back to environment variable
@@ -3490,14 +3565,28 @@ class NearmapAIExporter(BaseExporter):
         # To force a rebuild from cached chunks, delete final/README.md
         # before re-invoking. Atomic write in ReadmeGenerator guarantees the
         # file only ever exists with full content; no torn-write false signal.
+        #
+        # We additionally validate that the export config hasn't changed in
+        # any output-affecting way (see _CONFIG_KEYS_NOT_AFFECTING_OUTPUT):
+        # if the user re-ran with different packs / country / date range /
+        # etc., we rebuild rather than silently returning the previous run's
+        # output.
         readme_path = storage.join_path(self.final_path, "README.md")
         if storage.file_exists(readme_path):
-            self.logger.info(
-                f"Prior run already complete: README.md present at {readme_path}. "
-                "Skipping all processing. Delete this file to force a rebuild "
-                "from cached chunks."
-            )
-            return
+            config_diff = self._config_diff_for_fast_path()
+            if not config_diff:
+                self.logger.info(
+                    f"Prior run already complete: README.md present at {readme_path}. "
+                    "Skipping all processing. Delete this file (or change export "
+                    "flags) to force a rebuild from cached chunks."
+                )
+                return
+            else:
+                changed = ", ".join(f"{k} ({prev!r} -> {cur!r})" for k, prev, cur in config_diff)
+                self.logger.info(
+                    f"README.md present at {readme_path} but export config has changed "
+                    f"since the prior run ({changed}). Rebuilding."
+                )
 
         # Process a single AOI file
         aoi_path = self.aoi_file

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -311,13 +311,22 @@ class ReadmeGenerator:
         """
         Generate README and save to final directory.
 
+        Writes atomically: content is first written to README.md.tmp and then
+        moved to README.md. The exporter's run_inner uses README.md presence as
+        a "fully complete" marker that skips rebuild on re-run; a torn write
+        would falsely signal completion. Atomic move (os.replace on local,
+        s3fs.mv on S3) guarantees README.md only ever appears with the full
+        generated content.
+
         Returns:
             Path to generated README.md file (string, may be S3 URI).
         """
         content = self._generate()
         readme_path = storage.join_path(self.final_dir, "README.md")
-        with storage.open_file(readme_path, "w") as f:
+        tmp_path = readme_path + ".tmp"
+        with storage.open_file(tmp_path, "w") as f:
             f.write(content)
+        storage.move_file(tmp_path, readme_path)
         return readme_path
 
     def _generate(self) -> str:

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -255,6 +255,34 @@ def remove_file(path: str) -> None:
         pass
 
 
+def move_file(src: str, dst: str) -> None:
+    """
+    Move a file. Used for atomic-write patterns (write-to-temp + move).
+
+    On local filesystems, uses os.replace which is atomic on POSIX (and best-
+    effort atomic on Windows). On S3, uses s3fs server-side COPY+DELETE — the
+    destination becomes visible atomically at the S3 object level, even though
+    the operation is two API calls.
+
+    Cross-scheme moves (local <-> S3) are not supported.
+
+    Args:
+        src: Source path
+        dst: Destination path
+    """
+    src_is_s3 = is_s3_path(src)
+    dst_is_s3 = is_s3_path(dst)
+    if src_is_s3 != dst_is_s3:
+        raise ValueError(
+            f"move_file does not support cross-scheme moves: src={src!r} dst={dst!r}"
+        )
+    if src_is_s3:
+        fs = _get_s3_filesystem()
+        fs.mv(src, dst)
+    else:
+        os.replace(src, dst)
+
+
 def read_json(path: str, compressed: bool = False) -> Optional[Dict]:
     """
     Read a JSON file, optionally gzip-compressed. Works for both local and S3.

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1021,3 +1021,61 @@ class TestPerClassChunkGlobFiltering:
 if __name__ == "__main__":
     current_file = os.path.abspath(__file__)
     sys.exit(pytest.main([current_file]))
+
+
+# ---------------------------------------------------------------------------
+# Fast-path: skip rebuild when README.md exists
+# ---------------------------------------------------------------------------
+
+
+class TestSkipRebuildWhenReadmeExists:
+    """README.md is the very last file written by a successful run, so its
+    presence implies every other final/ artifact was successfully produced.
+    The fast-path in _run_inner returns immediately and skips chunk reading,
+    consolidation, and per-class merging."""
+
+    def test_fast_path_returns_immediately_when_readme_exists(self, tmp_path):
+        final_dir = tmp_path / "final"
+        final_dir.mkdir()
+        (final_dir / "README.md").write_text("# Nearmap AI Export\n\nany content")
+
+        exporter = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+
+        # FeatureApi construction is the first heavy step after the fast-path.
+        # If the fast-path triggers, FeatureApi is never instantiated.
+        with patch("nmaipy.exporter.FeatureApi") as mock_api:
+            exporter.run()
+            mock_api.assert_not_called()
+
+    def test_full_pipeline_runs_when_readme_missing(self, tmp_path):
+        """Sanity check the inverse: with no README, _run_inner proceeds past
+        the fast-path. We force an early controlled failure so the test
+        doesn't have to actually run an export."""
+        final_dir = tmp_path / "final"
+        final_dir.mkdir()
+        # No README.md present
+
+        exporter = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+
+        # If we get past the fast-path, FeatureApi gets constructed. We patch
+        # it to raise; observing the raise confirms we did NOT take the fast
+        # path. This is a structural assertion — the actual export work isn't
+        # executed.
+        sentinel = RuntimeError("got past the fast-path as expected")
+
+        def boom(*args, **kwargs):
+            raise sentinel
+
+        with patch("nmaipy.exporter.FeatureApi", side_effect=boom):
+            with pytest.raises(RuntimeError, match="got past the fast-path"):
+                exporter.run()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1079,3 +1079,126 @@ class TestSkipRebuildWhenReadmeExists:
         with patch("nmaipy.exporter.FeatureApi", side_effect=boom):
             with pytest.raises(RuntimeError, match="got past the fast-path"):
                 exporter.run()
+
+    def test_fast_path_triggered_when_config_unchanged(self, tmp_path):
+        """README + matching config → fast-path triggers.
+
+        Constructing exporter1 saves export_config.json. Constructing
+        exporter2 with identical args reads that config as `_previous_config_params`
+        before saving its own; comparison sees no diff, so the fast-path fires.
+        """
+        # Run 1: constructor saves export_config.json
+        AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+        # Mark "completed" by writing the README sentinel
+        (tmp_path / "final" / "README.md").write_text("# done")
+
+        # Run 2: same args
+        exporter2 = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+
+        with patch("nmaipy.exporter.FeatureApi") as mock_api:
+            exporter2.run()
+            mock_api.assert_not_called()
+
+    def test_fast_path_skipped_when_output_affecting_param_changed(self, tmp_path):
+        """README present but country changed → rebuild (don't silently return prior output)."""
+        # Run 1: country=au
+        AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+        (tmp_path / "final" / "README.md").write_text("# done")
+
+        # Run 2: country=us — output-affecting change, must rebuild
+        exporter2 = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="us",
+            packs=["building"],
+        )
+
+        with patch("nmaipy.exporter.FeatureApi", side_effect=RuntimeError("got past fast-path")):
+            with pytest.raises(RuntimeError, match="got past fast-path"):
+                exporter2.run()
+
+    def test_fast_path_skipped_when_packs_changed(self, tmp_path):
+        """Packs change → rebuild even though README is present."""
+        AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+        (tmp_path / "final" / "README.md").write_text("# done")
+
+        exporter2 = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building", "vegetation"],  # added vegetation
+        )
+
+        with patch("nmaipy.exporter.FeatureApi", side_effect=RuntimeError("got past fast-path")):
+            with pytest.raises(RuntimeError, match="got past fast-path"):
+                exporter2.run()
+
+    def test_fast_path_triggered_when_only_ignored_param_changed(self, tmp_path):
+        """Performance / ergonomics knobs (processes, threads, log_level, etc.)
+        do NOT invalidate the fast-path. The previous run's output is still
+        valid; the user just changed how the export would have been computed,
+        not what would have come out."""
+        AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+            processes=4,
+        )
+        (tmp_path / "final" / "README.md").write_text("# done")
+
+        exporter2 = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+            processes=8,  # ignored — pure perf knob
+        )
+
+        with patch("nmaipy.exporter.FeatureApi") as mock_api:
+            exporter2.run()
+            mock_api.assert_not_called()
+
+    def test_fast_path_triggered_when_no_previous_config(self, tmp_path):
+        """Backward-compat: README present but no export_config.json → fast-path
+        still triggers. Pre-existing exports from before this comparison logic
+        landed shouldn't lose their fast-path on upgrade.
+        """
+        final_dir = tmp_path / "final"
+        final_dir.mkdir()
+        (final_dir / "README.md").write_text("# legacy")
+        # No export_config.json — emulate a pre-feature export
+
+        exporter = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+        # Constructor will write its own export_config.json (overwriting nothing
+        # since none was there). _previous_config_params should be None and the
+        # diff should be empty → fast-path.
+
+        with patch("nmaipy.exporter.FeatureApi") as mock_api:
+            exporter.run()
+            mock_api.assert_not_called()

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -711,3 +711,48 @@ class TestExactSkipMatch:
 
         class_columns = [c["column"] for c in classes]
         assert "latency_stats_detail" in class_columns, "Superstrings of skip names should not be skipped"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write semantics
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAndSaveAtomicWrite:
+    """README.md presence is used by exporter._run_inner as a 'fully complete'
+    marker that skips rebuild on re-run. A torn write would falsely signal
+    completion. These tests lock in the atomic-write invariant."""
+
+    def test_no_tmp_file_left_after_successful_save(self, tmp_path):
+        (tmp_path / "rollup.csv").write_text("aoi_id\n0\n")
+
+        gen = ReadmeGenerator(output_dir=tmp_path)
+        gen.generate_and_save()
+
+        assert (tmp_path / "README.md").exists()
+        # The temp file must not linger after a successful save
+        assert not (tmp_path / "README.md.tmp").exists()
+
+    def test_failure_before_move_does_not_create_readme(self, tmp_path, monkeypatch):
+        """If the move step fails (simulated), README.md must not exist —
+        only the .tmp file. Next run sees no README and rebuilds normally,
+        rather than fast-pathing on a phantom complete marker."""
+        from nmaipy import storage as storage_module
+
+        (tmp_path / "rollup.csv").write_text("aoi_id\n0\n")
+
+        def fail_move(src, dst):
+            raise OSError("simulated failure during move")
+
+        monkeypatch.setattr(storage_module, "move_file", fail_move)
+
+        gen = ReadmeGenerator(output_dir=tmp_path)
+        try:
+            gen.generate_and_save()
+        except OSError:
+            pass
+
+        assert not (tmp_path / "README.md").exists()
+        # A .tmp file may exist from the failed move attempt — that's fine,
+        # the next run won't be misled by it (only README.md presence triggers
+        # the fast-path).

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -420,3 +420,41 @@ class TestWriteParquet:
         storage.write_parquet(df, "s3://bucket/test.parquet", index=False)
         mock_fs.open.assert_called_with("s3://bucket/test.parquet", "wb")
         df.to_parquet.assert_called_once_with(mock_file, index=False)
+
+
+# ---------------------------------------------------------------------------
+# move_file
+# ---------------------------------------------------------------------------
+
+
+class TestMoveFile:
+    def test_local_move_replaces_atomically(self, tmp_path):
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("hello")
+        storage.move_file(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_text() == "hello"
+
+    def test_local_move_overwrites_existing_destination(self, tmp_path):
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("new")
+        dst.write_text("old")
+        storage.move_file(str(src), str(dst))
+        assert dst.read_text() == "new"
+
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_move_routes_through_fs_mv(self, mock_get_fs):
+        mock_fs = MagicMock()
+        mock_get_fs.return_value = mock_fs
+        storage.move_file("s3://bucket/src", "s3://bucket/dst")
+        mock_fs.mv.assert_called_once_with("s3://bucket/src", "s3://bucket/dst")
+
+    def test_cross_scheme_move_rejected(self, tmp_path):
+        local = str(tmp_path / "local.txt")
+        Path(local).write_text("x")
+        with pytest.raises(ValueError, match="cross-scheme"):
+            storage.move_file(local, "s3://bucket/dst")
+        with pytest.raises(ValueError, match="cross-scheme"):
+            storage.move_file("s3://bucket/src", local)


### PR DESCRIPTION
## Summary

When `_run_inner` finds `final/README.md` already on disk (or S3) **and the saved export config matches the current run's params**, it returns immediately. README is the last file a successful run writes (post-consolidation, post-per-class merge, post-error files), so its presence is a sound "fully complete" sentinel. The headline benefit is a 60+ minute → ~1 second turnaround on no-op re-invocations.

To force a rebuild from cached chunks, delete `final/README.md` before re-invoking, **or just change an output-affecting flag** — the comparison detects the change and rebuilds automatically.

This PR also bumps the version to **5.0.0b2** (carried as a commit on the feature branch so the bump lands as part of the merge, no separate commit on main needed).

## Two-layer gate

1. **README.md presence** — implies the prior run completed end-to-end. Atomically written via `<file>.tmp` + move, so a torn write can't leave a phantom marker.
2. **Export config equality** — current run's params (`--packs`, `--country`, `--since`/`--until`, `--roof-age-dataset`, etc.) match the `export_config.json` that produced the existing README. Pure perf / ergonomics knobs (`processes`, `threads`, `chunk_size`, `log_level`, `cache_dir`, `compress_cache`, `no_cache`, `overwrite_cache`) are explicitly ignored — they don't affect output content.

If config drift is detected, the runtime log lists which keys changed and proceeds to rebuild rather than silently returning stale output.

## Why atomic write

For the README sentinel to be trustworthy, `ReadmeGenerator.generate_and_save` writes via `README.md.tmp` + `storage.move_file()` (a new helper using `os.replace` locally and `s3fs.mv` on S3 — server-side COPY+DELETE, where the COPY makes the destination object visible atomically).

A torn write can no longer leave a partial README that the fast-path would falsely treat as "complete".

## Implementation

- [`nmaipy/exporter.py`](nmaipy/exporter.py) — fast-path at the top of `_run_inner`: `README.md` present AND no config diff → return. New module-level `_CONFIG_KEYS_NOT_AFFECTING_OUTPUT` set, plus `_read_existing_config_params()` (called from `__init__` BEFORE `_save_config` overwrites the file) and `_config_diff_for_fast_path()` helpers.
- [`nmaipy/readme_generator.py`](nmaipy/readme_generator.py) — `generate_and_save` writes via tmp + move.
- [`nmaipy/storage.py`](nmaipy/storage.py) — new `move_file(src, dst)` helper supporting local (`os.replace`) and S3 (`s3fs.mv`); rejects cross-scheme moves.
- [`nmaipy/__version__.py`](nmaipy/__version__.py) — bump to 5.0.0b2.

## Backward compat

If README exists but no `export_config.json` is on disk (pre-feature exports), the comparison sees no previous config and the diff is empty — fast-path still triggers. Existing completed exports retain the speed-up on upgrade without manual intervention.

## Test plan

- [x] Unit tests for `storage.move_file`: local replace, overwrite, S3 routing through `fs.mv`, cross-scheme rejection.
- [x] Unit tests for atomic README write: no `.tmp` left after success; simulated `move_file` failure leaves no `README.md` (so the next run rebuilds rather than fast-pathing on a phantom).
- [x] Fast-path: with README present, `FeatureApi` is never constructed; with README absent, the run proceeds past the fast-path.
- [x] Config-aware fast-path: matching config triggers fast-path; `--country` change rebuilds; `--packs` change rebuilds; `processes`-only change still fast-paths (ignored); pre-feature export with no `export_config.json` still fast-paths (backward compat).
- [x] Full non-live, non-slow suite: 516 passed locally.
- [ ] CI green
- [ ] End-to-end smoke: run a small export, verify README.md is the last file written, re-run with same flags (~1s), re-run with `--country` flipped (rebuild), re-run with `processes=8` instead of `processes=4` (~1s — ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)