### PR TITLE
[INDS-2080] Auto-generated data dictionaries + canonical roof-age column order

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ The exporter writes results to `{output_dir}/final/` with the following structur
 | `{class}.csv` | Per-class attribute tables (e.g. `roof.csv`, `building.csv`) |
 | `{class}_features.parquet` | Per-class GeoParquet with feature geometries (when `save_features=True`) |
 | `features.parquet` | All features combined as GeoParquet (when `save_features=True`) |
-| `buildings.csv` or `.parquet` | Per-building detail rows (when `save_buildings=True`) |
 | `feature_api_errors.csv` | AOIs where the Feature API returned errors |
 | `roof_age_errors.csv` | AOIs where the Roof Age API returned errors (US only) |
 | `latency_stats.csv` | API timing diagnostics |
@@ -352,8 +351,7 @@ Key options:
 - `--roof-age`: Include Roof Age API data (US only)
 - `--roof-age-dataset`: Roof Age dataset to query when `--roof-age` is set. Aliases `latest` (default — pointer maintained by the API team, currently serving A.0), `A.0`, `A.1`; any other value is sent to the API as a literal resource UUID, so newly published datasets can be targeted without a code change. Note that the dataset alias is not the same thing as the model version: each row's `model_version` field records which model produced that record, and is the source of truth when reasoning about model behaviour
 - `--save-features`: Save per-class GeoParquet files with feature geometries
-- `--save-buildings`: Save per-building detail rows
-- `--tabular-file-format`: Format for tabular output files — rollup, buildings, and per-class attribute files (`csv` or `parquet`, default: `csv`)
+- `--tabular-file-format`: Format for tabular output files — rollup and per-class attribute files (`csv` or `parquet`, default: `csv`)
 - `--cache-dir`: Directory for caching API responses
 - `--no-cache`: Disable caching entirely
 - `--primary-decision`: Feature selection method (`largest_intersection`, `nearest`, `optimal`)

--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.0b2"
+__version__ = "5.0.0rc1"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -1,0 +1,566 @@
+"""Column metadata loader and lookup for nmaipy outputs.
+
+Single source of truth for column descriptions used by both the README generator
+and the data dictionary generator. Reads from ``nmaipy/data/column_metadata.json``,
+which the PM is expected to edit when descriptions need refining.
+
+Usage::
+
+    from nmaipy.column_metadata import lookup_column
+
+    meta = lookup_column("primary_roof_staining_area_sqft", area_unit="sqft")
+    print(meta.description)
+    # -> "Total area of staining detections on the primary roof of the parcel."
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, replace
+from functools import lru_cache
+from importlib import resources
+from typing import Optional
+
+# Sentinel string for fields that the PM must fill in. Surfaces visibly in
+# generated dictionaries so missing descriptions are easy to spot.
+UNKNOWN_SENTINEL = "?"
+
+# Long-form unit names paired with their short column-suffix form.
+_AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
+
+# Scope-prefix → human-readable phrase used to disambiguate parcel-wide vs
+# primary-feature-scope columns. Parcel-scope (no prefix) maps to a default
+# phrase produced by ``_format_scope_phrase``.
+_SCOPE_PHRASES: dict[str, str] = {
+    "primary_roof_": "on the primary roof of the parcel",
+    "primary_building_": "on the primary building of the parcel",
+    "primary_roof_instance_": "on the primary roof age instance of the parcel",
+    "primary_building_lifecycle_": "on the primary building lifecycle of the parcel",
+    "primary_swimming_pool_": "on the primary swimming pool of the parcel",
+    "primary_solar_panel_": "on the primary solar panel of the parcel",
+    "primary_child_roof_": "on the primary child roof of the parent feature",
+    "primary_child_roof_age_": "on the primary linked roof age instance of the parent feature",
+}
+_DEFAULT_SCOPE_PHRASE = "across the entire parcel"
+
+# When scope-stripping resolves a bare entry against a scoped column, the scope
+# prefix carries class information. Two flavours of label:
+#   - ``simple``: bare class name (used inside e.g. "Total {class_label} area"
+#     so the rendering reads "Total roof area").
+#   - ``primary``: full "primary <class> on the parcel" phrase (used inside
+#     e.g. "Feature ID of the {class_label}" so the rendering reads
+#     "Feature ID of the primary roof on the parcel"). The template chooses
+#     which flavour by where it places ``{class_label}``.
+# Today both fall back to the simple form unless the description text reads
+# more naturally with the primary phrasing — that's controlled by the seeded
+# JSON's wording, not by code.
+_SCOPE_CLASS_LABELS_SIMPLE: dict[str, str] = {
+    "primary_roof_": "roof",
+    "primary_building_": "building",
+    "primary_roof_instance_": "roof age instance",
+    "primary_building_lifecycle_": "building lifecycle",
+    "primary_swimming_pool_": "swimming pool",
+    "primary_solar_panel_": "solar panel",
+    "primary_child_roof_": "roof",
+    "primary_child_roof_age_": "roof age instance",
+}
+_SCOPE_CLASS_LABELS_PRIMARY: dict[str, str] = {
+    "primary_roof_": "primary roof on the parcel",
+    "primary_building_": "primary building on the parcel",
+    "primary_roof_instance_": "primary roof age instance on the parcel",
+    "primary_building_lifecycle_": "primary building lifecycle on the parcel",
+    "primary_swimming_pool_": "primary swimming pool on the parcel",
+    "primary_solar_panel_": "primary solar panel on the parcel",
+    "primary_child_roof_": "primary child roof of the parent feature",
+    "primary_child_roof_age_": "primary linked roof age instance of the parent feature",
+}
+# Backwards-compatibility alias kept for any callers using the old name.
+_SCOPE_CLASS_LABELS = _SCOPE_CLASS_LABELS_SIMPLE
+
+
+@dataclass(frozen=True)
+class ColumnMeta:
+    """In-memory representation of one column's metadata.
+
+    Field order matches the data-dictionary CSV column order requested in
+    the INDS-2080 ticket: column name → description → allowed values →
+    dtype → source → min → max → precision. Plus internal-only helpers.
+    """
+
+    dtype: str = ""
+    description: str = ""
+    allowed_values: str = ""
+    source: str = ""
+    min: str = ""
+    max: str = ""
+    unit: str = ""
+    precision: str = ""
+    notes: str = ""
+    group: str = ""
+
+    def is_unknown(self) -> bool:
+        """True when description and source are both the unknown sentinel."""
+        return self.description == UNKNOWN_SENTINEL and self.source == UNKNOWN_SENTINEL
+
+
+@dataclass(frozen=True)
+class _CompiledPattern:
+    """Internal: a compiled pattern row from the JSON config."""
+
+    regex: re.Pattern
+    template: ColumnMeta
+
+
+def _format_scope_phrase(scope_prefix: Optional[str]) -> str:
+    """Return the human-readable phrase for a scope prefix.
+
+    Empty/None → the parcel-wide phrase ("across the entire parcel").
+    """
+    if not scope_prefix:
+        return _DEFAULT_SCOPE_PHRASE
+    return _SCOPE_PHRASES.get(scope_prefix, _DEFAULT_SCOPE_PHRASE)
+
+
+def _substitute(
+    value: str,
+    *,
+    area_unit: str = "",
+    scope: str = "",
+    cls: str = "",
+    class_label: str = "",
+    class_label_primary: str = "",
+    scope_phrase_override: str = "",
+    extra_groups: Optional[dict[str, str]] = None,
+) -> str:
+    """Substitute templated placeholders.
+
+    Recognised placeholders:
+      ``{unit}``          – ``"sqft"`` / ``"sqm"``.
+      ``{unit_name}``     – ``"square feet"`` / ``"square metres"``.
+      ``{scope_phrase}``  – e.g. ``"on the primary roof of the parcel"``.
+      ``{class}``         – pattern-captured detection class (humanised).
+      ``{class_label}``   – simple class name from filename or scope (e.g. ``"roof"``).
+      ``{class_label_primary}`` – primary-feature scope phrasing (e.g. ``"primary roof on the parcel"``).
+        Falls back to ``{class_label}`` when no scope is set.
+    """
+    if not value:
+        return value
+    unit_long = _AREA_UNIT_LONG_NAMES.get(area_unit, area_unit)
+    scope_phrase = scope_phrase_override or _format_scope_phrase(scope)
+    # Render {class} as a human-readable phrase. Three stages:
+    #  1. Strip the rollup-internal ``_total`` suffix (sometimes paired with
+    #     ``_clipped`` / ``_unclipped``) so e.g. ``roof_total_area_sqft`` reads
+    #     "Total area of roof detected …" rather than "roof total".
+    #  2. Map ``_clipped`` / ``_unclipped`` suffixes to a parenthetical so the
+    #     distinction survives without doubling up the word "area".
+    #  3. Replace remaining underscores with spaces.
+    cls_phrase = cls
+    suffix_phrase = ""
+    if cls_phrase.endswith("_total_clipped"):
+        cls_phrase = cls_phrase[: -len("_total_clipped")]
+        suffix_phrase = " (clipped to parcel boundary)"
+    elif cls_phrase.endswith("_total_unclipped"):
+        cls_phrase = cls_phrase[: -len("_total_unclipped")]
+        suffix_phrase = " (before parcel clipping)"
+    elif cls_phrase.endswith("_clipped"):
+        cls_phrase = cls_phrase[: -len("_clipped")]
+        suffix_phrase = " (clipped to parcel boundary)"
+    elif cls_phrase.endswith("_unclipped"):
+        cls_phrase = cls_phrase[: -len("_unclipped")]
+        suffix_phrase = " (before parcel clipping)"
+    elif cls_phrase.endswith("_total"):
+        cls_phrase = cls_phrase[: -len("_total")]
+    cls_phrase = cls_phrase.replace("_", " ") + suffix_phrase
+    # {class_label_primary} falls back to plain {class_label} when no scope-aware
+    # primary phrase is supplied.
+    primary_label = class_label_primary or class_label
+    result = (
+        value.replace("{unit}", area_unit)
+        .replace("{unit_name}", unit_long)
+        .replace("{scope_phrase}", scope_phrase)
+        .replace("{class}", cls_phrase)
+        .replace("{class_label_primary}", primary_label)
+        .replace("{class_label}", class_label)
+    )
+    # Substitute any other named groups (e.g. {peril}, {feature}) the pattern
+    # exposed. Underscores → spaces so multi-word groups read naturally.
+    # Each group also exposes a Title-case variant ({Peril}, {Feature}, ...) for
+    # sentence-initial use.
+    for key, val in (extra_groups or {}).items():
+        if val:
+            humanised = val.replace("_", " ")
+            result = result.replace(f"{{{key}}}", humanised)
+            result = result.replace(f"{{{key.capitalize()}}}", humanised.capitalize())
+    return result
+
+
+def _meta_from_json(entry: dict) -> ColumnMeta:
+    """Construct ColumnMeta from a JSON entry. Empty strings are the default."""
+    return ColumnMeta(
+        dtype=entry.get("dtype", ""),
+        description=entry.get("description", ""),
+        allowed_values=entry.get("allowed_values", ""),
+        source=entry.get("source", ""),
+        min=entry.get("min", ""),
+        max=entry.get("max", ""),
+        unit=entry.get("unit", ""),
+        precision=entry.get("precision", ""),
+        notes=entry.get("notes", ""),
+        group=entry.get("group", ""),
+    )
+
+
+def _validate(payload: dict) -> None:
+    """Basic shape validation. Raises ValueError with a friendly message on bad input."""
+    if not isinstance(payload, dict):
+        raise ValueError("column_metadata.json: top-level value must be an object/dict.")
+    for required in ("exact_matches", "patterns"):
+        if required not in payload:
+            raise ValueError(f"column_metadata.json: missing required top-level key '{required}'.")
+    if not isinstance(payload["exact_matches"], dict):
+        raise ValueError("column_metadata.json: 'exact_matches' must be an object (column name → metadata).")
+    if not isinstance(payload["patterns"], list):
+        raise ValueError("column_metadata.json: 'patterns' must be a list of pattern objects.")
+    for i, pattern in enumerate(payload["patterns"]):
+        if not isinstance(pattern, dict):
+            raise ValueError(f"column_metadata.json: patterns[{i}] must be an object.")
+        if "regex" not in pattern:
+            raise ValueError(f"column_metadata.json: patterns[{i}] is missing 'regex'.")
+        try:
+            re.compile(pattern["regex"])
+        except re.error as exc:
+            raise ValueError(f"column_metadata.json: patterns[{i}] regex is invalid: {exc}.") from exc
+
+
+@lru_cache(maxsize=1)
+def load_metadata(
+    json_path: Optional[str] = None,
+) -> tuple[dict[str, ColumnMeta], tuple[_CompiledPattern, ...], dict[str, str], dict[str, str]]:
+    """Load and validate the column metadata JSON.
+
+    Returns a 4-tuple of:
+      - exact_matches: dict mapping column name → ColumnMeta.
+      - patterns: tuple of compiled patterns, ordered by config order.
+      - evidence_type_legend: dict mapping integer code (as string) → description.
+      - defensible_space_zone_distances: dict mapping zoneId (as string) → distance band.
+
+    Cached: subsequent calls with the same ``json_path`` reuse the parsed result.
+    Pass an explicit path to load a different config (used by tests).
+    """
+    if json_path is None:
+        # Use importlib.resources so this works in installed packages too.
+        with resources.files("nmaipy.data").joinpath("column_metadata.json").open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    else:
+        with open(json_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+
+    _validate(payload)
+
+    exact: dict[str, ColumnMeta] = {
+        name: _meta_from_json(entry) for name, entry in payload["exact_matches"].items()
+    }
+    patterns = tuple(
+        _CompiledPattern(regex=re.compile(p["regex"]), template=_meta_from_json(p))
+        for p in payload["patterns"]
+    )
+    legend = {
+        k: v
+        for k, v in payload.get("evidence_type_legend", {}).items()
+        if not k.startswith("_")
+    }
+    zone_distances = {
+        k: v
+        for k, v in payload.get("defensible_space_zone_distances", {}).items()
+        if not k.startswith("_")
+    }
+    return exact, patterns, legend, zone_distances
+
+
+def reload_metadata() -> None:
+    """Clear the loader cache. Useful for tests that edit the JSON in place."""
+    load_metadata.cache_clear()
+
+
+def lookup_column(name: str, area_unit: str = "", class_label: str = "feature") -> ColumnMeta:
+    """Resolve a column name to its ColumnMeta.
+
+    Args:
+        name: Column name to look up.
+        area_unit: ``"sqft"`` or ``"sqm"`` for area-unit substitution.
+        class_label: Human-readable class label for the file the column lives in
+            (e.g. ``"building"`` for ``building_features.parquet``). Used to
+            substitute ``{class_label}`` in bare entries like ``area_sqft``.
+            Defaults to ``"feature"`` for mixed-class or rollup files.
+
+    Lookup precedence:
+      1. Exact match in ``exact_matches`` (templates substituted with ``area_unit``).
+      2. Scope-stripped exact match: strip a known scope prefix from the front,
+         re-look up the remainder, and append the scope phrase to the description.
+         This catches columns like ``primary_roof_instance_roof_age_installation_date``
+         that share semantics with the bare ``roof_age_installation_date`` entry but
+         appear with a scope prefix in the rollup.
+      3. First matching regex in ``patterns`` (templates substituted with the
+         pattern's named groups: ``scope``, ``class``, ``unit``).
+      4. Sentinel ColumnMeta with ``description = source = "?"``.
+    """
+    exact, patterns, _, zone_distances = load_metadata()
+
+    # 1. Exact match. Try the literal name first, then a unit-templated form
+    #    (e.g. "tile_area_sqft" → check "tile_area_{unit}").
+    if name in exact:
+        return _instantiate(exact[name], area_unit=area_unit, class_label=class_label)
+    if area_unit:
+        templated = name.replace(f"_{area_unit}", "_{unit}")
+        if templated != name and templated in exact:
+            return _instantiate(exact[templated], area_unit=area_unit, class_label=class_label)
+
+    # 2. Scope-stripped exact match.
+    for scope_prefix in _SCOPE_PHRASES:
+        if not name.startswith(scope_prefix):
+            continue
+        remainder = name[len(scope_prefix):]
+        scoped_meta = _scope_stripped_lookup(remainder, exact, area_unit, scope_prefix, class_label)
+        if scoped_meta is not None:
+            return scoped_meta
+
+    # 3. Pattern match.
+    for pattern in patterns:
+        match = pattern.regex.match(name)
+        if match:
+            groups = match.groupdict()
+            scope = groups.get("scope", "") or ""
+            cls = groups.get("class", "") or ""
+            # Forward any other named groups (e.g. peril, feature, unit, zone_id)
+            # so the template can reference them as {peril}, {feature}, {zone_id}, ...
+            extra_groups = {k: (v or "") for k, v in groups.items() if k not in ("scope", "class")}
+            # If the pattern captured a zone_id, look up its distance band and
+            # expose it as {zone_band}. Falls back to the captured id if unknown.
+            zone_id = extra_groups.get("zone_id", "")
+            if zone_id:
+                extra_groups["zone_band"] = zone_distances.get(zone_id, zone_id)
+            # If the pattern captured an optional ``primary_`` prefix, expose
+            # {primary_phrasing} so a single description can read sensibly in
+            # both the rollup (primary-roof scope, with BL fallback) and the
+            # per-row roof.csv contexts.
+            if "primary_prefix" in extra_groups:
+                if extra_groups["primary_prefix"]:
+                    extra_groups["primary_phrasing"] = (
+                        "the primary roof on the parcel (with Building Lifecycle fallback when structural damage is present)"
+                    )
+                else:
+                    extra_groups["primary_phrasing"] = f"this {class_label}"
+            # Defensible-space scope phrasing. The same patterns serve three
+            # contexts: rollup (``primary_``/``aggregate_`` prefixes) and the
+            # per-roof ``roof.csv`` (no prefix — the row already identifies the
+            # roof). Surface a single ``{ds_scope_phrasing}`` token so one
+            # description can read sensibly in all three.
+            if "roof_scope" in extra_groups:
+                rs = extra_groups["roof_scope"]
+                if rs == "primary_":
+                    extra_groups["ds_scope_phrasing"] = (
+                        "around the primary roof on the parcel"
+                    )
+                elif rs == "aggregate_":
+                    extra_groups["ds_scope_phrasing"] = (
+                        "aggregated across all roofs on the parcel"
+                    )
+                else:
+                    extra_groups["ds_scope_phrasing"] = f"around this {class_label}"
+            # Dominant-subject phrasing for ``<class>_dominant`` Y/N columns,
+            # which read as "...whether {dominant_subject} is predominantly
+            # {class}." Resolves against the captured ``scope`` group:
+            # primary_roof_/etc. → the primary <thing>; no scope → reflects the
+            # filename (per-class file = "this <thing>"; rollup unscoped = "the parcel").
+            scope_for_subject = groups.get("scope") or ""
+            if scope_for_subject in _SCOPE_CLASS_LABELS_SIMPLE:
+                extra_groups["dominant_subject"] = (
+                    f"the primary {_SCOPE_CLASS_LABELS_SIMPLE[scope_for_subject]}"
+                )
+            elif class_label and class_label != "feature" and class_label != "parcel":
+                extra_groups["dominant_subject"] = f"this {class_label}"
+            else:
+                extra_groups["dominant_subject"] = "the parcel"
+            # Swimming-pool condition-ratio phrasing. Pattern captures
+            # ``condition`` ∈ {unmaintained, in_lanai, covered, empty,
+            # above_ground} and an optional ``primary_swimming_pool_`` scope.
+            # Surfaces ``{pool_subject}`` (parcel total vs primary pool) and
+            # ``{condition_phrase}`` (humanised, including the irregular
+            # "inside a lanai" / "above-ground" cases).
+            if "condition" in extra_groups:
+                cond = extra_groups["condition"]
+                _COND_PHRASES = {
+                    "unmaintained": "unmaintained",
+                    "in_lanai": "inside a lanai",
+                    "covered": "covered",
+                    "empty": "empty",
+                    "above_ground": "above-ground",
+                }
+                extra_groups["condition_phrase"] = _COND_PHRASES.get(cond, cond.replace("_", " "))
+                extra_groups["pool_subject"] = (
+                    "the primary swimming pool on the parcel"
+                    if scope_for_subject == "primary_swimming_pool_"
+                    else "the parcel's total swimming pool area"
+                )
+            # Per-class file override: when a column has no scope prefix
+            # (e.g. ``tile_ratio`` on roof.csv) and the file is a per-class
+            # output, the parcel-default scope phrase reads wrong — each row
+            # is one feature, not a parcel aggregate. Override to "on this
+            # {class_label}".
+            scope_phrase_override = ""
+            if not scope and class_label and class_label not in ("feature", "parcel"):
+                scope_phrase_override = f"on this {class_label}"
+            return _instantiate(
+                pattern.template,
+                area_unit=area_unit,
+                scope=scope,
+                cls=cls,
+                class_label=class_label,
+                scope_phrase_override=scope_phrase_override,
+                extra_groups=extra_groups,
+            )
+
+    # 4. Sentinel.
+    return ColumnMeta(description=UNKNOWN_SENTINEL, source=UNKNOWN_SENTINEL)
+
+
+def _scope_stripped_lookup(
+    remainder: str,
+    exact: dict[str, ColumnMeta],
+    area_unit: str,
+    scope_prefix: str,
+    class_label: str = "feature",
+) -> Optional[ColumnMeta]:
+    """If ``remainder`` is in ``exact_matches``, return its meta with scope phrase appended.
+
+    Also tries ``roof_age_<remainder>`` for child/instance scope prefixes, since the
+    bare metadata is keyed under the ``roof_age_`` prefix (e.g.
+    ``primary_child_roof_age_installation_date`` strips to ``installation_date`` but
+    the seeded entry is ``roof_age_installation_date``).
+    """
+    candidates = [remainder]
+    if area_unit:
+        templated = remainder.replace(f"_{area_unit}", "_{unit}")
+        if templated != remainder:
+            candidates.append(templated)
+    if "roof_age" in scope_prefix:
+        candidates.append(f"roof_age_{remainder}")
+        if area_unit:
+            ra_templated = f"roof_age_{remainder}".replace(f"_{area_unit}", "_{unit}")
+            if ra_templated != f"roof_age_{remainder}":
+                candidates.append(ra_templated)
+
+    base: Optional[ColumnMeta] = None
+    for candidate in candidates:
+        if candidate in exact:
+            base = exact[candidate]
+            break
+    if base is None:
+        return None
+    # The scope prefix carries class information; let it override the
+    # file-level class_label so e.g. primary_roof_area_sqft on a rollup
+    # renders as "Total roof area" rather than "Total feature area".
+    effective_simple = _SCOPE_CLASS_LABELS_SIMPLE.get(scope_prefix, class_label)
+    effective_primary = _SCOPE_CLASS_LABELS_PRIMARY.get(scope_prefix, effective_simple)
+    rendered = _instantiate(
+        base,
+        area_unit=area_unit,
+        class_label=effective_simple,
+        class_label_primary=effective_primary,
+    )
+    scope_phrase = _format_scope_phrase(scope_prefix)
+    # Append the scope phrase to the description so callers can tell parcel-scope
+    # apart from primary-feature-scope at a glance. Skip it when the template
+    # already references {scope_phrase}, {class_label}, or {class_label_primary}
+    # — those placeholders already encode the scope-aware information.
+    template_uses_scope = (
+        "{scope_phrase}" in base.description
+        or "{class_label}" in base.description
+        or "{class_label_primary}" in base.description
+    )
+    if not template_uses_scope and scope_phrase not in rendered.description:
+        new_desc = rendered.description.rstrip(".")
+        if new_desc:
+            new_desc = f"{new_desc} ({scope_phrase})."
+        else:
+            new_desc = f"{scope_phrase}."
+        rendered = replace(rendered, description=new_desc)
+    return rendered
+
+
+def _instantiate(
+    template: ColumnMeta,
+    *,
+    area_unit: str = "",
+    scope: str = "",
+    cls: str = "",
+    class_label: str = "",
+    class_label_primary: str = "",
+    scope_phrase_override: str = "",
+    extra_groups: Optional[dict[str, str]] = None,
+) -> ColumnMeta:
+    """Render templates in a ColumnMeta against the given context."""
+    kw = dict(
+        area_unit=area_unit,
+        scope=scope,
+        cls=cls,
+        class_label=class_label,
+        class_label_primary=class_label_primary,
+        scope_phrase_override=scope_phrase_override,
+        extra_groups=extra_groups or {},
+    )
+    return replace(
+        template,
+        dtype=_substitute(template.dtype, **kw),
+        description=_substitute(template.description, **kw),
+        allowed_values=_substitute(template.allowed_values, **kw),
+        source=_substitute(template.source, **kw),
+        min=_substitute(template.min, **kw),
+        max=_substitute(template.max, **kw),
+        unit=_substitute(template.unit, **kw),
+        precision=_substitute(template.precision, **kw),
+    )
+
+
+def evidence_type_legend() -> dict[str, str]:
+    """Return a copy of the roof age evidence_type integer-code → description mapping."""
+    _, _, legend, _ = load_metadata()
+    return dict(legend)
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatible README dict re-exports
+# ---------------------------------------------------------------------------
+# The existing readme_generator.py expects module-level dicts named
+# COMMON_COLUMNS, ADDRESS_QUERY_COLUMNS, RSI_COLUMNS, ROOF_AGE_COLUMNS,
+# DOMINANT_ROOF_MATERIAL_COLUMNS, DOMINANT_ROOF_TYPES_COLUMNS, and
+# DEFENSIBLE_SPACE_ZONE_COLUMNS. We rebuild them from the JSON by group.
+# ---------------------------------------------------------------------------
+
+
+def _by_group(group_name: str) -> dict[str, ColumnMeta]:
+    """Return all exact-match entries with the given ``group``, in JSON order."""
+    exact, _, _, _ = load_metadata()
+    return {name: meta for name, meta in exact.items() if meta.group == group_name}
+
+
+def _group_dict() -> dict[str, dict[str, ColumnMeta]]:
+    """Pre-computed group → entries, evaluated lazily and cached via load_metadata."""
+    return {
+        "COMMON_COLUMNS": _by_group("common"),
+        "ADDRESS_QUERY_COLUMNS": _by_group("address_query"),
+        "RSI_COLUMNS": _by_group("rsi"),
+        "ROOF_AGE_COLUMNS": _by_group("roof_age"),
+        "DOMINANT_ROOF_MATERIAL_COLUMNS": _by_group("dominant_roof_material"),
+        "DOMINANT_ROOF_TYPES_COLUMNS": _by_group("dominant_roof_types"),
+        "DEFENSIBLE_SPACE_ZONE_COLUMNS": _by_group("defensible_space"),
+    }
+
+
+def __getattr__(name: str):
+    """Lazily expose group dicts as module attributes for README generator imports."""
+    groups = _group_dict()
+    if name in groups:
+        return groups[name]
+    raise AttributeError(f"module 'nmaipy.column_metadata' has no attribute {name!r}")

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -44,6 +44,21 @@ _SCOPE_PHRASES: dict[str, str] = {
 }
 _DEFAULT_SCOPE_PHRASE = "across the entire parcel"
 
+# Terse labels for scope-stripped lookup, appended in parens to the resolved
+# description (e.g. "Estimated roof installation date (primary roof's roof
+# age)."). Used only when the underlying template doesn't already carry scope
+# information via ``{scope_phrase}`` / ``{class_label}`` / ``{class_label_primary}``.
+_SCOPE_APPENDED_LABELS: dict[str, str] = {
+    "primary_roof_": "primary roof",
+    "primary_building_": "primary building",
+    "primary_roof_instance_": "primary roof's roof age",
+    "primary_building_lifecycle_": "primary building lifecycle",
+    "primary_swimming_pool_": "primary swimming pool",
+    "primary_solar_panel_": "primary solar panel",
+    "primary_child_roof_": "primary linked roof",
+    "primary_child_roof_age_": "primary linked roof's roof age",
+}
+
 # When scope-stripping resolves a bare entry against a scoped column, the scope
 # prefix carries class information. Two flavours of label:
 #   - ``simple``: bare class name (used inside e.g. "Total {class_label} area"
@@ -55,26 +70,41 @@ _DEFAULT_SCOPE_PHRASE = "across the entire parcel"
 # Today both fall back to the simple form unless the description text reads
 # more naturally with the primary phrasing — that's controlled by the seeded
 # JSON's wording, not by code.
+
+# Canonical per-class label dict, keyed by the snake_case slug from
+# `_description_to_cname`. Single source of truth — `output_files.py` imports
+# this for filename → label resolution, and the scope-prefixed dicts below
+# derive from it.
+PER_CLASS_LABELS: dict[str, str] = {
+    "building": "building",
+    "building_lifecycle": "building lifecycle",
+    "roof": "roof",
+    "roof_instance": "roof age instance",
+    "swimming_pool": "swimming pool",
+    "solar_panel": "solar panel",
+}
+
 _SCOPE_CLASS_LABELS_SIMPLE: dict[str, str] = {
-    "primary_roof_": "roof",
-    "primary_building_": "building",
-    "primary_roof_instance_": "roof age instance",
-    "primary_building_lifecycle_": "building lifecycle",
-    "primary_swimming_pool_": "swimming pool",
-    "primary_solar_panel_": "solar panel",
-    "primary_child_roof_": "roof",
-    "primary_child_roof_age_": "roof age instance",
+    f"primary_{cname}_": label for cname, label in PER_CLASS_LABELS.items()
 }
+# Child-feature scope variants don't fit the per-class label layout above
+# (they refer to the parent feature, not the parcel). Keep these explicit.
+_SCOPE_CLASS_LABELS_SIMPLE.update(
+    {
+        "primary_child_roof_": "roof",
+        "primary_child_roof_age_": "roof age instance",
+    }
+)
+
 _SCOPE_CLASS_LABELS_PRIMARY: dict[str, str] = {
-    "primary_roof_": "primary roof on the parcel",
-    "primary_building_": "primary building on the parcel",
-    "primary_roof_instance_": "primary roof age instance on the parcel",
-    "primary_building_lifecycle_": "primary building lifecycle on the parcel",
-    "primary_swimming_pool_": "primary swimming pool on the parcel",
-    "primary_solar_panel_": "primary solar panel on the parcel",
-    "primary_child_roof_": "primary child roof of the parent feature",
-    "primary_child_roof_age_": "primary linked roof age instance of the parent feature",
+    f"primary_{cname}_": f"primary {label} on the parcel" for cname, label in PER_CLASS_LABELS.items()
 }
+_SCOPE_CLASS_LABELS_PRIMARY.update(
+    {
+        "primary_child_roof_": "primary child roof of the parent feature",
+        "primary_child_roof_age_": "primary linked roof age instance of the parent feature",
+    }
+)
 # Backwards-compatibility alias kept for any callers using the old name.
 _SCOPE_CLASS_LABELS = _SCOPE_CLASS_LABELS_SIMPLE
 
@@ -283,45 +313,53 @@ def reload_metadata() -> None:
     load_metadata.cache_clear()
 
 
-def lookup_column(name: str, area_unit: str = "", class_label: str = "feature") -> ColumnMeta:
+def lookup_column(
+    name: str,
+    area_unit: str = "",
+    class_label: str = "feature",
+    extras: Optional[dict[str, str]] = None,
+) -> ColumnMeta:
     """Resolve a column name to its ColumnMeta.
 
     Args:
         name: Column name to look up.
         area_unit: ``"sqft"`` or ``"sqm"`` for area-unit substitution.
         class_label: Human-readable class label for the file the column lives in
-            (e.g. ``"building"`` for ``building_features.parquet``). Used to
-            substitute ``{class_label}`` in bare entries like ``area_sqft``.
-            Defaults to ``"feature"`` for mixed-class or rollup files.
+            (e.g. ``"building"`` for ``building.csv``). Used to substitute
+            ``{class_label}`` in templates. Defaults to ``"feature"`` for
+            mixed-class or rollup files.
+        extras: Caller-supplied substitutions (e.g.
+            ``{"primary_strategy": "optimal"}``). Each key becomes a
+            ``{key}`` placeholder in the description; values use snake_case →
+            spaces and a ``{Key}`` capitalised variant for sentence-initial use.
 
     Lookup precedence:
       1. Exact match in ``exact_matches`` (templates substituted with ``area_unit``).
-      2. Scope-stripped exact match: strip a known scope prefix from the front,
-         re-look up the remainder, and append the scope phrase to the description.
-         This catches columns like ``primary_roof_instance_roof_age_installation_date``
-         that share semantics with the bare ``roof_age_installation_date`` entry but
-         appear with a scope prefix in the rollup.
-      3. First matching regex in ``patterns`` (templates substituted with the
-         pattern's named groups: ``scope``, ``class``, ``unit``).
+      2. Scope-stripped exact match: strip a known scope prefix, re-look up the
+         remainder, and append a terse scope label.
+      3. First matching regex in ``patterns``.
       4. Sentinel ColumnMeta with ``description = source = "?"``.
     """
     exact, patterns, _, zone_distances = load_metadata()
 
-    # 1. Exact match. Try the literal name first, then a unit-templated form
-    #    (e.g. "tile_area_sqft" → check "tile_area_{unit}").
+    # 1. Exact match. Try the literal name first, then a unit-templated form.
     if name in exact:
-        return _instantiate(exact[name], area_unit=area_unit, class_label=class_label)
+        return _instantiate(exact[name], area_unit=area_unit, class_label=class_label, extra_groups=extras)
     if area_unit:
         templated = name.replace(f"_{area_unit}", "_{unit}")
         if templated != name and templated in exact:
-            return _instantiate(exact[templated], area_unit=area_unit, class_label=class_label)
+            return _instantiate(
+                exact[templated], area_unit=area_unit, class_label=class_label, extra_groups=extras
+            )
 
     # 2. Scope-stripped exact match.
     for scope_prefix in _SCOPE_PHRASES:
         if not name.startswith(scope_prefix):
             continue
         remainder = name[len(scope_prefix):]
-        scoped_meta = _scope_stripped_lookup(remainder, exact, area_unit, scope_prefix, class_label)
+        scoped_meta = _scope_stripped_lookup(
+            remainder, exact, area_unit, scope_prefix, class_label, extras
+        )
         if scoped_meta is not None:
             return scoped_meta
 
@@ -352,13 +390,13 @@ def lookup_column(name: str, area_unit: str = "", class_label: str = "feature") 
                 else:
                     extra_groups["primary_phrasing"] = f"this {class_label}"
             # Defensible-space scope phrasing. The same patterns serve three
-            # contexts: rollup (``primary_``/``aggregate_`` prefixes) and the
+            # contexts: rollup (``primary_roof_``/``aggregate_`` prefixes) and the
             # per-roof ``roof.csv`` (no prefix — the row already identifies the
             # roof). Surface a single ``{ds_scope_phrasing}`` token so one
             # description can read sensibly in all three.
             if "roof_scope" in extra_groups:
                 rs = extra_groups["roof_scope"]
-                if rs == "primary_":
+                if rs == "primary_roof_":
                     extra_groups["ds_scope_phrasing"] = (
                         "around the primary roof on the parcel"
                     )
@@ -411,6 +449,8 @@ def lookup_column(name: str, area_unit: str = "", class_label: str = "feature") 
             scope_phrase_override = ""
             if not scope and class_label and class_label not in ("feature", "parcel"):
                 scope_phrase_override = f"on this {class_label}"
+            if extras:
+                extra_groups.update(extras)
             return _instantiate(
                 pattern.template,
                 area_unit=area_unit,
@@ -431,6 +471,7 @@ def _scope_stripped_lookup(
     area_unit: str,
     scope_prefix: str,
     class_label: str = "feature",
+    extras: Optional[dict[str, str]] = None,
 ) -> Optional[ColumnMeta]:
     """If ``remainder`` is in ``exact_matches``, return its meta with scope phrase appended.
 
@@ -468,23 +509,24 @@ def _scope_stripped_lookup(
         area_unit=area_unit,
         class_label=effective_simple,
         class_label_primary=effective_primary,
+        extra_groups=extras,
     )
-    scope_phrase = _format_scope_phrase(scope_prefix)
-    # Append the scope phrase to the description so callers can tell parcel-scope
-    # apart from primary-feature-scope at a glance. Skip it when the template
-    # already references {scope_phrase}, {class_label}, or {class_label_primary}
-    # — those placeholders already encode the scope-aware information.
+    # Append a terse scope label to the description so callers can tell
+    # parcel-scope apart from primary-feature-scope at a glance. Skipped when
+    # the template already references {scope_phrase}, {class_label}, or
+    # {class_label_primary} — those placeholders already encode scope info.
+    scope_label = _SCOPE_APPENDED_LABELS.get(scope_prefix, _format_scope_phrase(scope_prefix))
     template_uses_scope = (
         "{scope_phrase}" in base.description
         or "{class_label}" in base.description
         or "{class_label_primary}" in base.description
     )
-    if not template_uses_scope and scope_phrase not in rendered.description:
+    if not template_uses_scope and scope_label not in rendered.description:
         new_desc = rendered.description.rstrip(".")
         if new_desc:
-            new_desc = f"{new_desc} ({scope_phrase})."
+            new_desc = f"{new_desc} ({scope_label})."
         else:
-            new_desc = f"{scope_phrase}."
+            new_desc = f"{scope_label}."
         rendered = replace(rendered, description=new_desc)
     return rendered
 

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -87,29 +87,33 @@ ROOF_AGE_MODEL_VERSION_FIELD = "modelVersion"
 ROOF_AGE_MAPBROWSER_URL_FIELD = "mapBrowserUrl"
 
 # Roof Age API columns that should receive the roof_age_ prefix during export.
-# Whitelist of snake_case column names from _parse_response() that are specific
-# to the Roof Age API. Only these get prefixed; all other columns (standard
-# feature columns, exporter columns, Feature API columns) are left untouched.
-ROOF_AGE_PREFIX_COLUMNS = {
-    "kind",
+# Ordered list of snake_case column names from _parse_response() that are
+# specific to the Roof Age API. Only these get the ``roof_age_`` prefix
+# applied during flattening; all other columns (standard feature columns,
+# exporter columns, Feature API columns) are left untouched. Iteration order
+# below is the canonical column order applied wherever roof-age data is
+# emitted (roof_instance.csv, rollup primary_roof_instance_*, roof.csv
+# primary_child_roof_age_*, building.csv chained primary_child_roof_*_*).
+ROOF_AGE_PREFIX_COLUMNS = (
+    "map_browser_url",
     "installation_date",
-    "as_of_date",
-    "until_date",
-    "trust_score",
     "evidence_type",
     "evidence_type_description",
+    "trust_score",
     "before_installation_capture_date",
     "after_installation_capture_date",
     "min_capture_date",
     "max_capture_date",
     "number_of_captures",
-    "relevant_permits",
-    "relevant_permits_details",
+    "as_of_date",
+    "until_date",
+    "kind",
     "assessor_data",
     "assessor_data_details",
-    "map_browser_url",
+    "relevant_permits",
+    "relevant_permits_details",
     "model_version",
-}
+)
 
 
 # ============================================================================

--- a/nmaipy/data/__init__.py
+++ b/nmaipy/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data files shipped with nmaipy (column metadata config, etc.)."""

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -201,6 +201,12 @@
       "description": "Reference date for age calculation. When --until is set, this is the requested cutoff (clamped to the dataset's nearest snapshot date).",
       "source": "roof age model"
     },
+    "roof_age_until_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "The original requested cutoff (`untilAsOfDate`) before snapshot clamping. Differs from `roof_age_as_of_date` when the requested cutoff fell between dataset snapshots; null when no historical cutoff was applied.",
+      "source": "roof age model"
+    },
     "roof_age_years_as_of_date": {
       "group": "roof_age",
       "dtype": "float",
@@ -631,6 +637,12 @@
       "group": "roof_age_bare",
       "dtype": "date",
       "description": "Reference date for age calculation.",
+      "source": "roof age model"
+    },
+    "until_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Original requested cutoff (`untilAsOfDate`) before snapshot clamping. Un-prefixed; appears on roof age instance features. Null when no historical cutoff was applied.",
       "source": "roof age model"
     },
     "trust_score": {

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -1,0 +1,1004 @@
+{
+  "_doc": "Data dictionary metadata for nmaipy export columns. PM-editable. See nmaipy/column_metadata.py for the loader. Sentinel '?' values mark cells where a definition is intentionally not yet provided.",
+  "exact_matches": {
+    "aoi_id": {
+      "group": "common",
+      "dtype": "string \\| int",
+      "description": "Property identifier. If the input file had an `aoi_id` column it is preserved; otherwise generated from row index (0-indexed).",
+      "source": "input data"
+    },
+    "mesh_date": {
+      "group": "common",
+      "dtype": "date",
+      "description": "Date of the Nearmap 3D data capture.",
+      "source": "image metadata"
+    },
+    "system_version": {
+      "group": "common",
+      "dtype": "string",
+      "description": "Base AI model version used for detection (applies to all columns with source = 'base ai model').",
+      "source": "model metadata"
+    },
+    "link": {
+      "group": "common",
+      "dtype": "URL",
+      "description": "URL to view the {class_label} in Nearmap MapBrowser. Per-class files (roof, building, etc.) frame the URL on each feature's centroid; the rollup frames it on the parcel.",
+      "source": "image metadata"
+    },
+    "streetAddress": {
+      "group": "address_query",
+      "dtype": "string",
+      "description": "Street address from input (used for address-based API queries).",
+      "source": "input data"
+    },
+    "city": {
+      "group": "address_query",
+      "dtype": "string",
+      "description": "City from input (used for address-based API queries).",
+      "source": "input data"
+    },
+    "state": {
+      "group": "address_query",
+      "dtype": "string",
+      "description": "State from input (used for address-based API queries).",
+      "source": "input data"
+    },
+    "zip": {
+      "group": "address_query",
+      "dtype": "string",
+      "description": "ZIP/postal code from input (used for address-based API queries).",
+      "source": "input data"
+    },
+    "query_aoi_lat": {
+      "group": "address_query",
+      "dtype": "float",
+      "min": "-90.0",
+      "max": "90.0",
+      "unit": "degrees",
+      "description": "Representative latitude of the query AOI geometry.",
+      "source": "input data"
+    },
+    "query_aoi_lon": {
+      "group": "address_query",
+      "dtype": "float",
+      "min": "-180.0",
+      "max": "180.0",
+      "unit": "degrees",
+      "description": "Representative longitude of the query AOI geometry.",
+      "source": "input data"
+    },
+    "lat": {
+      "group": "address_query",
+      "dtype": "float",
+      "min": "-90.0",
+      "max": "90.0",
+      "unit": "degrees",
+      "description": "Input latitude used for primary feature selection.",
+      "source": "input data"
+    },
+    "lon": {
+      "group": "address_query",
+      "dtype": "float",
+      "min": "-180.0",
+      "max": "180.0",
+      "unit": "degrees",
+      "description": "Input longitude used for primary feature selection.",
+      "source": "input data"
+    },
+    "roof_spotlight_index": {
+      "group": "rsi",
+      "dtype": "int",
+      "min": "0",
+      "max": "100",
+      "description": "Roof Spotlight Index — roof condition score. 100 = best condition, 0 = worst condition.",
+      "allowed_values": "integer 0-100",
+      "source": "score model"
+    },
+    "roof_spotlight_index_confidence": {
+      "group": "rsi",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Confidence in RSI score.",
+      "source": "score model"
+    },
+    "primary_roof_spotlight_index": {
+      "group": "rsi",
+      "dtype": "int",
+      "min": "0",
+      "max": "100",
+      "description": "Roof Spotlight Index of the primary roof on the parcel (with Building Lifecycle fallback when structural damage is present). 100 = best condition, 0 = worst condition.",
+      "allowed_values": "integer 0-100",
+      "source": "score model"
+    },
+    "primary_roof_spotlight_index_confidence": {
+      "group": "rsi",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Confidence in the primary roof's Roof Spotlight Index.",
+      "source": "score model"
+    },
+    "dominant_roof_material_feature_class": {
+      "group": "dominant_roof_material",
+      "dtype": "UUID",
+      "description": "Feature class UUID of the dominant roof material. Dominant = highest-ratio component; UNKNOWN (null) when ratio < 0.5.",
+      "source": "base ai model"
+    },
+    "dominant_roof_material_description": {
+      "group": "dominant_roof_material",
+      "dtype": "string",
+      "description": "Snake_case name of the dominant material feature class (`unknown` when ratio < 0.5). Open-ended; consult the Feature API class registry for the full list of possible values.",
+      "source": "base ai model"
+    },
+    "dominant_roof_material_area_{unit}": {
+      "group": "dominant_roof_material",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Area of the dominant material component on the primary roof.",
+      "source": "base ai model"
+    },
+    "dominant_roof_material_ratio": {
+      "group": "dominant_roof_material",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Ratio of the dominant material relative to total roof area.",
+      "source": "base ai model"
+    },
+    "dominant_roof_material_confidence": {
+      "group": "dominant_roof_material",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Confidence in the dominant material classification.",
+      "source": "base ai model"
+    },
+    "dominant_roof_types_feature_class": {
+      "group": "dominant_roof_types",
+      "dtype": "UUID",
+      "description": "Feature class UUID of the dominant roof shape. Dominant = highest-ratio component; UNKNOWN (null) when no detected area.",
+      "source": "base ai model"
+    },
+    "dominant_roof_types_description": {
+      "group": "dominant_roof_types",
+      "dtype": "string",
+      "description": "Snake_case name of the dominant shape feature class (`unknown` when no detected area). Open-ended; consult the Feature API class registry for the full list of possible values. Excludes deprecated flat roof and `shed`.",
+      "source": "base ai model"
+    },
+    "dominant_roof_types_area_{unit}": {
+      "group": "dominant_roof_types",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Area of the dominant shape component on the primary roof.",
+      "source": "base ai model"
+    },
+    "dominant_roof_types_confidence": {
+      "group": "dominant_roof_types",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Confidence in the dominant shape classification.",
+      "source": "base ai model"
+    },
+    "defensible_space_model_version": {
+      "group": "defensible_space",
+      "dtype": "string",
+      "description": "Version of the defensible space model used.",
+      "source": "model metadata"
+    },
+    "roof_age_installation_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "Estimated roof installation date.",
+      "source": "roof age model"
+    },
+    "roof_age_as_of_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "Reference date for age calculation. When --until is set, this is the requested cutoff (clamped to the dataset's nearest snapshot date).",
+      "source": "roof age model"
+    },
+    "roof_age_years_as_of_date": {
+      "group": "roof_age",
+      "dtype": "float",
+      "min": "0",
+      "unit": "years",
+      "description": "Calculated roof age in years (as_of_date \u2212 installation_date).",
+      "source": "roof age model"
+    },
+    "roof_age_trust_score": {
+      "group": "roof_age",
+      "dtype": "int",
+      "min": "0",
+      "max": "100",
+      "description": "Reliability of age estimate (higher = more reliable).",
+      "source": "roof age model"
+    },
+    "roof_age_evidence_type": {
+      "group": "roof_age",
+      "dtype": "int",
+      "min": "0",
+      "max": "8",
+      "description": "How age was determined (numeric code; see evidence_type_legend in README.md).",
+      "allowed_values": "0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8",
+      "source": "roof age model"
+    },
+    "roof_age_evidence_type_description": {
+      "group": "roof_age",
+      "dtype": "string",
+      "description": "Human-readable evidence type description.",
+      "source": "roof age model"
+    },
+    "roof_age_before_installation_capture_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "Last capture before roof installation.",
+      "source": "roof age model"
+    },
+    "roof_age_after_installation_capture_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "First capture after roof installation.",
+      "source": "roof age model"
+    },
+    "roof_age_min_capture_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "Earliest imagery capture date analyzed.",
+      "source": "roof age model"
+    },
+    "roof_age_max_capture_date": {
+      "group": "roof_age",
+      "dtype": "date",
+      "description": "Latest imagery capture date analyzed.",
+      "source": "roof age model"
+    },
+    "roof_age_number_of_captures": {
+      "group": "roof_age",
+      "dtype": "int",
+      "min": "0",
+      "description": "Number of images analyzed.",
+      "source": "roof age model"
+    },
+    "roof_age_map_browser_url": {
+      "group": "roof_age",
+      "dtype": "URL",
+      "description": "URL to view roof age timeline in MapBrowser.",
+      "source": "roof age model"
+    },
+    "roof_age_model_version": {
+      "group": "roof_age",
+      "dtype": "string",
+      "description": "Version of the roof age prediction model used.",
+      "source": "model metadata"
+    },
+    "roof_age_kind": {
+      "group": "roof_age",
+      "dtype": "string",
+      "description": "Type of estimate. One of `roof` (roof section) or `parcel` (property-level). Parcel-level estimates are only provided when no imagery is available.",
+      "allowed_values": "roof | parcel",
+      "source": "roof age model"
+    },
+    "roof_age_relevant_permits": {
+      "group": "roof_age",
+      "dtype": "Y/N",
+      "description": "Whether relevant building permits were used in determining roof age.",
+      "allowed_values": "Y | N",
+      "source": "roof age model"
+    },
+    "roof_age_relevant_permits_details": {
+      "group": "roof_age",
+      "dtype": "JSON",
+      "description": "Details of relevant building permits (present when permits used in determining roof age).",
+      "source": "roof age model"
+    },
+    "roof_age_assessor_data": {
+      "group": "roof_age",
+      "dtype": "Y/N",
+      "description": "Whether assessor records (year built) were used in determining roof age.",
+      "allowed_values": "Y | N",
+      "source": "roof age model"
+    },
+    "roof_age_assessor_data_details": {
+      "group": "roof_age",
+      "dtype": "JSON",
+      "description": "Details of assessor (year built) records (present when records were used in determining roof age).",
+      "source": "roof age model"
+    },
+    "feature_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "Feature ID of the {class_label_primary}.",
+      "source": "base ai model"
+    },
+    "class_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "AI feature class UUID for this row.",
+      "source": "model metadata"
+    },
+    "description": {
+      "group": "feature_meta",
+      "dtype": "string",
+      "description": "Human-readable name of this feature's class.",
+      "source": "model metadata"
+    },
+    "geometry": {
+      "group": "feature_meta",
+      "dtype": "WKT \\| GeoParquet",
+      "description": "Feature geometry. WKT in CSVs, native GeoParquet geometry in `_features.parquet`.",
+      "source": "base ai model"
+    },
+    "parent_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "Feature ID of this feature's parent in the API hierarchy. For the new Building class, this points to the Building Lifecycle ancestor.",
+      "source": "base ai model"
+    },
+    "is_primary": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "description": "Whether this feature is the parcel's primary feature for its class (selected by --primary-decision).",
+      "allowed_values": "Y | N",
+      "source": "base ai model"
+    },
+    "confidence": {
+      "group": "feature_meta",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Confidence in detection of the {class_label_primary}.",
+      "source": "base ai model"
+    },
+    "roof_confidence": {
+      "group": "rollup_class_confidence",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one roof was detected on the parcel. When multiple roofs are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no roofs are detected.",
+      "source": "base ai model"
+    },
+    "building_confidence": {
+      "group": "rollup_class_confidence",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one building was detected on the parcel. When multiple buildings are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no buildings are detected.",
+      "source": "base ai model"
+    },
+    "building_lifecycle_confidence": {
+      "group": "rollup_class_confidence",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one building lifecycle feature was detected on the parcel. When multiple are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when none are detected.",
+      "source": "base ai model"
+    },
+    "swimming_pool_confidence": {
+      "group": "rollup_class_confidence",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one swimming pool was detected on the parcel. When multiple pools are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no pools are detected.",
+      "source": "base ai model"
+    },
+    "solar_panel_confidence": {
+      "group": "rollup_class_confidence",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one solar panel was detected on the parcel. When multiple panels are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no panels are detected.",
+      "source": "base ai model"
+    },
+    "fidelity": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Quality of the vectorized footprint polygon for the {class_label_primary} (higher = better fidelity to the true outline). Only present on structural classes (e.g. building, roof).",
+      "source": "base ai model"
+    },
+    "has_3d_attributes": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "allowed_values": "Y | N",
+      "description": "Boolean indicator of whether 3D attribute data from Nearmap is available for this record.",
+      "source": "model metadata"
+    },
+    "pitch_degrees": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "unit": "degrees",
+      "description": "Predominant roof pitch in degrees, from 3D data. Building-level pitch is identical to roof pitch.",
+      "source": "model metadata"
+    },
+    "survey_date": {
+      "group": "feature_meta",
+      "dtype": "date",
+      "description": "Date the imagery was captured for this feature's source survey.",
+      "source": "image metadata"
+    },
+    "survey_resource_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "Survey resource UUID for the imagery.",
+      "source": "image metadata"
+    },
+    "match_quality": {
+      "group": "feature_meta",
+      "dtype": "string",
+      "description": "Quality of address-to-AOI geocoding match.",
+      "source": "input data"
+    },
+    "geocode_source": {
+      "group": "feature_meta",
+      "dtype": "string",
+      "description": "Source of the geocoded coordinates for an address-based query.",
+      "source": "input data"
+    },
+    "area_sqm": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square metres",
+      "description": "Area of the {class_label_primary}, in square metres.",
+      "source": "base ai model"
+    },
+    "area_sqft": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square feet",
+      "description": "Area of the {class_label_primary}, in square feet.",
+      "source": "base ai model"
+    },
+    "clipped_area_sqm": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square metres",
+      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in square metres.",
+      "source": "base ai model"
+    },
+    "clipped_area_sqft": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square feet",
+      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in square feet.",
+      "source": "base ai model"
+    },
+    "unclipped_area_sqm": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square metres",
+      "description": "Total area of the {class_label_primary} before parcel clipping, in square metres.",
+      "source": "base ai model"
+    },
+    "unclipped_area_sqft": {
+      "group": "feature_meta",
+      "dtype": "float",
+      "min": "0",
+      "unit": "square feet",
+      "description": "Total area of the {class_label_primary} before parcel clipping, in square feet.",
+      "source": "base ai model"
+    },
+    "resource_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "Identifier of the AI resource (model dataset) that produced this row.",
+      "source": "model metadata"
+    },
+    "parent_building_id": {
+      "group": "linkage",
+      "dtype": "UUID",
+      "description": "Feature ID of the building this roof spatially matches (IoU-linked).",
+      "source": "base ai model"
+    },
+    "parent_building_iou": {
+      "group": "linkage",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Intersection-over-Union score with the parent building (\u22650.005 to assign).",
+      "source": "base ai model"
+    },
+    "parent_iou": {
+      "group": "linkage",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Intersection-over-Union score with the parent feature (\u22650.005 to assign).",
+      "source": "base ai model"
+    },
+    "primary_child_roof_id": {
+      "group": "linkage",
+      "dtype": "UUID",
+      "description": "Feature ID of this building's primary child roof (highest IoU above threshold).",
+      "source": "base ai model"
+    },
+    "primary_child_roof_iou": {
+      "group": "linkage",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "IoU between this building and its primary child roof.",
+      "source": "base ai model"
+    },
+    "primary_child_roof_age_feature_id": {
+      "group": "linkage",
+      "dtype": "UUID",
+      "description": "Feature ID of the roof age instance linked to this roof (highest IoU above 0.005).",
+      "source": "base ai model"
+    },
+    "primary_child_roof_age_iou": {
+      "group": "linkage",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "IoU between this roof and its primary linked roof age instance.",
+      "source": "base ai model"
+    },
+    "child_roofs": {
+      "group": "linkage",
+      "dtype": "JSON",
+      "description": "JSON list of all roofs linked to this building, sorted by IoU descending. Each item: `{feature_id, iou}`.",
+      "source": "base ai model"
+    },
+    "child_roof_count": {
+      "group": "linkage",
+      "dtype": "int",
+      "min": "0",
+      "description": "Count of linked child roofs.",
+      "source": "base ai model"
+    },
+    "child_roof_instances": {
+      "group": "linkage",
+      "dtype": "JSON",
+      "description": "JSON list of all roof age instances linked to this roof, sorted by IoU descending. Each item: `{feature_id, iou, kind}`.",
+      "source": "base ai model"
+    },
+    "child_roof_instance_count": {
+      "group": "linkage",
+      "dtype": "int",
+      "min": "0",
+      "description": "Count of linked roof age instances.",
+      "source": "base ai model"
+    },
+    "damage_class": {
+      "group": "damage",
+      "dtype": "string",
+      "description": "Most-likely damage class for this Building Lifecycle feature.",
+      "allowed_values": "Undamaged | Affected | Minor | Major | Destroyed",
+      "source": "base ai model"
+    },
+    "since": {
+      "group": "query_input",
+      "dtype": "date",
+      "description": "Earliest survey date filter for the query (per-AOI override of the bulk --since flag).",
+      "source": "input data"
+    },
+    "until": {
+      "group": "query_input",
+      "dtype": "date",
+      "description": "Latest survey date filter for the query (per-AOI override of the bulk --until flag). Also drives Roof Age `untilAsOfDate` when --roof-age is set with an A.1+ dataset.",
+      "source": "input data"
+    },
+    "survey_id": {
+      "group": "query_input",
+      "dtype": "UUID",
+      "description": "Survey identifier the AI features were drawn from.",
+      "source": "image metadata"
+    },
+    "perspective": {
+      "group": "feature_meta",
+      "dtype": "string",
+      "description": "Imagery perspective (e.g. 'Vert' for vertical/orthographic).",
+      "source": "image metadata"
+    },
+    "postcat": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "description": "Whether this feature comes from post-catastrophe imagery.",
+      "allowed_values": "Y | N",
+      "source": "image metadata"
+    },
+    "feature_api_success": {
+      "group": "api_status",
+      "dtype": "Y/N",
+      "description": "Whether the Feature API call succeeded for this AOI.",
+      "allowed_values": "Y | N",
+      "source": "model metadata"
+    },
+    "roof_age_api_success": {
+      "group": "api_status",
+      "dtype": "Y/N",
+      "description": "Whether the Roof Age API call succeeded for this AOI.",
+      "allowed_values": "Y | N",
+      "source": "model metadata"
+    },
+    "installation_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Estimated roof installation date.",
+      "source": "roof age model"
+    },
+    "as_of_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Reference date for age calculation.",
+      "source": "roof age model"
+    },
+    "trust_score": {
+      "group": "roof_age_bare",
+      "dtype": "int",
+      "min": "0",
+      "max": "100",
+      "description": "Reliability of age estimate.",
+      "source": "roof age model"
+    },
+    "evidence_type": {
+      "group": "roof_age_bare",
+      "dtype": "int",
+      "min": "0",
+      "max": "8",
+      "description": "How age was determined (numeric code; un-prefixed; appears on roof age instance features).",
+      "allowed_values": "0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8",
+      "source": "roof age model"
+    },
+    "evidence_type_description": {
+      "group": "roof_age_bare",
+      "dtype": "string",
+      "description": "Human-readable evidence description.",
+      "source": "roof age model"
+    },
+    "before_installation_capture_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Last capture before roof installation.",
+      "source": "roof age model"
+    },
+    "after_installation_capture_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "First capture after roof installation.",
+      "source": "roof age model"
+    },
+    "min_capture_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Earliest imagery capture date analyzed.",
+      "source": "roof age model"
+    },
+    "max_capture_date": {
+      "group": "roof_age_bare",
+      "dtype": "date",
+      "description": "Latest imagery capture date analyzed.",
+      "source": "roof age model"
+    },
+    "number_of_captures": {
+      "group": "roof_age_bare",
+      "dtype": "int",
+      "min": "0",
+      "description": "Number of aerial captures analyzed.",
+      "source": "roof age model"
+    },
+    "map_browser_url": {
+      "group": "roof_age_bare",
+      "dtype": "URL",
+      "description": "URL to view roof age timeline in MapBrowser.",
+      "source": "roof age model"
+    },
+    "model_version": {
+      "group": "roof_age_bare",
+      "dtype": "string",
+      "description": "Model version.",
+      "source": "model metadata"
+    },
+    "kind": {
+      "group": "roof_age_bare",
+      "dtype": "string",
+      "description": "Type of estimate. One of `roof` (roof section) or `parcel` (property-level). Un-prefixed; appears on roof age instance features.",
+      "allowed_values": "roof | parcel",
+      "source": "roof age model"
+    },
+    "relevant_permits": {
+      "group": "roof_age_bare",
+      "dtype": "Y/N",
+      "description": "Whether relevant building permits were found.",
+      "allowed_values": "Y | N",
+      "source": "roof age model"
+    },
+    "assessor_data": {
+      "group": "roof_age_bare",
+      "dtype": "Y/N",
+      "description": "Whether assessor records were found.",
+      "allowed_values": "Y | N",
+      "source": "roof age model"
+    },
+    "assessor_data_details": {
+      "group": "roof_age_bare",
+      "dtype": "JSON",
+      "description": "Details of assessor records.",
+      "source": "roof age model"
+    },
+    "internal_class_id": {
+      "group": "feature_meta",
+      "dtype": "UUID",
+      "description": "Internal class ID used by the Feature API for downstream linkage; not customer-facing.",
+      "source": "model metadata"
+    },
+    "attributes": {
+      "group": "feature_meta",
+      "dtype": "JSON",
+      "description": "Raw API attributes payload for this feature (used during processing; preserved on raw feature outputs).",
+      "source": "base ai model"
+    },
+    "damage": {
+      "group": "feature_meta",
+      "dtype": "JSON",
+      "description": "Raw API damage payload for Building Lifecycle features (used by damage flattening).",
+      "source": "base ai model"
+    },
+    "belongs_to_parcel": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "description": "Whether this feature is contained within (rather than spanning beyond) the AOI parcel.",
+      "allowed_values": "Y | N",
+      "source": "base ai model"
+    },
+    "multiparcel_feature": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "description": "Whether the {class_label_primary} is also detected on at least one other parcel (e.g. a roof or building spanning a row of townhomes). 'Y' indicates this feature is shared across multiple parcels.",
+      "allowed_values": "Y | N",
+      "source": "base ai model"
+    },
+    "is_footprint": {
+      "group": "feature_meta",
+      "dtype": "Y/N",
+      "description": "Whether this feature is a building footprint.",
+      "allowed_values": "Y | N",
+      "source": "base ai model"
+    },
+    "aoi_geometry": {
+      "group": "feature_meta",
+      "dtype": "WKT \\| GeoParquet",
+      "description": "Original AOI geometry (preserved on grid-failure error rows for context).",
+      "source": "input data"
+    }
+  },
+  "patterns": [
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_zone_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_defensible_space_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Clear/defensible area within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing} — area free of vegetation, buildings and yard debris. In {unit}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_coverage_ratio$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Fraction of defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing} that is defensible (clear of vegetation, buildings and yard debris).",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_risk_object_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of all risk objects (vegetation, neighbouring roofs, yard debris, etc.) within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Area of {risk_class} within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_ratio$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Ratio of {risk_class} area to total zone area within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane)_vulnerability_model_input_(?P<feature>.+)$",
+      "dtype": "float",
+      "description": "Value of {feature} used as input to the {peril} vulnerability score model.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane)_vulnerability_score$",
+      "dtype": "int",
+      "min": "1",
+      "max": "5",
+      "allowed_values": "1 | 2 | 3 | 4 | 5",
+      "description": "{Peril} vulnerability score of {primary_phrasing}. 1 = most vulnerable, 5 = least vulnerable.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane)_vulnerability_probability$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Raw model probability from the {peril} vulnerability model. This probability is binned into the 1-5 {peril} vulnerability score.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane|wind_hail)_risk_score$",
+      "dtype": "int",
+      "min": "1",
+      "max": "5",
+      "allowed_values": "1 | 2 | 3 | 4 | 5",
+      "description": "{Peril} risk score of {primary_phrasing}. 1 = highest risk, 5 = lowest risk.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?wind_hail_risk_model_input_(?P<feature>.+)$",
+      "dtype": "float",
+      "description": "Value of {feature} used as input to the wind/hail risk score model for {primary_phrasing}.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane|wind_hail)_(?P<kind>vulnerability|risk)_rate_factor$",
+      "dtype": "float",
+      "description": "Rate factor corresponding to the {peril} {kind} score for {primary_phrasing}, as per Nearmap's approved regulatory filings.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane)_fema_annual_frequency$",
+      "dtype": "float",
+      "description": "Estimated annual frequency of {peril} at the location of {primary_phrasing}, according to the FEMA National Risk Index (version reported in {peril}_fema_version).",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<primary_prefix>primary_)?(?P<peril>hail|wind|wildfire|hurricane)_fema_version$",
+      "dtype": "string",
+      "description": "Version of the FEMA National Risk Index used to derive {peril}-related risk fields. Sourced from the API response field femaVersion on each {peril} score block.",
+      "source": "model metadata"
+    },
+    {
+      "regex": "^(?:primary_)?(?P<score>roof_spotlight_index|(?:hail|wind|wildfire|hurricane)_score|wind_hail_risk_score)_model_version$",
+      "dtype": "string",
+      "description": "Model version for {score}.",
+      "source": "model metadata"
+    },
+    {
+      "regex": "^(?P<score>roof_spotlight_index|(?:hail|wind|wildfire|hurricane)_(?:vulnerability|risk)_score|wind_hail_risk_score)_min$",
+      "dtype": "float",
+      "description": "Minimum {score} across all roofs on the parcel.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<score>roof_spotlight_index|(?:hail|wind|wildfire|hurricane)_(?:vulnerability|risk)_score|wind_hail_risk_score)_max$",
+      "dtype": "float",
+      "description": "Maximum {score} across all roofs on the parcel.",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<score>roof_spotlight_index|(?:hail|wind|wildfire|hurricane)_(?:vulnerability|risk)_score|wind_hail_risk_score)_area_weighted_mean$",
+      "dtype": "float",
+      "description": "Area-weighted mean {score} across all roofs on the parcel (weighted by each roof's clipped area).",
+      "source": "score model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_child_roof_)?ground_height_(?P<length_unit>ft|m)$",
+      "dtype": "float",
+      "unit": "{length_unit}",
+      "description": "Ground elevation in {length_unit}, from 3D data.",
+      "source": "model metadata"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_child_roof_)?height_(?P<length_unit>ft|m)$",
+      "dtype": "float",
+      "unit": "{length_unit}",
+      "description": "Height of building above ground in {length_unit}, from 3D data.",
+      "source": "model metadata"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of {class} detected {scope_phrase}, in {unit}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<class>building|building_under_construction|roof|roof_instance|building_lifecycle|swimming_pool|solar_panel)_multiparcel_feature_count$",
+      "dtype": "int",
+      "min": "0",
+      "description": "Count of {class} features on this parcel that are also detected on at least one other parcel (e.g. row-home features whose footprint spans multiple parcels).",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_swimming_pool_)?(?P<condition>unmaintained|in_lanai|covered|empty|above_ground)_swimming_pool_ratio$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Fraction of {pool_subject} detected to be {condition_phrase}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_count$",
+      "dtype": "int",
+      "min": "0",
+      "description": "Count of {class} detections {scope_phrase}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_present$",
+      "dtype": "Y/N",
+      "allowed_values": "Y | N",
+      "description": "Whether any {class} is detected {scope_phrase}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_ratio$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Ratio of {class} detected {scope_phrase}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_dominant$",
+      "dtype": "Y/N",
+      "allowed_values": "Y | N",
+      "description": "Boolean indicator of whether {dominant_subject} is predominantly {class}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_confidence$",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "precision": "uint8 quantised (0-255 \u2192 0.0-1.0)",
+      "description": "Confidence in {class} classification {scope_phrase}. Aggregation when multiple detections contribute: probabilistic union 1 - product(1 - confidence_i) for top-level pack classes on the parcel (e.g. all roofs, all vegetation segments); maximum across detections for sub-attributes within a parent feature (e.g. staining detections on a roof). Null when the corresponding area is 0.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)(?P<class>.+?)_feature_id$",
+      "dtype": "UUID",
+      "description": "Feature ID of the primary {class} {scope_phrase}.",
+      "source": "base ai model"
+    }
+  ],
+  "defensible_space_zone_distances": {
+    "_doc": "Defensible space zoneId \u2192 distance band around the structure. Used by patterns to substitute {zone_band} in descriptions. Edit here if the API team changes the zone definitions.",
+    "0": "0-5 ft",
+    "1": "5-30 ft",
+    "2": "30-100 ft"
+  },
+  "evidence_type_legend": {
+    "_doc": "Roof age evidence_type code \u2192 human-readable description. Source: https://help.nearmap.com/kb/articles/1811-evidence-type-and-trust-score. Used by roof_age_evidence_type allowed_values and the README evidence-type legend.",
+    "0": "No unobscured images of the roof or parcel and no relevant building permits or assessor year-built data. No roof installation date is provided.",
+    "1": "(Future Release) No unobscured images and no relevant permits/assessor data, but aggregated supporting evidence from the area indicates the likely age of roofs nearby.",
+    "2": "No unobscured images of the roof or parcel, but relevant building permits and/or assessor year-built data provide an indication of the installation date.",
+    "3": "A single unobscured image of the roof. Roof change cannot be detected; a machine-learning model predicts the age from the image plus other sources (e.g. climate data). No supporting evidence corroborating the date.",
+    "4": "A single unobscured image of the roof (ML-predicted age, as in Type 3), with relevant building permits and/or assessor year-built data supporting the predicted installation date.",
+    "5": "Multiple unobscured images of the roof, no roof change detected between captures. A separate ML model predicts the age from imagery plus other sources. No supporting evidence corroborating the date.",
+    "6": "Multiple unobscured images of the roof, no roof change detected (ML-predicted age, as in Type 5), with relevant building permits and/or assessor year-built data supporting the predicted installation date.",
+    "7": "Multiple unobscured images of the roof. AI model detects a roof change between two captures; installation date is set as the mid-point of those captures. No supporting evidence corroborating the date.",
+    "8": "Multiple unobscured images of the roof, with detected roof change (mid-point installation date, as in Type 7), with relevant building permits and/or assessor year-built data supporting the predicted installation date."
+  }
+}

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -356,7 +356,7 @@
       "dtype": "float (quantised uint8)",
       "min": "0.0",
       "max": "1.0",
-      "description": "Confidence in detection of the {class_label_primary}.",
+      "description": "Confidence in detection of the {class_label_primary} (single feature, not combined).",
       "source": "base ai model"
     },
     "fidelity": {
@@ -364,7 +364,7 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "Quality of the vectorized footprint polygon for the {class_label_primary} (higher = better fidelity to the true outline). Only present on structural classes (e.g. building, roof).",
+      "description": "Quality of the shape of the vectorized footprint polygon (and implicitly the accuracy of the area measurement).",
       "source": "base ai model"
     },
     "has_3d_attributes": {
@@ -545,7 +545,7 @@
     "postcat": {
       "group": "feature_meta",
       "dtype": "Y/N",
-      "description": "Whether this feature comes from post-catastrophe imagery.",
+      "description": "Whether the resource was tagged as a post catastrophe survey.",
       "allowed_values": "Y | N",
       "source": "image metadata"
     },

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -10,7 +10,7 @@
     "mesh_date": {
       "group": "common",
       "dtype": "date",
-      "description": "Date of the Nearmap 3D data capture.",
+      "description": "Date of the 3D mesh used for 3D attributes (height, pitch, etc.). The mesh is usually comprised of a number of overlapping surveys captured at a similar time of year, so this date represents that capture window rather than a single survey.",
       "source": "image metadata"
     },
     "system_version": {
@@ -22,7 +22,7 @@
     "link": {
       "group": "common",
       "dtype": "URL",
-      "description": "URL to view the {class_label} in Nearmap MapBrowser. Per-class files (roof, building, etc.) frame the URL on each feature's centroid; the rollup frames it on the parcel.",
+      "description": "URL to view this row in Nearmap MapBrowser. Per-class files (roof, building, etc.) frame the URL on each feature's centroid; the rollup frames it on the parcel.",
       "source": "image metadata"
     },
     "streetAddress": {
@@ -347,7 +347,7 @@
     "is_primary": {
       "group": "feature_meta",
       "dtype": "Y/N",
-      "description": "Whether this feature is the parcel's primary feature for its class (selected by --primary-decision).",
+      "description": "Whether this feature is the parcel's primary feature for its class — selected by {primary_strategy_description} (see README → Primary Feature Selection).",
       "allowed_values": "Y | N",
       "source": "base ai model"
     },
@@ -357,46 +357,6 @@
       "min": "0.0",
       "max": "1.0",
       "description": "Confidence in detection of the {class_label_primary}.",
-      "source": "base ai model"
-    },
-    "roof_confidence": {
-      "group": "rollup_class_confidence",
-      "dtype": "float (quantised uint8)",
-      "min": "0.0",
-      "max": "1.0",
-      "description": "Combined confidence that at least one roof was detected on the parcel. When multiple roofs are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no roofs are detected.",
-      "source": "base ai model"
-    },
-    "building_confidence": {
-      "group": "rollup_class_confidence",
-      "dtype": "float (quantised uint8)",
-      "min": "0.0",
-      "max": "1.0",
-      "description": "Combined confidence that at least one building was detected on the parcel. When multiple buildings are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no buildings are detected.",
-      "source": "base ai model"
-    },
-    "building_lifecycle_confidence": {
-      "group": "rollup_class_confidence",
-      "dtype": "float (quantised uint8)",
-      "min": "0.0",
-      "max": "1.0",
-      "description": "Combined confidence that at least one building lifecycle feature was detected on the parcel. When multiple are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when none are detected.",
-      "source": "base ai model"
-    },
-    "swimming_pool_confidence": {
-      "group": "rollup_class_confidence",
-      "dtype": "float (quantised uint8)",
-      "min": "0.0",
-      "max": "1.0",
-      "description": "Combined confidence that at least one swimming pool was detected on the parcel. When multiple pools are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no pools are detected.",
-      "source": "base ai model"
-    },
-    "solar_panel_confidence": {
-      "group": "rollup_class_confidence",
-      "dtype": "float (quantised uint8)",
-      "min": "0.0",
-      "max": "1.0",
-      "description": "Combined confidence that at least one solar panel was detected on the parcel. When multiple panels are present, individual confidences are combined via the probabilistic union (noisy-OR): 1 - product(1 - confidence_i). Null when no panels are detected.",
       "source": "base ai model"
     },
     "fidelity": {
@@ -424,13 +384,13 @@
     "survey_date": {
       "group": "feature_meta",
       "dtype": "date",
-      "description": "Date the imagery was captured for this feature's source survey.",
+      "description": "Capture date of the 2D aerial imagery this feature was extracted from. Use as the canonical 'as-of' date for AI-derived attributes (counts, areas, materials, RSI, damage). May differ from mesh_date when 3D attributes draw on a different survey window.",
       "source": "image metadata"
     },
     "survey_resource_id": {
       "group": "feature_meta",
       "dtype": "UUID",
-      "description": "Survey resource UUID for the imagery.",
+      "description": "UUID of the specific imagery resource (the model dataset within a survey) that produced this row. Use this when reproducibility matters; survey_id can resolve to different resources over time as the API team publishes corrections.",
       "source": "image metadata"
     },
     "match_quality": {
@@ -445,52 +405,28 @@
       "description": "Source of the geocoded coordinates for an address-based query.",
       "source": "input data"
     },
-    "area_sqm": {
+    "area_{unit}": {
       "group": "feature_meta",
       "dtype": "float",
       "min": "0",
-      "unit": "square metres",
-      "description": "Area of the {class_label_primary}, in square metres.",
+      "unit": "{unit_name}",
+      "description": "Area of the {class_label_primary}, in {unit_name}.",
       "source": "base ai model"
     },
-    "area_sqft": {
+    "clipped_area_{unit}": {
       "group": "feature_meta",
       "dtype": "float",
       "min": "0",
-      "unit": "square feet",
-      "description": "Area of the {class_label_primary}, in square feet.",
+      "unit": "{unit_name}",
+      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in {unit_name}.",
       "source": "base ai model"
     },
-    "clipped_area_sqm": {
+    "unclipped_area_{unit}": {
       "group": "feature_meta",
       "dtype": "float",
       "min": "0",
-      "unit": "square metres",
-      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in square metres.",
-      "source": "base ai model"
-    },
-    "clipped_area_sqft": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "square feet",
-      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in square feet.",
-      "source": "base ai model"
-    },
-    "unclipped_area_sqm": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "square metres",
-      "description": "Total area of the {class_label_primary} before parcel clipping, in square metres.",
-      "source": "base ai model"
-    },
-    "unclipped_area_sqft": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "square feet",
-      "description": "Total area of the {class_label_primary} before parcel clipping, in square feet.",
+      "unit": "{unit_name}",
+      "description": "Total area of the {class_label_primary} before parcel clipping, in {unit_name}.",
       "source": "base ai model"
     },
     "resource_id": {
@@ -502,7 +438,7 @@
     "parent_building_id": {
       "group": "linkage",
       "dtype": "UUID",
-      "description": "Feature ID of the building this roof spatially matches (IoU-linked).",
+      "description": "Feature ID of the building this roof spatially matches, linked by IoU (Intersection over Union) overlap.",
       "source": "base ai model"
     },
     "parent_building_iou": {
@@ -510,7 +446,7 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "Intersection-over-Union score with the parent building (\u22650.005 to assign).",
+      "description": "IoU (Intersection over Union) score with the parent building (\u22650.005 to assign).",
       "source": "base ai model"
     },
     "parent_iou": {
@@ -518,13 +454,13 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "Intersection-over-Union score with the parent feature (\u22650.005 to assign).",
+      "description": "IoU (Intersection over Union) score with the parent feature (\u22650.005 to assign).",
       "source": "base ai model"
     },
     "primary_child_roof_id": {
       "group": "linkage",
       "dtype": "UUID",
-      "description": "Feature ID of this building's primary child roof (highest IoU above threshold).",
+      "description": "Feature ID of this building's primary child roof \u2014 highest IoU (Intersection over Union) above the linkage threshold.",
       "source": "base ai model"
     },
     "primary_child_roof_iou": {
@@ -532,13 +468,13 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "IoU between this building and its primary child roof.",
+      "description": "IoU (Intersection over Union) between this building and its primary child roof.",
       "source": "base ai model"
     },
     "primary_child_roof_age_feature_id": {
       "group": "linkage",
       "dtype": "UUID",
-      "description": "Feature ID of the roof age instance linked to this roof (highest IoU above 0.005).",
+      "description": "Feature ID of the roof age instance linked to this roof \u2014 highest IoU (Intersection over Union) above 0.005.",
       "source": "base ai model"
     },
     "primary_child_roof_age_iou": {
@@ -546,13 +482,13 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "IoU between this roof and its primary linked roof age instance.",
+      "description": "IoU (Intersection over Union) between this roof and its primary linked roof age instance.",
       "source": "base ai model"
     },
     "child_roofs": {
       "group": "linkage",
       "dtype": "JSON",
-      "description": "JSON list of all roofs linked to this building, sorted by IoU descending. Each item: `{feature_id, iou}`.",
+      "description": "JSON list of all roofs linked to this building, sorted by IoU (Intersection over Union) descending. Each item: `{feature_id, iou}`.",
       "source": "base ai model"
     },
     "child_roof_count": {
@@ -565,7 +501,7 @@
     "child_roof_instances": {
       "group": "linkage",
       "dtype": "JSON",
-      "description": "JSON list of all roof age instances linked to this roof, sorted by IoU descending. Each item: `{feature_id, iou, kind}`.",
+      "description": "JSON list of all roof age instances linked to this roof, sorted by IoU (Intersection over Union) descending. Each item: `{feature_id, iou, kind}`.",
       "source": "base ai model"
     },
     "child_roof_instance_count": {
@@ -597,7 +533,7 @@
     "survey_id": {
       "group": "query_input",
       "dtype": "UUID",
-      "description": "Survey identifier the AI features were drawn from.",
+      "description": "UUID of the logical survey from which AI features were drawn. Pairs with survey_date. Multiple resource versions can share one survey_id; use survey_resource_id for an exact reproducible reference to the model output.",
       "source": "image metadata"
     },
     "perspective": {
@@ -626,117 +562,6 @@
       "description": "Whether the Roof Age API call succeeded for this AOI.",
       "allowed_values": "Y | N",
       "source": "model metadata"
-    },
-    "installation_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Estimated roof installation date.",
-      "source": "roof age model"
-    },
-    "as_of_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Reference date for age calculation.",
-      "source": "roof age model"
-    },
-    "until_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Original requested cutoff (`untilAsOfDate`) before snapshot clamping. Un-prefixed; appears on roof age instance features. Null when no historical cutoff was applied.",
-      "source": "roof age model"
-    },
-    "trust_score": {
-      "group": "roof_age_bare",
-      "dtype": "int",
-      "min": "0",
-      "max": "100",
-      "description": "Reliability of age estimate.",
-      "source": "roof age model"
-    },
-    "evidence_type": {
-      "group": "roof_age_bare",
-      "dtype": "int",
-      "min": "0",
-      "max": "8",
-      "description": "How age was determined (numeric code; un-prefixed; appears on roof age instance features).",
-      "allowed_values": "0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8",
-      "source": "roof age model"
-    },
-    "evidence_type_description": {
-      "group": "roof_age_bare",
-      "dtype": "string",
-      "description": "Human-readable evidence description.",
-      "source": "roof age model"
-    },
-    "before_installation_capture_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Last capture before roof installation.",
-      "source": "roof age model"
-    },
-    "after_installation_capture_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "First capture after roof installation.",
-      "source": "roof age model"
-    },
-    "min_capture_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Earliest imagery capture date analyzed.",
-      "source": "roof age model"
-    },
-    "max_capture_date": {
-      "group": "roof_age_bare",
-      "dtype": "date",
-      "description": "Latest imagery capture date analyzed.",
-      "source": "roof age model"
-    },
-    "number_of_captures": {
-      "group": "roof_age_bare",
-      "dtype": "int",
-      "min": "0",
-      "description": "Number of aerial captures analyzed.",
-      "source": "roof age model"
-    },
-    "map_browser_url": {
-      "group": "roof_age_bare",
-      "dtype": "URL",
-      "description": "URL to view roof age timeline in MapBrowser.",
-      "source": "roof age model"
-    },
-    "model_version": {
-      "group": "roof_age_bare",
-      "dtype": "string",
-      "description": "Model version.",
-      "source": "model metadata"
-    },
-    "kind": {
-      "group": "roof_age_bare",
-      "dtype": "string",
-      "description": "Type of estimate. One of `roof` (roof section) or `parcel` (property-level). Un-prefixed; appears on roof age instance features.",
-      "allowed_values": "roof | parcel",
-      "source": "roof age model"
-    },
-    "relevant_permits": {
-      "group": "roof_age_bare",
-      "dtype": "Y/N",
-      "description": "Whether relevant building permits were found.",
-      "allowed_values": "Y | N",
-      "source": "roof age model"
-    },
-    "assessor_data": {
-      "group": "roof_age_bare",
-      "dtype": "Y/N",
-      "description": "Whether assessor records were found.",
-      "allowed_values": "Y | N",
-      "source": "roof age model"
-    },
-    "assessor_data_details": {
-      "group": "roof_age_bare",
-      "dtype": "JSON",
-      "description": "Details of assessor records.",
-      "source": "roof age model"
     },
     "internal_class_id": {
       "group": "feature_meta",
@@ -786,15 +611,23 @@
   },
   "patterns": [
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_zone_area_(?P<unit>sqft|sqm)$",
-      "dtype": "float",
-      "min": "0",
-      "unit": "{unit_name}",
-      "description": "Total area of defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "regex": "^(?P<feature_class>roof|building|building_lifecycle|swimming_pool|solar_panel)_confidence$",
+      "dtype": "float (quantised uint8)",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Combined confidence that at least one {feature_class} was detected on the parcel — higher when multiple high-confidence detections agree. Null when none are detected.",
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_defensible_space_area_(?P<unit>sqft|sqm)$",
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_zone_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit_name}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_defensible_space_area_(?P<unit>sqft|sqm)$",
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",
@@ -802,7 +635,7 @@
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_coverage_ratio$",
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_coverage_ratio$",
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
@@ -810,23 +643,23 @@
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_risk_object_area_(?P<unit>sqft|sqm)$",
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_risk_object_area_(?P<unit>sqft|sqm)$",
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",
-      "description": "Total area of all risk objects (vegetation, neighbouring roofs, yard debris, etc.) within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "description": "Total area of all risk objects (vegetation, neighbouring roofs, yard debris, etc.) within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit_name}.",
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_area_(?P<unit>sqft|sqm)$",
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_area_(?P<unit>sqft|sqm)$",
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",
-      "description": "Area of {risk_class} within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit}.",
+      "description": "Area of {risk_class} within defensible-space zone {zone_id} ({zone_band} from the structure) {ds_scope_phrasing}. In {unit_name}.",
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<roof_scope>primary_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_ratio$",
+      "regex": "^(?P<roof_scope>primary_roof_|aggregate_)?defensible_space_zone_(?P<zone_id>\\d+)_(?P<risk_class>.+?)_ratio$",
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
@@ -932,7 +765,7 @@
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",
-      "description": "Total area of {class} detected {scope_phrase}, in {unit}.",
+      "description": "Total area of {class} detected {scope_phrase}, in {unit_name}.",
       "source": "base ai model"
     },
     {
@@ -985,7 +818,7 @@
       "min": "0.0",
       "max": "1.0",
       "precision": "uint8 quantised (0-255 \u2192 0.0-1.0)",
-      "description": "Confidence in {class} classification {scope_phrase}. Aggregation when multiple detections contribute: probabilistic union 1 - product(1 - confidence_i) for top-level pack classes on the parcel (e.g. all roofs, all vegetation segments); maximum across detections for sub-attributes within a parent feature (e.g. staining detections on a roof). Null when the corresponding area is 0.",
+      "description": "Confidence in {class} classification {scope_phrase}. When multiple detections contribute: top-level feature classes on the parcel (e.g. all roofs, all vegetation segments) are combined so confidence rises with corroborating detections; sub-attributes within a parent feature (e.g. staining on a roof) take the maximum across detections. Null when the corresponding area is 0.",
       "source": "base ai model"
     },
     {

--- a/nmaipy/data_dictionary_generator.py
+++ b/nmaipy/data_dictionary_generator.py
@@ -1,20 +1,8 @@
-"""Data dictionary generator.
-
-Generates a ``<filename>_data_dictionary.csv`` next to every tabular AI-data
-output file in an nmaipy export ``final/`` directory. Each dictionary lists
-every column with description, allowed values, dtype, source, min, max, and
-precision — sourced from ``nmaipy/data/column_metadata.json`` via
-``column_metadata.lookup_column``.
-
-The set of files we emit dictionaries for is driven by the
-``nmaipy.output_files`` registry, gated on the export's ``tabular_file_format``
-(csv|parquet) so geoparquet companions and parallel format variants don't get
-redundant dictionaries.
-
-Mirrors the shape of ``ReadmeGenerator``: construct with ``output_dir``, call
-``generate_and_save()``. Failure is isolated and logged per-file; the export's
-primary contract is the data files themselves, and the README atomic write
-remains the "all done" sentinel.
+"""Generate ``<filename>_data_dictionary.csv`` next to every tabular AI-data
+output in an export ``final/`` directory. Columns are looked up via
+``column_metadata.lookup_column``; eligible files come from the
+``output_files`` registry, gated on the export's ``tabular_file_format``.
+Per-file failures are logged and isolated.
 """
 
 from __future__ import annotations
@@ -32,8 +20,6 @@ from nmaipy.column_metadata import lookup_column
 
 logger = logging.getLogger(__name__)
 
-# CSV column order in the generated data dictionaries. Matches the field
-# sequence requested in the INDS-2080 ticket.
 _DD_COLUMNS = [
     "column_name",
     "description",
@@ -77,10 +63,11 @@ class DataDictionaryGenerator:
         """Generate all data dictionaries for the export. Returns list of written paths."""
         ext = self._tabular_extension()
         area_unit = self._detect_area_unit()
+        extras = self._description_extras()
         written: list[str] = []
         for filepath, class_label in output_files.tabular_ai_files(self.final_dir, ext):
             try:
-                out_path = self._build_and_write(filepath, class_label, area_unit)
+                out_path = self._build_and_write(filepath, class_label, area_unit, extras)
             except Exception as exc:
                 logger.warning(f"Data dictionary generation failed for {filepath}: {exc}")
                 continue
@@ -114,6 +101,26 @@ class DataDictionaryGenerator:
         fmt = self._load_export_config().get("parameters", {}).get("tabular_file_format", "csv")
         return fmt if fmt in ("csv", "parquet") else "csv"
 
+    def _description_extras(self) -> dict[str, str]:
+        """Build the extra-substitution dict used by ``column_metadata.lookup_column``.
+
+        Currently surfaces the export's ``primary_decision`` strategy so that
+        descriptions like ``is_primary`` can render the actual selection
+        method ("optimal" / "nearest" / "largest_intersection") instead of
+        referencing a CLI flag the customer never sees.
+        """
+        params = self._load_export_config().get("parameters", {})
+        method = params.get("primary_decision") or "optimal"
+        method_descriptions = {
+            "optimal": "the optimal strategy (geocoded point preferred, falling back to largest intersection)",
+            "nearest": "the nearest-to-centroid strategy",
+            "largest_intersection": "the largest-intersection strategy",
+        }
+        return {
+            "primary_strategy": method,
+            "primary_strategy_description": method_descriptions.get(method, method),
+        }
+
     # ------------------------------------------------------------------
     # Schema reads
     # ------------------------------------------------------------------
@@ -140,23 +147,24 @@ class DataDictionaryGenerator:
     # Per-file dictionary build + write
     # ------------------------------------------------------------------
 
-    def _build_and_write(self, filepath: str, class_label: str, area_unit: str) -> Optional[str]:
+    def _build_and_write(
+        self, filepath: str, class_label: str, area_unit: str, extras: dict[str, str]
+    ) -> Optional[str]:
         columns = self._read_columns(filepath)
-        rows = [self._row_for_column(name, area_unit, class_label) for name in columns]
+        rows = [self._row_for_column(name, area_unit, class_label, extras) for name in columns]
         if not rows:
             return None
         out_path = self._dictionary_path_for(filepath)
         df = pd.DataFrame(rows, columns=_DD_COLUMNS)
-        # ``encoding="utf-8-sig"`` writes a BOM so Excel on macOS renders Unicode
-        # (em-dashes, etc.) correctly when opening the .csv. Pandas + fsspec
-        # handles ``s3://`` URIs natively — same idiom as the rollup write
-        # (exporter.py ``data.to_csv(outpath, ...)``).
+        # utf-8-sig writes a BOM so Excel on macOS renders Unicode correctly.
         df.to_csv(out_path, index=False, encoding="utf-8-sig")
         return out_path
 
-    def _row_for_column(self, name: str, area_unit: str, class_label: str) -> dict[str, str]:
+    def _row_for_column(
+        self, name: str, area_unit: str, class_label: str, extras: dict[str, str]
+    ) -> dict[str, str]:
         """Build a single dictionary row for one column."""
-        meta = lookup_column(name, area_unit=area_unit, class_label=class_label)
+        meta = lookup_column(name, area_unit=area_unit, class_label=class_label, extras=extras)
         return {
             "column_name": name,
             "description": meta.description,
@@ -177,17 +185,8 @@ class DataDictionaryGenerator:
         return storage.join_path(directory, f"{stem}_data_dictionary.csv")
 
 
-# ---------------------------------------------------------------------------
-# Module-level convenience
-# ---------------------------------------------------------------------------
-
 def generate_dictionaries(output_dir: str) -> list[str]:
-    """Generate dictionaries for an export. Returns list of written paths.
-
-    Wrapper around ``DataDictionaryGenerator(output_dir).generate_and_save()``
-    that swallows top-level errors and logs a warning, mirroring the
-    failure-isolation contract requested in the design.
-    """
+    """Generate dictionaries for an export, swallowing top-level errors. Returns written paths."""
     try:
         return DataDictionaryGenerator(output_dir=output_dir).generate_and_save()
     except Exception as exc:

--- a/nmaipy/data_dictionary_generator.py
+++ b/nmaipy/data_dictionary_generator.py
@@ -1,0 +1,285 @@
+"""Data dictionary generator.
+
+Generates a ``<filename>_data_dictionary.csv`` next to every CSV/parquet output
+file containing AI data in an nmaipy export ``final/`` directory. Each
+dictionary lists every column with description, allowed values, dtype, source,
+min, max, and precision — sourced from ``nmaipy/data/column_metadata.json``.
+
+Mirrors the shape of ``ReadmeGenerator``: construct with ``output_dir``, call
+``generate_and_save()``. Designed to be safe to call after the README has been
+written; failure is isolated and logged (the export's primary contract is the
+data files themselves).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+from nmaipy import storage
+from nmaipy.column_metadata import ColumnMeta, lookup_column
+
+logger = logging.getLogger(__name__)
+
+# CSV column order in the generated data dictionaries. Matches the field
+# sequence requested in the INDS-2080 ticket.
+_DD_COLUMNS = [
+    "column_name",
+    "description",
+    "allowed_values",
+    "dtype",
+    "source",
+    "min",
+    "max",
+    "precision",
+]
+
+# Files in ``final/`` that should NOT receive a data dictionary. Operational
+# telemetry, error files, and config files are excluded per ticket scope.
+_SKIP_BASENAMES = {
+    "README.md",
+    ".DS_Store",
+    "export_config.json",
+    "roof_age_export_config.json",
+    "classes_availability.json",
+    "latency_stats.csv",
+    "feature_api_errors.csv",
+    "feature_api_errors.parquet",
+    "roof_age_errors.csv",
+    "roof_age_errors.parquet",
+    "errors.csv",  # Roof Age standalone errors
+    "metadata.csv",  # Roof Age standalone — only aoi_id + resource_id
+}
+
+_SUPPORTED_EXTENSIONS = (".csv", ".parquet")
+
+# Filename stem (with optional ``_features`` suffix stripped) → human-readable class
+# label used in column descriptions. Per-class files map to their class. The rollup
+# is parcel-level (one row per parcel), so its label is ``"parcel"``. ``features``
+# is mixed-class and falls back to the generic ``"feature"``.
+_FILENAME_CLASS_LABELS = {
+    "building": "building",
+    "building_lifecycle": "building lifecycle",
+    "roof": "roof",
+    "roof_instance": "roof age instance",
+    "solar_panel": "solar panel",
+    "swimming_pool": "swimming pool",
+    "rollup": "parcel",
+}
+
+
+def _filename_to_class_label(filename: str) -> str:
+    """Infer a human-readable class label from an output filename.
+
+    ``building_features.parquet`` → ``"building"``;
+    ``roof_instance.csv``         → ``"roof age instance"``;
+    ``rollup.csv``                → ``"parcel"`` (one row per parcel);
+    ``features.parquet``          → ``"feature"`` (mixed-class, generic).
+    """
+    stem = filename.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    if stem.endswith("_features"):
+        stem = stem[: -len("_features")]
+    return _FILENAME_CLASS_LABELS.get(stem, "feature")
+
+
+class DataDictionaryGenerator:
+    """Generate per-output ``*_data_dictionary.csv`` files for an export directory."""
+
+    def __init__(self, output_dir: str):
+        """
+        Args:
+            output_dir: Path to the export directory. Either the full export root
+                (``output_dir/final``) or the ``final/`` directory itself; the
+                constructor finds the right one in the same way ``ReadmeGenerator``
+                does.
+        """
+        self.output_dir = str(output_dir)
+        self._is_s3 = storage.is_s3_path(self.output_dir)
+
+        # Resolve the actual directory containing the AI-data files.
+        potential_final = storage.join_path(self.output_dir, "final")
+        if not self._is_s3 and Path(potential_final).exists() and Path(potential_final).is_dir():
+            self.final_dir = potential_final
+        elif self._is_s3 and storage.glob_files(potential_final, "*"):
+            self.final_dir = potential_final
+        else:
+            self.final_dir = self.output_dir
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate_and_save(self) -> list[str]:
+        """Generate all data dictionaries for the export. Returns list of written paths."""
+        files = self._discover_files()
+        area_unit = self._detect_area_unit()
+        written: list[str] = []
+        for filepath in files:
+            try:
+                out_path = self._build_and_write(filepath, area_unit)
+            except Exception as exc:
+                logger.warning(f"Data dictionary generation failed for {filepath}: {exc}")
+                continue
+            if out_path is not None:
+                written.append(out_path)
+        return written
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def _discover_files(self) -> list[str]:
+        """Return paths of files in ``final/`` that should receive a data dictionary."""
+        candidates = storage.glob_files(self.final_dir, "*")
+        eligible: list[str] = []
+        for path in sorted(candidates):
+            name = storage.basename(path)
+            if name in _SKIP_BASENAMES:
+                continue
+            if name.endswith("_data_dictionary.csv"):
+                # Don't recursively generate dictionaries for previously-generated dictionaries.
+                continue
+            if not name.lower().endswith(_SUPPORTED_EXTENSIONS):
+                continue
+            eligible.append(path)
+        return eligible
+
+    # ------------------------------------------------------------------
+    # Area unit detection (mirrors ReadmeGenerator behaviour)
+    # ------------------------------------------------------------------
+
+    def _detect_area_unit(self) -> str:
+        """Detect 'sqft' (US) or 'sqm' (elsewhere) from export config; default sqft."""
+        for config_name in ("export_config.json", "roof_age_export_config.json"):
+            cfg_path = storage.join_path(self.final_dir, config_name)
+            if storage.file_exists(cfg_path):
+                try:
+                    with storage.open_file(cfg_path, "r") as fh:
+                        cfg = json.load(fh)
+                    country = cfg.get("parameters", {}).get("country", "").lower()
+                    if country and country != "us":
+                        return "sqm"
+                    return "sqft"
+                except Exception:
+                    continue
+        return "sqft"
+
+    # ------------------------------------------------------------------
+    # Schema reads
+    # ------------------------------------------------------------------
+
+    def _read_columns(self, filepath: str) -> list[str]:
+        """Return ordered column names from a CSV or parquet file."""
+        name = storage.basename(filepath).lower()
+        if name.endswith(".csv"):
+            with storage.open_file(filepath, "r") as fh:
+                df_head = pd.read_csv(fh, nrows=0)
+            return list(df_head.columns)
+        if name.endswith(".parquet"):
+            try:
+                with storage.open_file(filepath, "rb") as fh:
+                    schema = pq.read_schema(fh)
+                return list(schema.names)
+            except Exception:
+                # Fallback for any case where pq.read_schema can't take the file handle.
+                df_head = pd.read_parquet(filepath, columns=[])
+                return list(df_head.columns)
+        raise ValueError(f"Unsupported file extension for {filepath!r}.")
+
+    # ------------------------------------------------------------------
+    # Per-file dictionary build + write
+    # ------------------------------------------------------------------
+
+    def _build_and_write(self, filepath: str, area_unit: str) -> Optional[str]:
+        columns = self._read_columns(filepath)
+        class_label = _filename_to_class_label(storage.basename(filepath))
+        rows = [self._row_for_column(name, area_unit, class_label) for name in columns]
+        out_path = self._dictionary_path_for(filepath)
+        self._write_csv(out_path, rows)
+        return out_path
+
+    def _row_for_column(self, name: str, area_unit: str, class_label: str) -> dict[str, str]:
+        """Build a single dictionary row for one column."""
+        meta = lookup_column(name, area_unit=area_unit, class_label=class_label)
+        return {
+            "column_name": name,
+            "description": meta.description,
+            "allowed_values": meta.allowed_values,
+            "dtype": meta.dtype,
+            "source": meta.source,
+            "min": meta.min,
+            "max": meta.max,
+            "precision": meta.precision,
+        }
+
+    @staticmethod
+    def _dictionary_path_for(filepath: str) -> str:
+        """``rollup.csv`` → ``rollup_data_dictionary.csv``; ``foo.parquet`` → ``foo_data_dictionary.csv``."""
+        directory = filepath.rsplit("/", 1)[0] if "/" in filepath else "."
+        name = storage.basename(filepath)
+        stem = name.rsplit(".", 1)[0]
+        return storage.join_path(directory, f"{stem}_data_dictionary.csv")
+
+    @staticmethod
+    def _write_csv(path: str, rows: list[dict[str, str]]) -> None:
+        """Atomic write: write to ``<path>.tmp`` then replace. Skips if rows is empty.
+
+        Prepends a UTF-8 BOM (``\\ufeff``) so Excel — which still defaults to
+        Latin-1/MacRoman on macOS when opening .csv files without explicit hints
+        — recognises the encoding and renders em-dashes and other Unicode
+        characters correctly. Other tools (pandas, csv module, VS Code, Numbers)
+        ignore or silently consume the BOM.
+        """
+        if not rows:
+            return
+        tmp_path = f"{path}.tmp"
+        with storage.open_file(tmp_path, "w") as fh:
+            fh.write("﻿")
+            writer = csv.DictWriter(fh, fieldnames=_DD_COLUMNS)
+            writer.writeheader()
+            writer.writerows(rows)
+        # Atomic replace. ``storage.open_file`` for non-S3 paths writes to the
+        # local filesystem; for S3 it has already uploaded on close. Either way,
+        # rename the temp into place so a partial write never overwrites a
+        # previous good dictionary.
+        if storage.is_s3_path(path):
+            # S3 doesn't support atomic rename; the close above completed the
+            # upload, so just remove the tmp marker.
+            try:
+                storage.remove_file(tmp_path) if hasattr(storage, "remove_file") else None
+            except Exception:
+                pass
+            # Re-write to the final path. Acceptable for S3 since ListObjects
+            # is eventually consistent anyway.
+            with storage.open_file(path, "w") as fh:
+                fh.write("﻿")
+                writer = csv.DictWriter(fh, fieldnames=_DD_COLUMNS)
+                writer.writeheader()
+                writer.writerows(rows)
+        else:
+            Path(tmp_path).replace(Path(path))
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+def generate_dictionaries(output_dir: str) -> list[str]:
+    """Generate dictionaries for an export. Returns list of written paths.
+
+    Wrapper around ``DataDictionaryGenerator(output_dir).generate_and_save()``
+    that swallows top-level errors and logs a warning, mirroring the
+    failure-isolation contract requested in the design.
+    """
+    try:
+        return DataDictionaryGenerator(output_dir=output_dir).generate_and_save()
+    except Exception as exc:
+        logger.warning(f"Data dictionary generation failed for {output_dir}: {exc}")
+        return []

--- a/nmaipy/data_dictionary_generator.py
+++ b/nmaipy/data_dictionary_generator.py
@@ -1,30 +1,34 @@
 """Data dictionary generator.
 
-Generates a ``<filename>_data_dictionary.csv`` next to every CSV/parquet output
-file containing AI data in an nmaipy export ``final/`` directory. Each
-dictionary lists every column with description, allowed values, dtype, source,
-min, max, and precision — sourced from ``nmaipy/data/column_metadata.json``.
+Generates a ``<filename>_data_dictionary.csv`` next to every tabular AI-data
+output file in an nmaipy export ``final/`` directory. Each dictionary lists
+every column with description, allowed values, dtype, source, min, max, and
+precision — sourced from ``nmaipy/data/column_metadata.json`` via
+``column_metadata.lookup_column``.
+
+The set of files we emit dictionaries for is driven by the
+``nmaipy.output_files`` registry, gated on the export's ``tabular_file_format``
+(csv|parquet) so geoparquet companions and parallel format variants don't get
+redundant dictionaries.
 
 Mirrors the shape of ``ReadmeGenerator``: construct with ``output_dir``, call
-``generate_and_save()``. Designed to be safe to call after the README has been
-written; failure is isolated and logged (the export's primary contract is the
-data files themselves).
+``generate_and_save()``. Failure is isolated and logged per-file; the export's
+primary contract is the data files themselves, and the README atomic write
+remains the "all done" sentinel.
 """
 
 from __future__ import annotations
 
-import csv
 import json
 import logging
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
 import pandas as pd
 import pyarrow.parquet as pq
 
-from nmaipy import storage
-from nmaipy.column_metadata import ColumnMeta, lookup_column
+from nmaipy import output_files, storage
+from nmaipy.column_metadata import lookup_column
 
 logger = logging.getLogger(__name__)
 
@@ -40,53 +44,6 @@ _DD_COLUMNS = [
     "max",
     "precision",
 ]
-
-# Files in ``final/`` that should NOT receive a data dictionary. Operational
-# telemetry, error files, and config files are excluded per ticket scope.
-_SKIP_BASENAMES = {
-    "README.md",
-    ".DS_Store",
-    "export_config.json",
-    "roof_age_export_config.json",
-    "classes_availability.json",
-    "latency_stats.csv",
-    "feature_api_errors.csv",
-    "feature_api_errors.parquet",
-    "roof_age_errors.csv",
-    "roof_age_errors.parquet",
-    "errors.csv",  # Roof Age standalone errors
-    "metadata.csv",  # Roof Age standalone — only aoi_id + resource_id
-}
-
-_SUPPORTED_EXTENSIONS = (".csv", ".parquet")
-
-# Filename stem (with optional ``_features`` suffix stripped) → human-readable class
-# label used in column descriptions. Per-class files map to their class. The rollup
-# is parcel-level (one row per parcel), so its label is ``"parcel"``. ``features``
-# is mixed-class and falls back to the generic ``"feature"``.
-_FILENAME_CLASS_LABELS = {
-    "building": "building",
-    "building_lifecycle": "building lifecycle",
-    "roof": "roof",
-    "roof_instance": "roof age instance",
-    "solar_panel": "solar panel",
-    "swimming_pool": "swimming pool",
-    "rollup": "parcel",
-}
-
-
-def _filename_to_class_label(filename: str) -> str:
-    """Infer a human-readable class label from an output filename.
-
-    ``building_features.parquet`` → ``"building"``;
-    ``roof_instance.csv``         → ``"roof age instance"``;
-    ``rollup.csv``                → ``"parcel"`` (one row per parcel);
-    ``features.parquet``          → ``"feature"`` (mixed-class, generic).
-    """
-    stem = filename.rsplit("/", 1)[-1].rsplit(".", 1)[0]
-    if stem.endswith("_features"):
-        stem = stem[: -len("_features")]
-    return _FILENAME_CLASS_LABELS.get(stem, "feature")
 
 
 class DataDictionaryGenerator:
@@ -118,12 +75,12 @@ class DataDictionaryGenerator:
 
     def generate_and_save(self) -> list[str]:
         """Generate all data dictionaries for the export. Returns list of written paths."""
-        files = self._discover_files()
+        ext = self._tabular_extension()
         area_unit = self._detect_area_unit()
         written: list[str] = []
-        for filepath in files:
+        for filepath, class_label in output_files.tabular_ai_files(self.final_dir, ext):
             try:
-                out_path = self._build_and_write(filepath, area_unit)
+                out_path = self._build_and_write(filepath, class_label, area_unit)
             except Exception as exc:
                 logger.warning(f"Data dictionary generation failed for {filepath}: {exc}")
                 continue
@@ -132,44 +89,30 @@ class DataDictionaryGenerator:
         return written
 
     # ------------------------------------------------------------------
-    # Discovery
+    # Config-driven detection
     # ------------------------------------------------------------------
 
-    def _discover_files(self) -> list[str]:
-        """Return paths of files in ``final/`` that should receive a data dictionary."""
-        candidates = storage.glob_files(self.final_dir, "*")
-        eligible: list[str] = []
-        for path in sorted(candidates):
-            name = storage.basename(path)
-            if name in _SKIP_BASENAMES:
-                continue
-            if name.endswith("_data_dictionary.csv"):
-                # Don't recursively generate dictionaries for previously-generated dictionaries.
-                continue
-            if not name.lower().endswith(_SUPPORTED_EXTENSIONS):
-                continue
-            eligible.append(path)
-        return eligible
-
-    # ------------------------------------------------------------------
-    # Area unit detection (mirrors ReadmeGenerator behaviour)
-    # ------------------------------------------------------------------
-
-    def _detect_area_unit(self) -> str:
-        """Detect 'sqft' (US) or 'sqm' (elsewhere) from export config; default sqft."""
+    def _load_export_config(self) -> dict:
+        """Load export_config.json (or roof_age_export_config.json) if present."""
         for config_name in ("export_config.json", "roof_age_export_config.json"):
             cfg_path = storage.join_path(self.final_dir, config_name)
             if storage.file_exists(cfg_path):
                 try:
                     with storage.open_file(cfg_path, "r") as fh:
-                        cfg = json.load(fh)
-                    country = cfg.get("parameters", {}).get("country", "").lower()
-                    if country and country != "us":
-                        return "sqm"
-                    return "sqft"
+                        return json.load(fh)
                 except Exception:
                     continue
-        return "sqft"
+        return {}
+
+    def _detect_area_unit(self) -> str:
+        """Return ``'sqft'`` (US) or ``'sqm'`` (elsewhere) based on export config; default sqft."""
+        country = self._load_export_config().get("parameters", {}).get("country", "").lower()
+        return "sqm" if country and country != "us" else "sqft"
+
+    def _tabular_extension(self) -> str:
+        """Return ``'csv'`` or ``'parquet'`` based on the export's tabular_file_format setting."""
+        fmt = self._load_export_config().get("parameters", {}).get("tabular_file_format", "csv")
+        return fmt if fmt in ("csv", "parquet") else "csv"
 
     # ------------------------------------------------------------------
     # Schema reads
@@ -197,12 +140,18 @@ class DataDictionaryGenerator:
     # Per-file dictionary build + write
     # ------------------------------------------------------------------
 
-    def _build_and_write(self, filepath: str, area_unit: str) -> Optional[str]:
+    def _build_and_write(self, filepath: str, class_label: str, area_unit: str) -> Optional[str]:
         columns = self._read_columns(filepath)
-        class_label = _filename_to_class_label(storage.basename(filepath))
         rows = [self._row_for_column(name, area_unit, class_label) for name in columns]
+        if not rows:
+            return None
         out_path = self._dictionary_path_for(filepath)
-        self._write_csv(out_path, rows)
+        df = pd.DataFrame(rows, columns=_DD_COLUMNS)
+        # ``encoding="utf-8-sig"`` writes a BOM so Excel on macOS renders Unicode
+        # (em-dashes, etc.) correctly when opening the .csv. Pandas + fsspec
+        # handles ``s3://`` URIs natively — same idiom as the rollup write
+        # (exporter.py ``data.to_csv(outpath, ...)``).
+        df.to_csv(out_path, index=False, encoding="utf-8-sig")
         return out_path
 
     def _row_for_column(self, name: str, area_unit: str, class_label: str) -> dict[str, str]:
@@ -226,45 +175,6 @@ class DataDictionaryGenerator:
         name = storage.basename(filepath)
         stem = name.rsplit(".", 1)[0]
         return storage.join_path(directory, f"{stem}_data_dictionary.csv")
-
-    @staticmethod
-    def _write_csv(path: str, rows: list[dict[str, str]]) -> None:
-        """Atomic write: write to ``<path>.tmp`` then replace. Skips if rows is empty.
-
-        Prepends a UTF-8 BOM (``\\ufeff``) so Excel — which still defaults to
-        Latin-1/MacRoman on macOS when opening .csv files without explicit hints
-        — recognises the encoding and renders em-dashes and other Unicode
-        characters correctly. Other tools (pandas, csv module, VS Code, Numbers)
-        ignore or silently consume the BOM.
-        """
-        if not rows:
-            return
-        tmp_path = f"{path}.tmp"
-        with storage.open_file(tmp_path, "w") as fh:
-            fh.write("﻿")
-            writer = csv.DictWriter(fh, fieldnames=_DD_COLUMNS)
-            writer.writeheader()
-            writer.writerows(rows)
-        # Atomic replace. ``storage.open_file`` for non-S3 paths writes to the
-        # local filesystem; for S3 it has already uploaded on close. Either way,
-        # rename the temp into place so a partial write never overwrites a
-        # previous good dictionary.
-        if storage.is_s3_path(path):
-            # S3 doesn't support atomic rename; the close above completed the
-            # upload, so just remove the tmp marker.
-            try:
-                storage.remove_file(tmp_path) if hasattr(storage, "remove_file") else None
-            except Exception:
-                pass
-            # Re-write to the final path. Acceptable for S3 since ListObjects
-            # is eventually consistent anyway.
-            with storage.open_file(path, "w") as fh:
-                fh.write("﻿")
-                writer = csv.DictWriter(fh, fieldnames=_DD_COLUMNS)
-                writer.writeheader()
-                writer.writerows(rows)
-        else:
-            Path(tmp_path).replace(Path(path))
 
 
 # ---------------------------------------------------------------------------

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1978,18 +1978,13 @@ def parse_arguments():
         action="store_true",
     )
     parser.add_argument(
-        "--save-buildings",
-        help="If set, save a building-level geoparquet file with one row per building feature and associated attributes.",
-        action="store_true",
-    )
-    parser.add_argument(
         "--no-class-level-files",
         help="If set, disable per-feature-class tabular exports (e.g., roof.csv, roof_instance.csv). By default, these are enabled.",
         action="store_true",
     )
     parser.add_argument(
         "--tabular-file-format",
-        help="csv | parquet: Format for tabular output files — rollup, buildings, and per-class attribute files (defaults to csv)",
+        help="csv | parquet: Format for tabular output files — rollup and per-class attribute files (defaults to csv)",
         type=str,
         required=False,
         default="csv",
@@ -2194,7 +2189,6 @@ class NearmapAIExporter(BaseExporter):
         chunk_size=CHUNK_SIZE,
         include_parcel_geometry=False,
         save_features=False,
-        save_buildings=False,
         tabular_file_format="csv",
         cache_dir=None,
         no_cache=False,
@@ -2242,7 +2236,6 @@ class NearmapAIExporter(BaseExporter):
         self.threads = threads
         self.include_parcel_geometry = include_parcel_geometry
         self.save_features = save_features
-        self.save_buildings = save_buildings
         self.tabular_file_format = tabular_file_format
         self.cache_dir = cache_dir
         self.no_cache = no_cache
@@ -2311,7 +2304,6 @@ class NearmapAIExporter(BaseExporter):
             "chunk_size": chunk_size,
             "include_parcel_geometry": include_parcel_geometry,
             "save_features": save_features,
-            "save_buildings": save_buildings,
             "tabular_file_format": tabular_file_format,
             "cache_dir": str(cache_dir) if cache_dir else None,
             "no_cache": no_cache,
@@ -3699,13 +3691,12 @@ class NearmapAIExporter(BaseExporter):
         # Output file paths in final directory (no stem prefix — directory provides context)
         outpath = storage.join_path(self.final_path, f"rollup.{self.tabular_file_format}")
         outpath_features = storage.join_path(self.final_path, "features.parquet")
-        outpath_buildings = storage.join_path(self.final_path, f"buildings.{self.tabular_file_format}")
 
         # Check for existing output files and warn about overwriting.
         # We always rebuild from chunks (the source of truth) to avoid leaving
         # partial outputs from a previous interrupted run.
         existing_outputs = []
-        for check_path in [outpath, outpath_features, outpath_buildings]:
+        for check_path in [outpath, outpath_features]:
             if storage.file_exists(check_path):
                 existing_outputs.append(storage.basename(check_path))
         if existing_outputs:
@@ -4090,53 +4081,6 @@ class NearmapAIExporter(BaseExporter):
                 outpath_features,
             )
 
-            # If buildings export is enabled, process building features
-            if self.save_buildings:
-                self.logger.info(f"Saving building-level data as {self.tabular_file_format} to {outpath_buildings}")
-                # Define geoparquet path for buildings
-                outpath_buildings_geoparquet = storage.join_path(self.final_path, "building_features.parquet")
-
-                buildings_gdf = parcels.extract_building_features(
-                    parcels_gdf=aoi_gdf,
-                    features_gdf=None,
-                    country=self.country,
-                )
-                if len(buildings_gdf) > 0:
-                    # First, save the geoparquet version with intact geometries
-                    self.logger.info(f"Saving building-level data as geoparquet to {outpath_buildings_geoparquet}")
-                    try:
-                        # Save with explicit schema version for better QGIS compatibility
-                        # Requires geopandas >= 1.1.0
-                        try:
-                            storage.write_parquet(
-                                buildings_gdf,
-                                outpath_buildings_geoparquet,
-                                schema_version="1.0.0",
-                            )
-                        except (TypeError, ValueError) as e:
-                            # Fallback for older geopandas or pyarrow versions
-                            self.logger.debug(f"Could not use schema_version parameter: {e}. Falling back to default.")
-                            storage.write_parquet(buildings_gdf, outpath_buildings_geoparquet)
-                    except Exception as e:
-                        self.logger.error(f"Failed to save buildings geoparquet file: {str(e)}")
-
-                    # Then convert geodataframe to plain dataframe for tabular output
-                    # Keep geometry as WKT representation if needed
-                    buildings_df = pd.DataFrame(buildings_gdf)
-                    if "geometry" in buildings_df.columns:
-                        buildings_df["geometry"] = buildings_df.geometry.apply(lambda geom: geom.wkt if geom else None)
-
-                    # Save in the same format as rollup
-                    if self.tabular_file_format == "parquet":
-                        storage.write_parquet(buildings_df, outpath_buildings, index=True)
-                    elif self.tabular_file_format == "csv":
-                        buildings_df.to_csv(outpath_buildings, index=True)
-                    else:
-                        self.logger.info("Invalid output format specified for buildings - reverting to csv")
-                        buildings_df.to_csv(outpath_buildings, index=True)
-                else:
-                    self.logger.info(f"No building features found for {Path(aoi_path).stem}")
-
         # Per-class export: merge pre-computed per-class chunk files into final files.
         # Per-class data was computed in process_chunk() while feature data was still
         # in memory, avoiding the expensive re-read of features.parquet.
@@ -4216,7 +4160,6 @@ def main():
         chunk_size=args.chunk_size,
         include_parcel_geometry=args.include_parcel_geometry,
         save_features=args.save_features,
-        save_buildings=args.save_buildings,
         tabular_file_format=args.tabular_file_format,
         cache_dir=args.cache_dir,
         no_cache=args.no_cache,

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -114,6 +114,7 @@ from nmaipy.parcels import (
     resolve_footprint_rsi,
     resolve_scores_with_bl_fallback,
 )
+from nmaipy.data_dictionary_generator import DataDictionaryGenerator
 from nmaipy.readme_generator import ReadmeGenerator
 from nmaipy.roof_age_api import RoofAgeApi
 
@@ -1032,20 +1033,30 @@ def _compute_feature_class_data(
                 ri_batch[col] = class_features[col].values
                 added_cols.add(col)
 
-        # Add roof_age_ prefix to Roof Age API columns (whitelist).
-        # Only known Roof Age columns get prefixed; all other columns are ignored.
-        for col in class_features.columns:
-            if col in added_cols:
-                continue
-            if col in ROOF_AGE_PREFIX_COLUMNS:
+        # Add roof_age_ prefix to Roof Age API columns. Iterate the canonical
+        # ROOF_AGE_PREFIX_COLUMNS order so the per-class roof_instance file
+        # lands columns in the same documented sequence the rollup uses.
+        # ``years_as_of_date`` is a calculated field already prefixed
+        # ``roof_age_*`` upstream; surface it right after ``map_browser_url``
+        # to match the canonical ordering in flatten_roof_instance_attributes.
+        for col in ROOF_AGE_PREFIX_COLUMNS:
+            if col in class_features.columns:
                 dst = f"roof_age_{col}"
-            elif col.startswith("roof_age_"):
-                dst = col  # calculated fields like roof_age_years_as_of_date
-            else:
+                if dst not in added_cols:
+                    ri_batch[dst] = class_features[col].values
+                    added_cols.add(dst)
+            if col == "map_browser_url":
+                years_col = "roof_age_years_as_of_date"
+                if years_col in class_features.columns and years_col not in added_cols:
+                    ri_batch[years_col] = class_features[years_col].values
+                    added_cols.add(years_col)
+        # Sweep any remaining roof_age_* columns not covered above (e.g. cached
+        # variants or future additions); preserves source order for them.
+        for col in class_features.columns:
+            if col in added_cols or not col.startswith("roof_age_"):
                 continue
-            if dst not in added_cols:
-                ri_batch[dst] = class_features[col].values
-                added_cols.add(dst)
+            ri_batch[col] = class_features[col].values
+            added_cols.add(col)
 
         convert_bool_columns_to_yn(ri_batch)
 
@@ -1077,11 +1088,28 @@ def _compute_feature_class_data(
                 else features_gdf[features_gdf["class_id"] == ROOF_INSTANCE_CLASS_ID]
             )
             if len(roof_instances) > 0 and "feature_id" in roof_instances.columns:
-                # Build lookup table with primary_child_roof_age_ prefixed column names
+                # Build lookup table with primary_child_roof_age_ prefixed
+                # column names. Iterate canonical order so the resulting roof
+                # rows (and downstream building chain) sit in the documented
+                # roof-age sequence, not the parquet-read order.
                 ri_cols = ["feature_id"]
                 col_rename = {}
+                ordered_ri_keys: list[str] = []
+                for col in ROOF_AGE_PREFIX_COLUMNS:
+                    ordered_ri_keys.append(col)
+                    if col == "map_browser_url":
+                        ordered_ri_keys.append("roof_age_years_as_of_date")
+                # Append any other roof_age_* columns present on the source
+                # frame that aren't covered above (legacy/future).
                 for col in roof_instances.columns:
                     if col == "feature_id":
+                        continue
+                    if col in ROOF_AGE_PREFIX_COLUMNS or col == "roof_age_years_as_of_date":
+                        continue
+                    if col.startswith("roof_age_"):
+                        ordered_ri_keys.append(col)
+                for col in ordered_ri_keys:
+                    if col == "feature_id" or col not in roof_instances.columns:
                         continue
                     if col in ROOF_AGE_PREFIX_COLUMNS:
                         base = f"roof_age_{col}"
@@ -1461,11 +1489,25 @@ def _compute_feature_class_data(
                         # Create lookup from roof feature_id → roof's primary_child_roof_age_feature_id
                         roof_to_ri = roofs_linked.set_index("feature_id")["primary_child_roof_age_feature_id"].to_dict()
 
-                        # Roof age columns to link through (same as what roofs get)
+                        # Roof age columns to link through (same as what roofs
+                        # get). Iterate canonical order so building.csv lands
+                        # the chained columns in the documented sequence.
                         ri_cols = ["feature_id"]
                         col_rename = {}
+                        ordered_ri_keys: list[str] = []
+                        for col in ROOF_AGE_PREFIX_COLUMNS:
+                            ordered_ri_keys.append(col)
+                            if col == "map_browser_url":
+                                ordered_ri_keys.append("roof_age_years_as_of_date")
                         for col in roof_instances.columns:
                             if col == "feature_id":
+                                continue
+                            if col in ROOF_AGE_PREFIX_COLUMNS or col == "roof_age_years_as_of_date":
+                                continue
+                            if col.startswith("roof_age_"):
+                                ordered_ri_keys.append(col)
+                        for col in ordered_ri_keys:
+                            if col == "feature_id" or col not in roof_instances.columns:
                                 continue
                             if col in ROOF_AGE_PREFIX_COLUMNS:
                                 base = f"roof_age_{col}"
@@ -4124,6 +4166,14 @@ class NearmapAIExporter(BaseExporter):
             self.logger.info(f"Generated README: {storage.basename(str(readme_path))}")
         except Exception as e:
             self.logger.warning(f"README generation warning: {e}")
+
+        # Generate per-output data dictionaries. Failure isolated; the export's
+        # contract is the data files themselves, not the dictionary.
+        try:
+            written = DataDictionaryGenerator(output_dir=self.final_path).generate_and_save()
+            self.logger.info(f"Generated {len(written)} data dictionary file(s).")
+        except Exception as e:
+            self.logger.warning(f"Data dictionary generation warning: {e}")
 
 
 # Backward compatibility alias

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -4159,21 +4159,24 @@ class NearmapAIExporter(BaseExporter):
                 requested_class_ids=set(classes_df.index),
             )
 
-        # Generate README data dictionary
+        # Generate per-output data dictionaries first. Failure isolated; the
+        # export's contract is the data files themselves, not the dictionary.
+        try:
+            written = DataDictionaryGenerator(output_dir=self.final_path).generate_and_save()
+            self.logger.info(f"Generated {len(written)} data dictionary file(s).")
+        except Exception as e:
+            self.logger.warning(f"Data dictionary generation warning: {e}")
+
+        # README must be the LAST file written — _run_inner uses its presence
+        # as the "fully complete" marker that triggers the fast-path skip on
+        # re-runs (see exporter._run_inner). Anything written after this would
+        # silently miss regeneration on cached re-invocations.
         try:
             readme_gen = ReadmeGenerator(output_dir=self.final_path)
             readme_path = readme_gen.generate_and_save()
             self.logger.info(f"Generated README: {storage.basename(str(readme_path))}")
         except Exception as e:
             self.logger.warning(f"README generation warning: {e}")
-
-        # Generate per-output data dictionaries. Failure isolated; the export's
-        # contract is the data files themselves, not the dictionary.
-        try:
-            written = DataDictionaryGenerator(output_dir=self.final_path).generate_and_save()
-            self.logger.info(f"Generated {len(written)} data dictionary file(s).")
-        except Exception as e:
-            self.logger.warning(f"Data dictionary generation warning: {e}")
 
 
 # Backward compatibility alias

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -896,13 +896,18 @@ def flatten_roof_instance_attributes(
         prefix: Optional prefix for flattened keys (e.g., "primary_child_")
 
     Returns:
-        Flattened dictionary with roof instance attributes
+        Flattened dictionary with every canonical ``roof_age_*`` key. Keys absent
+        from the input arrive as ``None`` so downstream DataFrame assembly
+        preserves canonical column ordering even when individual rows are
+        missing fields (pandas builds columns from first-seen-key order across
+        rows).
 
     Example:
         >>> instance = {"installation_date": "2019-06", "trust_score": 0.85, "evidence_type": 1}
         >>> attrs = flatten_roof_instance_attributes(instance, country="us")
-        >>> print(attrs)
-        {'roof_age_installation_date': '2019-06', 'roof_age_trust_score': 0.85, 'roof_age_evidence_type': 1}
+        >>> attrs["roof_age_installation_date"], attrs["roof_age_trust_score"]
+        ('2019-06', 0.85)
+        >>> attrs["roof_age_until_date"]  # not in input, emitted as None
     """
     flattened = {}
 

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -114,6 +114,7 @@ INCLUDE_FIELD_MAPPINGS = {
             "vulnerabilityScore": "hurricane_vulnerability_score",
             "vulnerabilityProbability": "hurricane_vulnerability_probability",
             "vulnerabilityRateFactor": "hurricane_vulnerability_rate_factor",
+            "femaVersion": "hurricane_fema_version",
         },
     },
     "windScore": {
@@ -126,6 +127,7 @@ INCLUDE_FIELD_MAPPINGS = {
             "riskScore": "wind_risk_score",
             "riskRateFactor": "wind_risk_rate_factor",
             "femaAnnualWindFrequency": "wind_fema_annual_frequency",
+            "femaVersion": "wind_fema_version",
         },
     },
     "hailScore": {
@@ -138,6 +140,7 @@ INCLUDE_FIELD_MAPPINGS = {
             "riskScore": "hail_risk_score",
             "riskRateFactor": "hail_risk_rate_factor",
             "femaAnnualHailFrequency": "hail_fema_annual_frequency",
+            "femaVersion": "hail_fema_version",
         },
     },
     "wildfireScore": {
@@ -148,6 +151,7 @@ INCLUDE_FIELD_MAPPINGS = {
             "vulnerabilityProbability": "wildfire_vulnerability_probability",
             "vulnerabilityRateFactor": "wildfire_vulnerability_rate_factor",
             "femaAnnualWildfireFrequency": "wildfire_fema_annual_frequency",
+            "femaVersion": "wildfire_fema_version",
         },
     },
     # windHailRisk is a composed risk score (not a vulnerability score like the four perils above),
@@ -914,27 +918,27 @@ def flatten_roof_instance_attributes(
                 return roof_instance.get(key)
         return None
 
-    # Get keys from the instance
-    keys = roof_instance.keys() if isinstance(roof_instance, dict) else roof_instance.index
-
-    # Generic loop: add roof_age_ prefix to all non-standard columns
+    # Iterate the canonical ROOF_AGE_PREFIX_COLUMNS order so output columns
+    # land in a stable, documented sequence regardless of the order the API
+    # response presents them in. Always emit every canonical key (None when
+    # absent) so downstream DataFrame assembly preserves canonical column
+    # order even when individual rows are missing fields — pandas builds
+    # DataFrame columns from first-seen-key order across rows.
     installation_date = None
     as_of_date = None
-    for key in keys:
-        if key not in ROOF_AGE_PREFIX_COLUMNS:
-            continue
+    for key in ROOF_AGE_PREFIX_COLUMNS:
         value = get_value(key)
-        if value is None or (isinstance(value, float) and pd.isna(value)):
-            continue
+        is_missing = value is None or (isinstance(value, float) and pd.isna(value))
         output_key = f"{prefix}roof_age_{key}"
-        if key in boolean_fields:
+        if is_missing:
+            flattened[output_key] = None
+        elif key in boolean_fields:
             flattened[output_key] = TRUE_STRING if value else FALSE_STRING
         else:
             flattened[output_key] = value
-        # Track values needed for calculated fields
-        if key == "installation_date":
+        if key == "installation_date" and not is_missing:
             installation_date = value
-        elif key == "as_of_date":
+        elif key == "as_of_date" and not is_missing:
             as_of_date = value
 
     # Legacy fallback: untilDate → as_of_date for cached API responses
@@ -943,10 +947,21 @@ def flatten_roof_instance_attributes(
         if as_of_date is not None:
             flattened[f"{prefix}roof_age_as_of_date"] = as_of_date
 
-    # Calculate roof age in years as of as_of_date
+    # Calculate roof age in years as of as_of_date. Inserted right after
+    # ``map_browser_url`` so the canonical sequence reads:
+    #   map_browser_url → years_as_of_date → installation_date → ...
     age_years = calculate_roof_age_years(installation_date, as_of_date)
     if age_years is not None:
-        flattened[f"{prefix}roof_age_years_as_of_date"] = age_years
+        ordered = {}
+        url_key = f"{prefix}roof_age_map_browser_url"
+        years_key = f"{prefix}roof_age_years_as_of_date"
+        for k, v in flattened.items():
+            ordered[k] = v
+            if k == url_key:
+                ordered[years_key] = age_years
+        if years_key not in ordered:
+            ordered[years_key] = age_years
+        flattened = ordered
     return flattened
 
 

--- a/nmaipy/output_files.py
+++ b/nmaipy/output_files.py
@@ -1,0 +1,150 @@
+"""Registry of files the nmaipy exporter is allowed to produce.
+
+Single source of truth used by `readme_generator` and `data_dictionary_generator`.
+Adding a new output file should be a one-line entry here, not a distributed
+update across blacklists/whitelists in multiple modules.
+
+The `kind` field drives downstream behaviour:
+- ``ai_data``     → has columns (rollup, per-class tabular); gets a data
+                    dictionary.
+- ``geometry``    → geoparquet with geometry; listed in README, no dictionary.
+- ``operational`` → telemetry / errors; listed in README, no dictionary.
+- ``config``      → input metadata; not listed in the README's file table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from nmaipy import storage
+
+
+@dataclass(frozen=True)
+class FileSpec:
+    """Metadata for one file produced by the exporter."""
+
+    description: str
+    kind: str
+    class_label: Optional[str] = None
+    is_per_class: bool = False
+
+
+# Static-name files. Stems only — extension is set by `tabular_file_format` for
+# `ai_data` files (csv|parquet), fixed for the rest.
+STATIC_FILES: dict[str, FileSpec] = {
+    "rollup": FileSpec(
+        description="Property-level summary with one row per property containing aggregated statistics",
+        kind="ai_data",
+        class_label="property",
+    ),
+    "buildings": FileSpec(
+        description="Building-level summary (one row per building; present when --save-buildings is set)",
+        kind="ai_data",
+        class_label="building",
+    ),
+    "features": FileSpec(
+        description="All detected features with geometry (GeoParquet)",
+        kind="geometry",
+    ),
+    "feature_api_errors": FileSpec(
+        description="Properties where Feature API calls failed",
+        kind="operational",
+    ),
+    "roof_age_errors": FileSpec(
+        description="Properties where Roof Age API calls failed",
+        kind="operational",
+    ),
+    "latency_stats": FileSpec(
+        description="API call timing statistics",
+        kind="operational",
+    ),
+    "classes_availability": FileSpec(
+        description="Available feature classes per AOI",
+        kind="operational",
+    ),
+    "export_config": FileSpec(
+        description="Parameters used to produce this export",
+        kind="config",
+    ),
+    "roof_age_export_config": FileSpec(
+        description="Parameters used to produce this Roof Age export",
+        kind="config",
+    ),
+}
+
+# Per-class file stems → human-readable class label.
+# Labels must match keys in `column_metadata._SCOPE_PHRASES` so that the
+# `{class_label}` substitution path in `lookup_column` resolves consistently.
+PER_CLASS_LABELS: dict[str, str] = {
+    "building": "building",
+    "building_lifecycle": "building lifecycle",
+    "roof": "roof",
+    "roof_instance": "roof age instance",
+    "swimming_pool": "swimming pool",
+    "solar_panel": "solar panel",
+}
+
+
+def file_spec_for(filename: str) -> Optional[FileSpec]:
+    """Return the `FileSpec` for a given basename, or None if not in the registry.
+
+    Recognises:
+    - ``<stem>.<ext>`` for stems in `STATIC_FILES` (any extension).
+    - ``<cname>.csv`` / ``<cname>.parquet`` for cnames in `PER_CLASS_LABELS`
+      (per-class tabular AI data).
+    - ``<cname>_features.parquet`` for cnames in `PER_CLASS_LABELS` (per-class
+      geometry / GeoParquet).
+    """
+    if "." not in filename:
+        return None
+    stem, ext = filename.rsplit(".", 1)
+    if stem in STATIC_FILES:
+        return STATIC_FILES[stem]
+    if stem in PER_CLASS_LABELS and ext in ("csv", "parquet"):
+        label = PER_CLASS_LABELS[stem]
+        return FileSpec(
+            description=f"Per-{label} data with feature attributes",
+            kind="ai_data",
+            class_label=label,
+            is_per_class=True,
+        )
+    if ext == "parquet" and stem.endswith("_features"):
+        cname = stem[: -len("_features")]
+        if cname in PER_CLASS_LABELS:
+            label = PER_CLASS_LABELS[cname]
+            return FileSpec(
+                description=f"{label.capitalize()} polygons with geometry (GeoParquet)",
+                kind="geometry",
+                class_label=label,
+                is_per_class=True,
+            )
+    return None
+
+
+def tabular_ai_files(final_dir: str, ext: str) -> list[tuple[str, str]]:
+    """Enumerate tabular AI-data files that exist on disk under `final_dir`.
+
+    Args:
+        final_dir: Path to the export's ``final/`` directory (local or ``s3://``).
+        ext: Tabular extension to look for — ``"csv"`` or ``"parquet"``. Comes from
+            the export config's ``tabular_file_format``.
+
+    Returns:
+        ``[(filepath, class_label), ...]`` for each registry entry whose file
+        exists at ``final_dir/<stem>.<ext>``. Used by the data dictionary
+        generator to emit one dictionary per logical class file (no duplication
+        across CSV+parquet variants, no geoparquet companions).
+    """
+    out: list[tuple[str, str]] = []
+    for stem, spec in STATIC_FILES.items():
+        if spec.kind != "ai_data":
+            continue
+        path = storage.join_path(final_dir, f"{stem}.{ext}")
+        if storage.file_exists(path):
+            out.append((path, spec.class_label or "property"))
+    for cname, label in PER_CLASS_LABELS.items():
+        path = storage.join_path(final_dir, f"{cname}.{ext}")
+        if storage.file_exists(path):
+            out.append((path, label))
+    return out

--- a/nmaipy/output_files.py
+++ b/nmaipy/output_files.py
@@ -1,12 +1,9 @@
-"""Registry of files the nmaipy exporter is allowed to produce.
+"""Registry of files the nmaipy exporter produces. Consumed by
+``readme_generator`` and ``data_dictionary_generator`` so output file metadata
+lives in one place.
 
-Single source of truth used by `readme_generator` and `data_dictionary_generator`.
-Adding a new output file should be a one-line entry here, not a distributed
-update across blacklists/whitelists in multiple modules.
-
-The `kind` field drives downstream behaviour:
-- ``ai_data``     → has columns (rollup, per-class tabular); gets a data
-                    dictionary.
+``kind`` drives downstream behaviour:
+- ``ai_data``     → has columns; gets a data dictionary.
 - ``geometry``    → geoparquet with geometry; listed in README, no dictionary.
 - ``operational`` → telemetry / errors; listed in README, no dictionary.
 - ``config``      → input metadata; not listed in the README's file table.
@@ -18,6 +15,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from nmaipy import storage
+from nmaipy.column_metadata import PER_CLASS_LABELS
 
 
 @dataclass(frozen=True)
@@ -28,20 +26,18 @@ class FileSpec:
     kind: str
     class_label: Optional[str] = None
     is_per_class: bool = False
+    list_in_readme: bool = True
 
 
-# Static-name files. Stems only — extension is set by `tabular_file_format` for
-# `ai_data` files (csv|parquet), fixed for the rest.
+# Static-name files. Per-class files are derived from PER_CLASS_LABELS in
+# ``file_spec_for``. Extension for ``ai_data`` files is the export's
+# ``tabular_file_format``; other entries are fixed-extension.
 STATIC_FILES: dict[str, FileSpec] = {
     "rollup": FileSpec(
-        description="Property-level summary with one row per property containing aggregated statistics",
+        description="Property-level summary with one row per parcel containing aggregated statistics",
         kind="ai_data",
-        class_label="property",
-    ),
-    "buildings": FileSpec(
-        description="Building-level summary (one row per building; present when --save-buildings is set)",
-        kind="ai_data",
-        class_label="building",
+        # "parcel" triggers parcel-aggregate scope phrasing in column_metadata.lookup_column.
+        class_label="parcel",
     ),
     "features": FileSpec(
         description="All detected features with geometry (GeoParquet)",
@@ -66,23 +62,13 @@ STATIC_FILES: dict[str, FileSpec] = {
     "export_config": FileSpec(
         description="Parameters used to produce this export",
         kind="config",
+        list_in_readme=False,
     ),
     "roof_age_export_config": FileSpec(
         description="Parameters used to produce this Roof Age export",
         kind="config",
+        list_in_readme=False,
     ),
-}
-
-# Per-class file stems → human-readable class label.
-# Labels must match keys in `column_metadata._SCOPE_PHRASES` so that the
-# `{class_label}` substitution path in `lookup_column` resolves consistently.
-PER_CLASS_LABELS: dict[str, str] = {
-    "building": "building",
-    "building_lifecycle": "building lifecycle",
-    "roof": "roof",
-    "roof_instance": "roof age instance",
-    "swimming_pool": "swimming pool",
-    "solar_panel": "solar panel",
 }
 
 
@@ -95,7 +81,14 @@ def file_spec_for(filename: str) -> Optional[FileSpec]:
       (per-class tabular AI data).
     - ``<cname>_features.parquet`` for cnames in `PER_CLASS_LABELS` (per-class
       geometry / GeoParquet).
+    - ``*_data_dictionary.csv`` — auto-generated sidecar; not listed.
     """
+    if filename.endswith("_data_dictionary.csv"):
+        return FileSpec(
+            description="Auto-generated data dictionary describing the columns of the matching output file",
+            kind="documentation",
+            list_in_readme=False,
+        )
     if "." not in filename:
         return None
     stem, ext = filename.rsplit(".", 1)
@@ -123,18 +116,8 @@ def file_spec_for(filename: str) -> Optional[FileSpec]:
 
 
 def tabular_ai_files(final_dir: str, ext: str) -> list[tuple[str, str]]:
-    """Enumerate tabular AI-data files that exist on disk under `final_dir`.
-
-    Args:
-        final_dir: Path to the export's ``final/`` directory (local or ``s3://``).
-        ext: Tabular extension to look for — ``"csv"`` or ``"parquet"``. Comes from
-            the export config's ``tabular_file_format``.
-
-    Returns:
-        ``[(filepath, class_label), ...]`` for each registry entry whose file
-        exists at ``final_dir/<stem>.<ext>``. Used by the data dictionary
-        generator to emit one dictionary per logical class file (no duplication
-        across CSV+parquet variants, no geoparquet companions).
+    """Return ``[(filepath, class_label), ...]`` for tabular AI-data files
+    present at ``final_dir/<stem>.<ext>``. ``ext`` is ``csv`` or ``parquet``.
     """
     out: list[tuple[str, str]] = []
     for stem, spec in STATIC_FILES.items():
@@ -142,7 +125,7 @@ def tabular_ai_files(final_dir: str, ext: str) -> list[tuple[str, str]]:
             continue
         path = storage.join_path(final_dir, f"{stem}.{ext}")
         if storage.file_exists(path):
-            out.append((path, spec.class_label or "property"))
+            out.append((path, spec.class_label or "parcel"))
     for cname, label in PER_CLASS_LABELS.items():
         path = storage.join_path(final_dir, f"{cname}.{ext}")
         if storage.file_exists(path):

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -73,7 +73,6 @@ logger = log.get_logger()
 __all__ = [
     "read_from_file",
     "parcel_rollup",
-    "extract_building_features",
     "feature_attributes",
     "link_roof_instances_to_roofs",
     "link_roofs_to_buildings",
@@ -1276,112 +1275,6 @@ def feature_attributes(
                     parcel[f"{field}_area_weighted_mean"] = float(np.dot(arr, a) / t)
 
     return parcel
-
-
-def extract_building_features(
-    parcels_gdf: gpd.GeoDataFrame,
-    features_gdf: gpd.GeoDataFrame,
-    country: str,
-) -> gpd.GeoDataFrame:
-    """
-    Extract building-related features and their attributes to create a building-level export. Note that this gets all building like features, not strictly buildings.
-
-    Args:
-        parcels_gdf: GeoDataFrame with AOI information
-        features_gdf: GeoDataFrame with all features
-        country: Country code for units
-
-    Returns:
-        GeoDataFrame with one row per building style feature, including geometry and attributes
-    """
-    if features_gdf is None or len(features_gdf) == 0:
-        return gpd.GeoDataFrame()
-
-    # Filter for building-style features only
-    building_gdf = features_gdf[features_gdf.class_id.isin(BUILDING_STYLE_CLASS_IDS)].copy()
-
-    if len(building_gdf) == 0:
-        return gpd.GeoDataFrame()
-
-    # Create a list to store processed building records
-    building_records = []
-
-    # Process each building feature
-    for idx, building in building_gdf.iterrows():
-        # Get AOI ID
-        aoi_id = building.name if hasattr(building, "name") else idx
-
-        # Start with basic feature info. Emit only the country-correct unit family,
-        # matching rollup behaviour.
-        suffix = country_area_suffix(country)
-        area_col = f"area_{suffix}"
-        clipped_col = f"clipped_area_{suffix}"
-        unclipped_col = f"unclipped_area_{suffix}"
-        building_record = {
-            AOI_ID_COLUMN_NAME: aoi_id,
-            "feature_id": building.feature_id,
-            "class_id": building.class_id,
-            "description": building.description,
-            "confidence": building.confidence,
-            "fidelity": building.fidelity if hasattr(building, "fidelity") else None,
-            area_col: getattr(building, area_col, None),
-            clipped_col: getattr(building, clipped_col, None),
-            unclipped_col: getattr(building, unclipped_col, None),
-            "survey_date": (building.survey_date if hasattr(building, "survey_date") else None),
-            "mesh_date": building.mesh_date if hasattr(building, "mesh_date") else None,
-            "geometry": building.geometry,
-            "is_primary": (building.is_primary if hasattr(building, "is_primary") else False),
-        }
-        if hasattr(building, "parent_id"):
-            building_record["parent_id"] = building.parent_id
-
-        # Preserve damage field for building lifecycle features
-        if hasattr(building, "damage") and building.damage is not None:
-            building_record["damage"] = building.damage
-
-        # Flatten attributes based on the class type
-        try:
-            if building.class_id == ROOF_ID:
-                # For roof attributes, don't wrap in a list if it's already a list
-                # This is the key fix - roof attributes should be processed as they are
-                if isinstance(building, list):
-                    flat_attrs = flatten_roof_attributes(building, country=country)
-                else:
-                    flat_attrs = flatten_roof_attributes([building], country=country)
-
-                for k, v in flat_attrs.items():
-                    building_record[k] = v
-            elif building.class_id == BUILDING_NEW_ID:
-                flat_attrs = flatten_building_attributes([building], country=country)
-                for k, v in flat_attrs.items():
-                    building_record[k] = v
-            elif building.class_id == BUILDING_LIFECYCLE_ID:
-                flat_attrs = flatten_building_lifecycle_damage_attributes([building])
-                for k, v in flat_attrs.items():
-                    building_record[k] = v
-        except Exception as e:
-            # If any issues processing attributes, log and continue
-            logger.warning(f"Error processing attributes for feature {building.feature_id}: {str(e)}")
-
-        building_records.append(building_record)
-
-    if not building_records:
-        return gpd.GeoDataFrame()
-
-    # Create GeoDataFrame from building records
-    buildings_df = gpd.GeoDataFrame(building_records, geometry="geometry", crs=API_CRS)
-
-    # Add AOI information if available (merge on AOI ID)
-    if parcels_gdf is not None:
-        # Identify columns from parcels_gdf to include (exclude geometry to avoid conflicts)
-        parcel_cols = [col for col in parcels_gdf.columns if col != "geometry"]
-        if parcel_cols:
-            # Create copy with reset index to allow merging
-            parcel_info = parcels_gdf.reset_index()[parcel_cols + [AOI_ID_COLUMN_NAME]]
-            # Merge with buildings dataframe
-            buildings_df = buildings_df.merge(parcel_info, on=AOI_ID_COLUMN_NAME, how="left")
-
-    return buildings_df
 
 
 def parcel_rollup(

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -32,209 +32,21 @@ FILE_PATTERNS = {
 EXCLUDE_FILES = {"README.md", ".DS_Store", "export_config.json"}
 
 # ---------------------------------------------------------------------------
-# Column metadata schema
+# Column metadata
 # ---------------------------------------------------------------------------
-# Each entry is a (dtype, min, max, unit, description) tuple. The render
-# helpers emit a 6-column markdown table:
-# | Column | Type | Min | Max | Unit | Description |.
-#
-# Min and Max are stored as strings so the `—` sentinel can mean "no bound /
-# not applicable" alongside actual numeric bounds.
-#
-# Conventions:
-#   - dtype: short type label — int, float, string, Y/N, date, JSON, UUID,
-#            URL, WKT. Use "float (quantised uint8)" for confidence scores
-#            since the wire format is uint8 even though the value space is
-#            documented as a 0.0–1.0 fraction.
-#   - min / max: numerical lower / upper bound as strings, or "—" when no
-#            bound applies (strings, IDs, unbounded counts).
-#   - unit:  physical unit — "{unit_name}" for area columns (substituted with
-#            "square feet" or "square metres" depending on country), "years",
-#            "degrees", or "—" when unitless.
-#   - description: short human-readable description (no inline range/unit;
-#            the dedicated columns already carry that info). For enums, the
-#            allowed values go in the description.
+# Source of truth lives in nmaipy/data/column_metadata.json and is loaded by
+# nmaipy.column_metadata. This module re-imports the per-section dicts so
+# downstream callers (and tests) can keep using the historical names.
 # ---------------------------------------------------------------------------
-
-# Common columns always present
-COMMON_COLUMNS = {
-    "aoi_id": (
-        "string \\| int",
-        "—",
-        "—",
-        "—",
-        "Property identifier. If the input file had an `aoi_id` column it is preserved; otherwise generated from row index (0-indexed).",
-    ),
-    "mesh_date": ("date", "—", "—", "—", "Date of AI model processing"),
-    "system_version": ("string", "—", "—", "—", "AI model version used for detection"),
-    "link": ("URL", "—", "—", "—", "URL to view property in Nearmap MapBrowser"),
-}
-
-# Address and query columns produced by nmaipy
-ADDRESS_QUERY_COLUMNS = {
-    "streetAddress": ("string", "—", "—", "—", "Street address from input (used for address-based API queries)"),
-    "city": ("string", "—", "—", "—", "City from input (used for address-based API queries)"),
-    "state": ("string", "—", "—", "—", "State from input (used for address-based API queries)"),
-    "zip": ("string", "—", "—", "—", "ZIP/postal code from input (used for address-based API queries)"),
-    "query_aoi_lat": ("float", "−90.0", "90.0", "degrees", "Representative latitude of the query AOI geometry"),
-    "query_aoi_lon": ("float", "−180.0", "180.0", "degrees", "Representative longitude of the query AOI geometry"),
-    "lat": ("float", "−90.0", "90.0", "degrees", "Input latitude used for primary feature selection"),
-    "lon": ("float", "−180.0", "180.0", "degrees", "Input longitude used for primary feature selection"),
-}
-
-# Roof Spotlight Index columns
-RSI_COLUMNS = {
-    "roof_spotlight_index": ("float", "0", "100", "—", "Roof condition score (higher = better condition)"),
-    "roof_spotlight_index_confidence": (
-        "float (quantised uint8)",
-        "0.0",
-        "1.0",
-        "—",
-        "Confidence in RSI score",
-    ),
-}
-
-# Dominant material/shape summary columns
-DOMINANT_ROOF_MATERIAL_COLUMNS = {
-    "dominant_roof_material_feature_class": (
-        "UUID",
-        "—",
-        "—",
-        "—",
-        "Feature class UUID of the dominant roof material",
-    ),
-    "dominant_roof_material_description": (
-        "string",
-        "—",
-        "—",
-        "—",
-        "Snake_case name of the `description` field of the dominant material feature class (or `unknown` if ratio < 0.5)",
-    ),
-    "dominant_roof_material_area_{unit}": (
-        "float",
-        "0",
-        "—",
-        "{unit_name}",
-        "Area of the dominant material component",
-    ),
-    "dominant_roof_material_ratio": (
-        "float",
-        "0.0",
-        "1.0",
-        "—",
-        "Ratio of the dominant material relative to total roof area",
-    ),
-    "dominant_roof_material_confidence": (
-        "float (quantised uint8)",
-        "0.0",
-        "1.0",
-        "—",
-        "Confidence in the dominant material classification",
-    ),
-}
-
-DOMINANT_ROOF_TYPES_COLUMNS = {
-    "dominant_roof_types_feature_class": (
-        "UUID",
-        "—",
-        "—",
-        "—",
-        "Feature class UUID of the dominant roof shape",
-    ),
-    "dominant_roof_types_description": (
-        "string",
-        "—",
-        "—",
-        "—",
-        "Snake_case name of the `description` field of the dominant shape feature class (or `unknown` if no detected area)",
-    ),
-    "dominant_roof_types_area_{unit}": (
-        "float",
-        "0",
-        "—",
-        "{unit_name}",
-        "Area of the dominant shape component",
-    ),
-    "dominant_roof_types_confidence": (
-        "float (quantised uint8)",
-        "0.0",
-        "1.0",
-        "—",
-        "Confidence in the dominant shape classification",
-    ),
-}
-
-# Defensible Space columns (per zone, on primary roof and aggregate)
-DEFENSIBLE_SPACE_ZONE_COLUMNS = {
-    "zone_area_{unit}": ("float", "0", "—", "{unit_name}", "Total area of the zone around the structure"),
-    "defensible_space_area_{unit}": ("float", "0", "—", "{unit_name}", "Clear/defensible area within the zone"),
-    "coverage_ratio": ("float", "0.0", "1.0", "—", "Fraction of zone that is defensible"),
-    "risk_object_area_{unit}": (
-        "float",
-        "0",
-        "—",
-        "{unit_name}",
-        "Total area of all risk objects within the zone",
-    ),
-    "medium_and_high_vegetation_with_woody_vegetation_area_{unit}": (
-        "float",
-        "0",
-        "—",
-        "{unit_name}",
-        "Area of medium/high woody vegetation in the zone",
-    ),
-    "medium_and_high_vegetation_with_woody_vegetation_ratio": (
-        "float",
-        "0.0",
-        "1.0",
-        "—",
-        "Ratio of medium/high woody vegetation to zone area",
-    ),
-    "roof_area_{unit}": ("float", "0", "—", "{unit_name}", "Area of neighbouring roof structures in the zone"),
-    "roof_ratio": ("float", "0.0", "1.0", "—", "Ratio of neighbouring roof area to zone area"),
-    "yard_debris_area_{unit}": ("float", "0", "—", "{unit_name}", "Area of yard debris in the zone"),
-    "yard_debris_ratio": ("float", "0.0", "1.0", "—", "Ratio of yard debris to zone area"),
-}
-
-ROOF_AGE_COLUMNS = {
-    "roof_age_installation_date": ("date", "—", "—", "—", "Estimated roof installation date"),
-    "roof_age_as_of_date": ("date", "—", "—", "—", "Reference date for age calculation"),
-    "roof_age_years_as_of_date": ("float", "0", "—", "years", "Calculated roof age in years"),
-    "roof_age_trust_score": ("int", "0", "100", "—", "Reliability of age estimate (higher = more reliable)"),
-    "roof_age_evidence_type": ("int", "0", "8", "—", "How age was determined (numeric code; see legend below)"),
-    "roof_age_evidence_type_description": ("string", "—", "—", "—", "Human-readable evidence description"),
-    "roof_age_before_installation_capture_date": ("date", "—", "—", "—", "Last capture before roof installation"),
-    "roof_age_after_installation_capture_date": ("date", "—", "—", "—", "First capture after roof installation"),
-    "roof_age_min_capture_date": ("date", "—", "—", "—", "Earliest imagery capture date analyzed"),
-    "roof_age_max_capture_date": ("date", "—", "—", "—", "Latest imagery capture date analyzed"),
-    "roof_age_number_of_captures": ("int", "0", "—", "—", "Number of aerial captures analyzed"),
-    "roof_age_map_browser_url": ("URL", "—", "—", "—", "URL to view roof age timeline in MapBrowser"),
-    "roof_age_model_version": ("string", "—", "—", "—", "Version of the roof age prediction model used"),
-    "roof_age_kind": (
-        "string",
-        "—",
-        "—",
-        "—",
-        "Type of estimate. One of `roof` (roof section) or `parcel` (property-level).",
-    ),
-    "roof_age_relevant_permits": ("Y/N", "—", "—", "—", "Whether relevant building permits were found"),
-    "roof_age_relevant_permits_details": (
-        "JSON",
-        "—",
-        "—",
-        "—",
-        "Details of relevant building permits (present when permits found)",
-    ),
-    "roof_age_assessor_data": ("Y/N", "—", "—", "—", "Whether assessor records were found"),
-    "roof_age_assessor_data_details": (
-        "JSON",
-        "—",
-        "—",
-        "—",
-        "Details of assessor records (present when records found)",
-    ),
-}
-
+from nmaipy.column_metadata import (  # noqa: E402
+    ADDRESS_QUERY_COLUMNS,
+    COMMON_COLUMNS,
+    DEFENSIBLE_SPACE_ZONE_COLUMNS,
+    DOMINANT_ROOF_MATERIAL_COLUMNS,
+    DOMINANT_ROOF_TYPES_COLUMNS,
+    ROOF_AGE_COLUMNS,
+    RSI_COLUMNS,
+)
 
 # Long-form unit names paired with their short column-suffix form.
 # Used by `_render_columns_table` to substitute the `{unit_name}` placeholder
@@ -245,12 +57,15 @@ _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
 def _render_columns_table(columns: dict, area_unit: str = "") -> list[str]:
     """Render a column metadata dict as a 6-column markdown table.
 
-    Each ``columns`` entry is ``(dtype, min, max, unit, description)``. Two
-    placeholders are substituted at render time:
+    Each ``columns`` value is a ``ColumnMeta`` dataclass with fields ``dtype``,
+    ``min``, ``max``, ``unit``, ``description``. Two placeholders are substituted
+    at render time:
       - ``{unit}`` (in column names, descriptions): replaced with the country's
         area-column suffix (``sqft``/``sqm``).
       - ``{unit_name}`` (in the Unit field): replaced with the country's
         spelled-out area unit (``square feet`` / ``square metres``).
+
+    Empty min/max/unit fields render as the ``—`` sentinel.
     """
     lines = [
         "| Column | Type | Min | Max | Unit | Description |",
@@ -258,11 +73,13 @@ def _render_columns_table(columns: dict, area_unit: str = "") -> list[str]:
     ]
     unit_name = _AREA_UNIT_LONG_NAMES.get(area_unit, area_unit)
     for col, meta in columns.items():
-        dtype, mn, mx, unit, desc = meta
+        dtype = meta.dtype or "—"
+        mn = meta.min or "—"
+        mx = meta.max or "—"
+        unit = (meta.unit or "—").replace("{unit_name}", unit_name)
+        desc = (meta.description or "").replace("{unit}", area_unit)
         col_rendered = col.replace("{unit}", area_unit)
-        unit_rendered = unit.replace("{unit_name}", unit_name)
-        desc_rendered = desc.replace("{unit}", area_unit)
-        lines.append(f"| `{col_rendered}` | {dtype} | {mn} | {mx} | {unit_rendered} | {desc_rendered} |")
+        lines.append(f"| `{col_rendered}` | {dtype} | {mn} | {mx} | {unit} | {desc} |")
     return lines
 
 

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -23,32 +23,28 @@ from nmaipy.column_metadata import (
     DOMINANT_ROOF_TYPES_COLUMNS,
     ROOF_AGE_COLUMNS,
     RSI_COLUMNS,
+    evidence_type_legend,
     lookup_column,
 )
 
 logger = logging.getLogger(__name__)
 
-# README is the export's "all done" sentinel (see exporter._run_inner).
-# Skip it from the listed files table; .DS_Store is filesystem noise.
+# Files always skipped from the README's file listing.
 _NEVER_LIST = {"README.md", ".DS_Store"}
 
-# Long-form unit names paired with the area-suffix used in column names.
 _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
 
 
 def _render_columns_table(
-    column_names: Iterable[str], area_unit: str = "", class_label: str = "property"
+    column_names: Iterable[str], area_unit: str = "", class_label: str = "parcel"
 ) -> list[str]:
-    """Render a list of column names as a 6-column markdown table.
+    """Render the named columns as a 6-column markdown table.
 
-    Each name is resolved through ``column_metadata.lookup_column``, which
-    handles ``{unit}`` / ``{unit_name}`` / ``{class_label}`` / ``{scope_phrase}``
-    substitution and pattern matching. This is the same path the data
-    dictionary uses, so README and dictionary descriptions stay in lock-step.
-
-    Names containing ``{unit}`` are resolved to the country's area suffix
-    before lookup (e.g. ``area_{unit}`` → ``area_sqft``). Empty min/max/unit
-    fields render as the ``—`` sentinel.
+    Each name is resolved via ``column_metadata.lookup_column`` so that
+    ``{unit}`` / ``{class_label}`` / ``{scope_phrase}`` substitution stays
+    consistent with the data dictionary. Templated names (``area_{unit}``)
+    are resolved against ``area_unit`` before lookup; empty min/max/unit
+    fields render as ``—``.
     """
     lines = [
         "| Column | Type | Min | Max | Unit | Description |",
@@ -166,10 +162,12 @@ class ReadmeGenerator:
         return "\n".join(sections)
 
     def _discover_files(self) -> list[str]:
-        """Discover files in the final/ directory worth listing in the README.
+        """List files in ``final/`` worth showing in the README's file table.
 
-        Excludes README itself, OS noise, config files, and any ``*_data_dictionary.csv``
-        sidecars (handled by their own paragraph rather than the file table).
+        Inclusion is governed by the ``output_files`` registry's
+        ``list_in_readme`` flag; ``_NEVER_LIST`` covers files outside the
+        registry. Unrecognised files are listed with a generic description so
+        unexpected outputs are visible.
         """
         all_files = storage.glob_files(self.final_dir, "*")
         files = []
@@ -177,10 +175,8 @@ class ReadmeGenerator:
             name = storage.basename(f)
             if name in _NEVER_LIST:
                 continue
-            if name.endswith("_data_dictionary.csv"):
-                continue
             spec = output_files.file_spec_for(name)
-            if spec is not None and spec.kind == "config":
+            if spec is not None and not spec.list_in_readme:
                 continue
             files.append(f)
         return files
@@ -197,7 +193,6 @@ class ReadmeGenerator:
             "feature_api_errors",
             "roof_age_errors",
             "latency_stats",
-            "buildings",
         }
         classes = []
         seen = set()
@@ -342,18 +337,11 @@ This folder contains AI-generated property data from Nearmap aerial imagery.
         return "\n".join(lines)
 
     def _get_file_description(self, filename: str) -> str:
-        """Get description for a file from the output_files registry.
-
-        Files not in the registry get a generic fallback and a debug log so
-        unexpected output filenames surface during development without
-        breaking the README.
-        """
+        """Description for ``filename`` from the registry, or a generic fallback."""
         spec = output_files.file_spec_for(filename)
         if spec is not None:
             return spec.description
-        logger.debug(
-            "README file table: no registry entry for %r; using generic description.", filename
-        )
+        logger.debug("No registry entry for %r; using generic description.", filename)
         return "Export data file"
 
     def _generate_classes_section(self, classes: list[dict]) -> str:
@@ -559,32 +547,45 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
 
         lines.extend(_render_columns_table(ROOF_AGE_COLUMNS.keys()))
 
+        # Evidence Type legend — sourced from column_metadata.json so the README
+        # and any downstream consumers see the same descriptions.
+        legend = evidence_type_legend()
+        lines.append("")
+        lines.append("**Evidence Type code → description:**")
+        lines.append("")
+        for code in sorted(legend, key=int):
+            lines.append(f"- **Type {code}**: {legend[code]}")
+        lines.append("")
         lines.append(
-            """
-**Evidence Type (0-8):**
-- **Type 8**: Multiple clear images with detected roof change, plus corroborating permits/assessor data
-- **Type 7**: Multiple clear images with detected roof change, no corroborating data
-- **Type 6**: Multiple clear images, no change detected but other strong evidence
-- **Type 2**: No clear imagery, but building permits or assessor records available
-- **Type 0**: Minimal supporting evidence
-
-Higher evidence types indicate more robust information sources.
-
-**Trust Score (0-100):**
-- Higher scores indicate more reliable estimates
-- Based on evidence quality (permits, imagery change detection, number of captures)
-
-For more details, see:
-- https://help.nearmap.com/kb/articles/1810-nearmap-roof-age
-- https://help.nearmap.com/kb/articles/1811-evidence-type-and-trust-score
-"""
+            "Higher evidence types indicate more robust information sources. "
+            "**Trust Score (0-100)** quantifies reliability based on the same evidence "
+            "quality factors (imagery, permits, change detection, capture count)."
         )
+        lines.append("")
+        lines.append("For more details, see:")
+        lines.append("- https://help.nearmap.com/kb/articles/1810-nearmap-roof-age")
+        lines.append("- https://help.nearmap.com/kb/articles/1811-evidence-type-and-trust-score")
+        lines.append("")
 
         return "\n".join(lines)
 
     def _generate_defensible_space_section(self, area_unit: str) -> str:
         """Generate the Defensible Space columns section."""
         u = area_unit
+        # Zone 0 is shown as a representative example; the API returns zones 0/1/2.
+        example_columns = [
+            f"primary_roof_defensible_space_zone_0_zone_area_{u}",
+            f"primary_roof_defensible_space_zone_0_defensible_space_area_{u}",
+            "primary_roof_defensible_space_zone_0_coverage_ratio",
+            f"primary_roof_defensible_space_zone_0_risk_object_area_{u}",
+            f"primary_roof_defensible_space_zone_0_medium_and_high_vegetation_with_woody_vegetation_area_{u}",
+            "primary_roof_defensible_space_zone_0_medium_and_high_vegetation_with_woody_vegetation_ratio",
+            f"primary_roof_defensible_space_zone_0_roof_area_{u}",
+            "primary_roof_defensible_space_zone_0_roof_ratio",
+            f"primary_roof_defensible_space_zone_0_yard_debris_area_{u}",
+            "primary_roof_defensible_space_zone_0_yard_debris_ratio",
+            "defensible_space_model_version",
+        ]
         lines = [
             "## Defensible Space Columns",
             "",
@@ -605,9 +606,9 @@ For more details, see:
             "| `primary_roof_defensible_space_zone_{N}_` | Defensible space for the primary roof feature only |",
             "| `aggregate_defensible_space_zone_{N}_` | Defensible space aggregated across the entire parcel (all structures) |",
             "",
-            "### Columns Per Zone",
+            "### Columns Per Zone (illustrated for zone 0; analogous columns exist for zones 1 and 2)",
             "",
-            *_render_columns_table(DEFENSIBLE_SPACE_ZONE_COLUMNS.keys(), u),
+            *_render_columns_table(example_columns, u),
         ]
 
         lines.append(

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -5,40 +5,17 @@ present in an export directory, rather than using a static template.
 """
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
 import pyarrow.parquet as pq
 
-from nmaipy import storage
+from nmaipy import output_files, storage
 from nmaipy.__version__ import __version__
-
-# Known output filenames mapped to descriptions.
-FILE_PATTERNS = {
-    "rollup.csv": "Property-level summary with one row per property containing aggregated statistics",
-    "rollup.parquet": "Property-level summary with one row per property containing aggregated statistics (Parquet format)",
-    "features.parquet": "All detected features with geometry (GeoParquet)",
-    "feature_api_errors.csv": "Properties where Feature API calls failed",
-    "feature_api_errors.parquet": "Feature API errors with geometry (GeoParquet)",
-    "roof_age_errors.csv": "Properties where Roof Age API calls failed",
-    "roof_age_errors.parquet": "Roof Age API errors with geometry (GeoParquet)",
-    "latency_stats.csv": "API call timing statistics",
-    "buildings.csv": "Building-level summary data",
-    "buildings.parquet": "Building-level summary data (Parquet format)",
-}
-
-# Files to exclude from documentation
-EXCLUDE_FILES = {"README.md", ".DS_Store", "export_config.json"}
-
-# ---------------------------------------------------------------------------
-# Column metadata
-# ---------------------------------------------------------------------------
-# Source of truth lives in nmaipy/data/column_metadata.json and is loaded by
-# nmaipy.column_metadata. This module re-imports the per-section dicts so
-# downstream callers (and tests) can keep using the historical names.
-# ---------------------------------------------------------------------------
-from nmaipy.column_metadata import (  # noqa: E402
+from nmaipy.column_metadata import (
     ADDRESS_QUERY_COLUMNS,
     COMMON_COLUMNS,
     DEFENSIBLE_SPACE_ZONE_COLUMNS,
@@ -46,40 +23,46 @@ from nmaipy.column_metadata import (  # noqa: E402
     DOMINANT_ROOF_TYPES_COLUMNS,
     ROOF_AGE_COLUMNS,
     RSI_COLUMNS,
+    lookup_column,
 )
 
-# Long-form unit names paired with their short column-suffix form.
-# Used by `_render_columns_table` to substitute the `{unit_name}` placeholder
-# in the Unit column based on the country's area unit.
+logger = logging.getLogger(__name__)
+
+# README is the export's "all done" sentinel (see exporter._run_inner).
+# Skip it from the listed files table; .DS_Store is filesystem noise.
+_NEVER_LIST = {"README.md", ".DS_Store"}
+
+# Long-form unit names paired with the area-suffix used in column names.
 _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
 
 
-def _render_columns_table(columns: dict, area_unit: str = "") -> list[str]:
-    """Render a column metadata dict as a 6-column markdown table.
+def _render_columns_table(
+    column_names: Iterable[str], area_unit: str = "", class_label: str = "property"
+) -> list[str]:
+    """Render a list of column names as a 6-column markdown table.
 
-    Each ``columns`` value is a ``ColumnMeta`` dataclass with fields ``dtype``,
-    ``min``, ``max``, ``unit``, ``description``. Two placeholders are substituted
-    at render time:
-      - ``{unit}`` (in column names, descriptions): replaced with the country's
-        area-column suffix (``sqft``/``sqm``).
-      - ``{unit_name}`` (in the Unit field): replaced with the country's
-        spelled-out area unit (``square feet`` / ``square metres``).
+    Each name is resolved through ``column_metadata.lookup_column``, which
+    handles ``{unit}`` / ``{unit_name}`` / ``{class_label}`` / ``{scope_phrase}``
+    substitution and pattern matching. This is the same path the data
+    dictionary uses, so README and dictionary descriptions stay in lock-step.
 
-    Empty min/max/unit fields render as the ``—`` sentinel.
+    Names containing ``{unit}`` are resolved to the country's area suffix
+    before lookup (e.g. ``area_{unit}`` → ``area_sqft``). Empty min/max/unit
+    fields render as the ``—`` sentinel.
     """
     lines = [
         "| Column | Type | Min | Max | Unit | Description |",
         "|--------|------|-----|-----|------|-------------|",
     ]
-    unit_name = _AREA_UNIT_LONG_NAMES.get(area_unit, area_unit)
-    for col, meta in columns.items():
+    for raw_name in column_names:
+        resolved_name = raw_name.replace("{unit}", area_unit)
+        meta = lookup_column(resolved_name, area_unit=area_unit, class_label=class_label)
         dtype = meta.dtype or "—"
         mn = meta.min or "—"
         mx = meta.max or "—"
-        unit = (meta.unit or "—").replace("{unit_name}", unit_name)
-        desc = (meta.description or "").replace("{unit}", area_unit)
-        col_rendered = col.replace("{unit}", area_unit)
-        lines.append(f"| `{col_rendered}` | {dtype} | {mn} | {mx} | {unit} | {desc} |")
+        unit = meta.unit or "—"
+        desc = meta.description or ""
+        lines.append(f"| `{resolved_name}` | {dtype} | {mn} | {mx} | {unit} | {desc} |")
     return lines
 
 
@@ -183,13 +166,23 @@ class ReadmeGenerator:
         return "\n".join(sections)
 
     def _discover_files(self) -> list[str]:
-        """Discover all files in the final/ directory, excluding certain files."""
+        """Discover files in the final/ directory worth listing in the README.
+
+        Excludes README itself, OS noise, config files, and any ``*_data_dictionary.csv``
+        sidecars (handled by their own paragraph rather than the file table).
+        """
         all_files = storage.glob_files(self.final_dir, "*")
         files = []
         for f in sorted(all_files):
             name = storage.basename(f)
-            if name not in EXCLUDE_FILES:
-                files.append(f)
+            if name in _NEVER_LIST:
+                continue
+            if name.endswith("_data_dictionary.csv"):
+                continue
+            spec = output_files.file_spec_for(name)
+            if spec is not None and spec.kind == "config":
+                continue
+            files.append(f)
         return files
 
     def _detect_classes(self, files: list[str]) -> list[dict]:
@@ -349,24 +342,18 @@ This folder contains AI-generated property data from Nearmap aerial imagery.
         return "\n".join(lines)
 
     def _get_file_description(self, filename: str) -> str:
-        """Get description for a file based on exact filename or pattern matching."""
-        if filename in FILE_PATTERNS:
-            return FILE_PATTERNS[filename]
+        """Get description for a file from the output_files registry.
 
-        # Per-class feature geometry files: {class}_features.parquet
-        if filename.endswith("_features.parquet"):
-            class_name = filename[: -len("_features.parquet")].replace("_", " ").title()
-            return f"{class_name} polygons with geometry (GeoParquet)"
-
-        # Per-class attribute files: {class}.csv or {class}.parquet
-        if filename.endswith(".csv"):
-            class_name = filename[: -len(".csv")].replace("_", " ").title()
-            return f"Per-{class_name.lower()} data with feature attributes"
-
-        if filename.endswith(".parquet") and not filename.endswith("_features.parquet"):
-            class_name = filename[: -len(".parquet")].replace("_", " ").title()
-            return f"Per-{class_name.lower()} data with feature attributes (Parquet format)"
-
+        Files not in the registry get a generic fallback and a debug log so
+        unexpected output filenames surface during development without
+        breaking the README.
+        """
+        spec = output_files.file_spec_for(filename)
+        if spec is not None:
+            return spec.description
+        logger.debug(
+            "README file table: no registry entry for %r; using generic description.", filename
+        )
         return "Export data file"
 
     def _generate_classes_section(self, classes: list[dict]) -> str:
@@ -447,20 +434,20 @@ This folder contains AI-generated property data from Nearmap aerial imagery.
             "",
             "These columns appear in most output files:",
             "",
-            *_render_columns_table(COMMON_COLUMNS),
+            *_render_columns_table(COMMON_COLUMNS.keys()),
             "",
         ]
         return "\n".join(lines)
 
     def _generate_address_query_section(self, rollup_columns: set[str]) -> str:
         """Generate the address/query columns section."""
-        present_cols = {col: meta for col, meta in ADDRESS_QUERY_COLUMNS.items() if col in rollup_columns}
+        present = [col for col in ADDRESS_QUERY_COLUMNS if col in rollup_columns]
         lines = [
             "## Address & Query Columns",
             "",
             "These columns are present based on the query mode used:",
             "",
-            *_render_columns_table(present_cols),
+            *_render_columns_table(present),
             "",
         ]
         return "\n".join(lines)
@@ -474,13 +461,13 @@ This folder contains AI-generated property data from Nearmap aerial imagery.
             "",
             "### Dominant Material",
             "",
-            *_render_columns_table(DOMINANT_ROOF_MATERIAL_COLUMNS, area_unit),
+            *_render_columns_table(DOMINANT_ROOF_MATERIAL_COLUMNS.keys(), area_unit),
             "",
             "If no single material has a ratio >= 0.5, the dominant material is reported as `unknown` with null statistics.",
             "",
             "### Dominant Shape",
             "",
-            *_render_columns_table(DOMINANT_ROOF_TYPES_COLUMNS, area_unit),
+            *_render_columns_table(DOMINANT_ROOF_TYPES_COLUMNS.keys(), area_unit),
             "",
             "If all shape components have zero area, the dominant shape is reported as `unknown` with null statistics.",
             "Shape does not include a ratio column because roof shapes can overlap or gap, so ratios do not sum to 1.",
@@ -495,7 +482,7 @@ This folder contains AI-generated property data from Nearmap aerial imagery.
             "",
             "RSI provides a roof condition assessment score:",
             "",
-            *_render_columns_table(RSI_COLUMNS),
+            *_render_columns_table(RSI_COLUMNS.keys()),
         ]
 
         lines.append(
@@ -570,7 +557,7 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
             )
             lines.append("")
 
-        lines.extend(_render_columns_table(ROOF_AGE_COLUMNS))
+        lines.extend(_render_columns_table(ROOF_AGE_COLUMNS.keys()))
 
         lines.append(
             """
@@ -620,7 +607,7 @@ For more details, see:
             "",
             "### Columns Per Zone",
             "",
-            *_render_columns_table(DEFENSIBLE_SPACE_ZONE_COLUMNS, u),
+            *_render_columns_table(DEFENSIBLE_SPACE_ZONE_COLUMNS.keys(), u),
         ]
 
         lines.append(

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -619,7 +619,9 @@ class RoofAgeExporter(BaseExporter):
             if self.output_format in ["geoparquet", "both"]:
                 roofs_path = storage.join_path(output_path, "roofs.parquet")
                 self.logger.info(f"Saving {len(roofs_gdf)} roofs to {roofs_path}")
-                storage.write_parquet(roofs_gdf, roofs_path, index=True)
+                # aoi_id is already a column, so don't also write the RangeIndex
+                # (it would surface as a vestigial __index_level_0__ column).
+                storage.write_parquet(roofs_gdf, roofs_path, index=False)
 
             if self.output_format in ["csv", "both"]:
                 roofs_path = storage.join_path(output_path, "roofs.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,11 @@ Repository = "https://github.com/nearmap/nmaipy.git"
 "Bug Tracker" = "https://github.com/nearmap/nmaipy/issues"
 
 [tool.setuptools]
-packages = ["nmaipy"]
+packages = ["nmaipy", "nmaipy.data"]
 
 [tool.setuptools.package-data]
 nmaipy = ["class_descriptions.json"]
+"nmaipy.data" = ["column_metadata.json"]
 
 [tool.setuptools.package-dir]
 "" = "."

--- a/tests/test_country_units.py
+++ b/tests/test_country_units.py
@@ -3,12 +3,11 @@ Tests for country-aware unit emission across per-feature exports.
 
 The Feature API returns both metric and imperial area columns; per-feature exports
 should keep only the country-correct family (matching rollup behaviour). These tests
-verify the four sites that the fix touches:
+verify the three sites that the fix touches:
 
 1. constants helpers — `country_area_suffix`, `wrong_unit_area_columns`.
 2. Per-class assembler in `_compute_feature_class_data` (US: sqft only, AU: sqm only).
-3. `extract_building_features` populates only the country-correct columns.
-4. `flatten_roof_attributes` clipping detection works for US (regression test for the
+3. `flatten_roof_attributes` clipping detection works for US (regression test for the
    previously latent metric-only hardcoding bug).
 """
 
@@ -33,7 +32,6 @@ from nmaipy.constants import (
 )
 from nmaipy.exporter import _add_is_primary_column, _compute_all_per_class_data
 from nmaipy.feature_attributes import flatten_roof_attributes
-from nmaipy.parcels import extract_building_features
 
 # ---------------------------------------------------------------------------
 # 1. Constants helpers
@@ -162,59 +160,7 @@ def test_roof_instance_per_class_export_emits_only_country_unit(country, kept, d
 
 
 # ---------------------------------------------------------------------------
-# 3. Buildings extract
-# ---------------------------------------------------------------------------
-
-
-def _building_features_and_parcels():
-    """Minimal features_gdf + parcels_gdf for extract_building_features."""
-    polygon = box(-111.89, 40.76, -111.8895, 40.7605)
-    features = pd.DataFrame(
-        [
-            {
-                "feature_id": "bld-1",
-                "class_id": BUILDING_NEW_ID,
-                "description": "Building",
-                "confidence": 0.9,
-                "fidelity": 0.95,
-                "area_sqm": 200.0,
-                "clipped_area_sqm": 180.0,
-                "unclipped_area_sqm": 200.0,
-                "area_sqft": 2153.0,
-                "clipped_area_sqft": 1937.0,
-                "unclipped_area_sqft": 2153.0,
-                "survey_date": "2024-01-01",
-                "mesh_date": "2024-01-01",
-                "geometry": polygon,
-                "is_primary": True,
-            }
-        ],
-        index=pd.Index(["aoi-1"], name=AOI_ID_COLUMN_NAME),
-    )
-    features_gdf = gpd.GeoDataFrame(features, geometry="geometry", crs=API_CRS)
-    parcels_gdf = gpd.GeoDataFrame(
-        {"geometry": [polygon]},
-        index=pd.Index(["aoi-1"], name=AOI_ID_COLUMN_NAME),
-        crs=API_CRS,
-    )
-    return features_gdf, parcels_gdf
-
-
-@pytest.mark.parametrize("country,kept,dropped", [("us", "sqft", "sqm"), ("au", "sqm", "sqft")])
-def test_extract_building_features_emits_only_country_unit(country, kept, dropped):
-    features_gdf, parcels_gdf = _building_features_and_parcels()
-    out = extract_building_features(parcels_gdf=parcels_gdf, features_gdf=features_gdf, country=country)
-    cols = set(out.columns)
-    assert f"area_{kept}" in cols
-    assert f"clipped_area_{kept}" in cols
-    assert f"unclipped_area_{kept}" in cols
-    assert f"area_{dropped}" not in cols
-    assert f"clipped_area_{dropped}" not in cols
-    assert f"unclipped_area_{dropped}" not in cols
-
-
-# ---------------------------------------------------------------------------
-# 4. Clipping detection regression test (real bug fix)
+# 3. Clipping detection regression test (real bug fix)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -7,13 +7,13 @@ the standalone Roof Age exporter is intentionally out of scope):
 - Generic suffix patterns
 - Unknown columns -> sentinel
 - Order preservation
-- File discovery (skips operational/error files; ignores existing dictionaries)
+- Registry-driven file discovery (gated on tabular_file_format)
 - Per-class file coverage
-- Atomic write
 - Source attribution (input data / base ai model / score model / roof age model)
 - JSON round-trip (PM editability)
 - JSON validation (malformed JSON / missing keys)
 - Confidence-null caveat in pattern descriptions
+- Cross-file structural consistency for shared columns
 """
 
 from __future__ import annotations
@@ -48,6 +48,12 @@ def _write_parquet(path: Path, columns: list[str]) -> None:
     """Write a tiny parquet with the given columns (zero rows)."""
     schema = pa.schema([pa.field(c, pa.string()) for c in columns])
     pq.write_table(pa.Table.from_pylist([], schema=schema), path)
+
+
+def _write_export_config(path: Path, *, tabular_file_format: str = "csv", country: str = "us") -> None:
+    """Write a minimal export_config.json that the generator reads for format/country."""
+    payload = {"parameters": {"tabular_file_format": tabular_file_format, "country": country}}
+    path.write_text(json.dumps(payload))
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +215,9 @@ class TestColumnOrderPreservation:
 
 
 class TestFileDiscovery:
-    def test_skips_operational_and_error_files(self, tmp_path):
+    def test_only_tabular_ai_files_get_dictionaries(self, tmp_path):
+        """Operational/error/geometry files are not in the registry — they get no dictionary."""
+        _write_export_config(tmp_path / "export_config.json")
         _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
         _write_parquet(tmp_path / "roof_features.parquet", ["aoi_id", "tile_area_sqft"])
         _write_csv(tmp_path / "latency_stats.csv", ["chunk_id", "p50"])
@@ -217,64 +225,67 @@ class TestFileDiscovery:
         _write_csv(tmp_path / "roof_age_errors.csv", ["aoi_id", "status_code"])
         DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
 
-        # Only rollup and roof_features should have dictionaries.
-        existing = sorted(p.name for p in tmp_path.iterdir() if p.suffix == ".csv" and p.name.endswith("_data_dictionary.csv"))
-        assert set(existing) == {"roof_features_data_dictionary.csv", "rollup_data_dictionary.csv"}
+        existing = sorted(
+            p.name for p in tmp_path.iterdir()
+            if p.suffix == ".csv" and p.name.endswith("_data_dictionary.csv")
+        )
+        # Only the tabular AI file (rollup.csv) gets a dictionary. The geoparquet
+        # companion (roof_features.parquet) and the operational files do not.
+        assert existing == ["rollup_data_dictionary.csv"]
 
-    def test_does_not_recursively_dictionary_existing_dictionaries(self, tmp_path):
-        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
-        # Pre-create a stray dictionary file as if from a prior run.
-        _write_csv(tmp_path / "stale_data_dictionary.csv", ["column_name", "dtype"])
+    def test_one_dictionary_per_logical_class(self, tmp_path):
+        """When CSV is the configured format, parquet variants get no parallel dictionary."""
+        _write_export_config(tmp_path / "export_config.json", tabular_file_format="csv")
+        # CSV variant is the configured tabular format → gets a dictionary.
+        _write_csv(tmp_path / "building.csv", ["aoi_id"])
+        # Geoparquet companion → no dictionary (geometry kind, not tabular AI).
+        _write_parquet(tmp_path / "building_features.parquet", ["aoi_id", "tile_area_sqft"])
         DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
-        # No "stale_data_dictionary_data_dictionary.csv" should be produced.
-        assert not (tmp_path / "stale_data_dictionary_data_dictionary.csv").exists()
 
-    def test_all_per_class_files_get_dictionaries(self, tmp_path):
+        existing = sorted(
+            p.name for p in tmp_path.iterdir()
+            if p.name.endswith("_data_dictionary.csv")
+        )
+        assert existing == ["building_data_dictionary.csv"]
+
+    def test_per_class_files_in_configured_format_get_dictionaries(self, tmp_path):
+        """Each per-class tabular file in the configured format gets exactly one dictionary."""
+        _write_export_config(tmp_path / "export_config.json", tabular_file_format="csv")
         per_class = [
             "building_lifecycle.csv", "building.csv", "roof.csv", "roof_instance.csv",
             "swimming_pool.csv", "solar_panel.csv",
+        ]
+        for name in per_class:
+            _write_csv(tmp_path / name, ["aoi_id"])
+        # Geoparquet companions exist alongside but should not get dictionaries.
+        for name in [
             "building_lifecycle_features.parquet", "building_features.parquet",
             "roof_features.parquet", "roof_instance_features.parquet",
             "swimming_pool_features.parquet", "solar_panel_features.parquet",
-        ]
-        for name in per_class:
-            (tmp_path / name).touch()
-            if name.endswith(".csv"):
-                _write_csv(tmp_path / name, ["aoi_id"])
-            else:
-                _write_parquet(tmp_path / name, ["aoi_id"])
+        ]:
+            _write_parquet(tmp_path / name, ["aoi_id"])
         DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
         for name in per_class:
             stem = name.rsplit(".", 1)[0]
-            dd = tmp_path / f"{stem}_data_dictionary.csv"
-            assert dd.exists(), f"missing dictionary for {name}"
+            assert (tmp_path / f"{stem}_data_dictionary.csv").exists(), f"missing dictionary for {name}"
+        # Geoparquet companions get no dictionary.
+        for name in ["roof_features", "building_features"]:
+            assert not (tmp_path / f"{name}_data_dictionary.csv").exists(), (
+                f"unexpected dictionary for geometry file {name}"
+            )
 
-
-# ---------------------------------------------------------------------------
-# 9. Atomic write
-# ---------------------------------------------------------------------------
-
-
-class TestAtomicWrite:
-    def test_does_not_clobber_existing_dictionary_on_failure(self, tmp_path, monkeypatch):
-        """If row generation throws mid-file, the previous dictionary stays intact."""
-        # Pre-existing dictionary content.
-        existing_dd = tmp_path / "rollup_data_dictionary.csv"
-        existing_dd.write_text("column_name,description\nlegacy_col,prior content\n")
+    def test_parquet_format_picks_parquet_variants(self, tmp_path):
+        """When tabular_file_format='parquet', only the parquet variants get dictionaries."""
+        _write_export_config(tmp_path / "export_config.json", tabular_file_format="parquet")
+        _write_parquet(tmp_path / "rollup.parquet", ["aoi_id"])
+        _write_parquet(tmp_path / "building.parquet", ["aoi_id"])
+        # A stray CSV variant exists alongside but isn't the configured format.
         _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
-
-        # Force the write helper to fail mid-flight.
-        from nmaipy import data_dictionary_generator as ddg
-
-        def _boom(path, rows):
-            raise OSError("simulated mid-write failure")
-
-        monkeypatch.setattr(ddg.DataDictionaryGenerator, "_write_csv", _boom)
-        # Should not raise (failures are caught per-file in generate_and_save).
         DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
-
-        # Existing dictionary content is preserved.
-        assert existing_dd.read_text().startswith("column_name,description\nlegacy_col,prior content")
+        existing = sorted(
+            p.name for p in tmp_path.iterdir() if p.name.endswith("_data_dictionary.csv")
+        )
+        assert existing == ["building_data_dictionary.csv", "rollup_data_dictionary.csv"]
 
 
 # ---------------------------------------------------------------------------
@@ -342,3 +353,64 @@ class TestOutputSchema:
         DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
         dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv")
         assert list(dd.columns) == _DD_COLUMNS
+
+    def test_does_not_dictionary_unregistered_files(self, tmp_path):
+        """Registry-driven discovery skips anything not in output_files."""
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
+        # A file with no registry entry — should be ignored, not produce a dictionary.
+        _write_csv(tmp_path / "some_random_export.csv", ["foo"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+        assert not (tmp_path / "some_random_export_data_dictionary.csv").exists()
+
+
+# ---------------------------------------------------------------------------
+# 12. Cross-file structural consistency
+# ---------------------------------------------------------------------------
+
+
+SHARED_COLUMNS = [
+    "aoi_id",
+    "feature_id",
+    "is_primary",
+    "confidence",
+    "roof_age_installation_date",
+    "roof_age_trust_score",
+]
+
+
+class TestCrossFileConsistency:
+    """Columns appearing in multiple output files must have identical structural metadata.
+
+    Descriptions are allowed to vary (scope/class-label phrasing). Anything that
+    would surprise a downstream consumer reading two dictionaries side-by-side
+    (dtype, min, max, unit, allowed_values) must be identical.
+    """
+
+    def test_shared_columns_have_identical_structural_metadata(self, tmp_path):
+        _write_export_config(tmp_path / "export_config.json", tabular_file_format="csv")
+        # Each column appears in every per-class file plus the rollup.
+        common = SHARED_COLUMNS + ["primary_roof_confidence"]
+        _write_csv(tmp_path / "rollup.csv", common)
+        _write_csv(tmp_path / "roof.csv", common)
+        _write_csv(tmp_path / "building.csv", common)
+        _write_csv(tmp_path / "roof_instance.csv", common)
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        # Load each generated dictionary, build {column → list of (file, structural-tuple)}.
+        observations: dict[str, list[tuple[str, tuple]]] = {}
+        for dd in tmp_path.glob("*_data_dictionary.csv"):
+            df = pd.read_csv(dd, keep_default_na=False)
+            for _, row in df.iterrows():
+                col = row["column_name"]
+                if col not in SHARED_COLUMNS:
+                    continue
+                structural = (row["dtype"], row["min"], row["max"], row["allowed_values"])
+                observations.setdefault(col, []).append((dd.name, structural))
+
+        # Every shared column should have appeared in 2+ dictionaries; check parity.
+        for col, entries in observations.items():
+            assert len(entries) >= 2, f"shared column {col!r} only seen in one file: {entries}"
+            unique = {struct for _, struct in entries}
+            assert len(unique) == 1, (
+                f"structural metadata for {col!r} differs across files: {entries}"
+            )

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -1,0 +1,344 @@
+"""Tests for the data dictionary generator and column metadata loader.
+
+Covers the cases enumerated in the INDS-2080 plan (NearmapAIExporter outputs only;
+the standalone Roof Age exporter is intentionally out of scope):
+- Known-column lookup
+- Scope-aware pattern matcher (parcel-scope vs primary-feature scope)
+- Generic suffix patterns
+- Unknown columns -> sentinel
+- Order preservation
+- File discovery (skips operational/error files; ignores existing dictionaries)
+- Per-class file coverage
+- Atomic write
+- Source attribution (input data / base ai model / score model / roof age model)
+- JSON round-trip (PM editability)
+- JSON validation (malformed JSON / missing keys)
+- Confidence-null caveat in pattern descriptions
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from nmaipy import column_metadata as cm
+from nmaipy.column_metadata import ColumnMeta, lookup_column, reload_metadata
+from nmaipy.data_dictionary_generator import DataDictionaryGenerator, _DD_COLUMNS
+
+
+@pytest.fixture(autouse=True)
+def _reset_metadata_cache():
+    """Ensure the loader cache doesn't leak between tests that may swap configs."""
+    reload_metadata()
+    yield
+    reload_metadata()
+
+
+def _write_csv(path: Path, columns: list[str]) -> None:
+    """Write a tiny CSV file with just the header row (no data needed)."""
+    pd.DataFrame(columns=columns).to_csv(path, index=False)
+
+
+def _write_parquet(path: Path, columns: list[str]) -> None:
+    """Write a tiny parquet with the given columns (zero rows)."""
+    schema = pa.schema([pa.field(c, pa.string()) for c in columns])
+    pq.write_table(pa.Table.from_pylist([], schema=schema), path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Known-column lookup
+# ---------------------------------------------------------------------------
+
+
+class TestKnownColumnLookup:
+    """Curated entries in exact_matches return their stored metadata."""
+
+    def test_aoi_id(self):
+        meta = lookup_column("aoi_id")
+        assert meta.dtype == "string \\| int"
+        assert "Property identifier" in meta.description
+        assert meta.source == "input data"
+
+    def test_roof_age_kind(self):
+        meta = lookup_column("roof_age_kind")
+        assert meta.dtype == "string"
+        assert meta.allowed_values == "roof | parcel"
+        assert meta.source == "roof age model"
+
+    def test_dominant_roof_material_ratio(self):
+        meta = lookup_column("dominant_roof_material_ratio")
+        assert meta.dtype == "float"
+        assert meta.min == "0.0"
+        assert meta.max == "1.0"
+        # Curated description (not the generic ? from the _ratio pattern).
+        assert meta.description != "?"
+        assert "dominant material" in meta.description.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Scope-aware pattern matcher (the critical PM concern)
+# ---------------------------------------------------------------------------
+
+
+class TestScopeAwarePatterns:
+    """staining_area_sqft (parcel) and primary_roof_staining_area_sqft must differ."""
+
+    def test_parcel_scope_vs_primary_roof_scope_descriptions_differ(self):
+        parcel = lookup_column("staining_area_sqft", area_unit="sqft")
+        primary = lookup_column("primary_roof_staining_area_sqft", area_unit="sqft")
+        assert parcel.description != primary.description
+
+    def test_parcel_scope_phrase(self):
+        parcel = lookup_column("staining_area_sqft", area_unit="sqft")
+        assert "across the entire parcel" in parcel.description
+        assert "primary roof" not in parcel.description
+
+    def test_primary_roof_scope_phrase(self):
+        primary = lookup_column("primary_roof_staining_area_sqft", area_unit="sqft")
+        assert "primary roof" in primary.description
+
+    def test_ratio_scopes_differ(self):
+        parcel = lookup_column("staining_ratio", area_unit="sqft")
+        primary = lookup_column("primary_roof_staining_ratio", area_unit="sqft")
+        assert parcel.description != primary.description
+        assert "across the entire parcel" in parcel.description
+        assert "primary roof" in primary.description
+
+    def test_confidence_scopes_differ(self):
+        parcel = lookup_column("staining_confidence", area_unit="sqft")
+        primary = lookup_column("primary_roof_staining_confidence", area_unit="sqft")
+        assert parcel.description != primary.description
+        assert "across the entire parcel" in parcel.description
+        assert "primary roof" in primary.description
+
+
+# ---------------------------------------------------------------------------
+# 3. Generic suffix patterns
+# ---------------------------------------------------------------------------
+
+
+class TestGenericPatterns:
+    """Each suffix family produces the expected dtype/source default."""
+
+    @pytest.mark.parametrize("name, dtype, expect_min", [
+        ("tile_area_sqft", "float", "0"),
+        ("metal_area_sqm", "float", "0"),
+    ])
+    def test_area_pattern(self, name, dtype, expect_min):
+        unit = "sqft" if name.endswith("_sqft") else "sqm"
+        meta = lookup_column(name, area_unit=unit)
+        assert meta.dtype == dtype
+        assert meta.min == expect_min
+        assert meta.source == "base ai model"
+
+    def test_count_pattern(self):
+        meta = lookup_column("solar_count", area_unit="sqft")
+        assert meta.dtype == "int"
+        assert meta.min == "0"
+
+    def test_present_pattern(self):
+        meta = lookup_column("solar_present", area_unit="sqft")
+        assert meta.dtype == "Y/N"
+        assert meta.allowed_values == "Y | N"
+
+    def test_confidence_includes_null_caveat(self):
+        meta = lookup_column("tile_confidence", area_unit="sqft")
+        assert meta.dtype == "float (quantised uint8)"
+        assert "Null when the corresponding area is 0" in meta.description
+
+
+# ---------------------------------------------------------------------------
+# 4. Unknown columns
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownColumns:
+    def test_completely_unknown_column_returns_sentinel(self):
+        meta = lookup_column("totally_invented_column_name_xyz")
+        assert meta.is_unknown()
+        assert meta.description == "?"
+        assert meta.source == "?"
+        assert meta.dtype == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. Source attribution
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAttribution:
+    def test_aoi_id_is_input_data(self):
+        assert lookup_column("aoi_id").source == "input data"
+
+    def test_roof_age_columns_are_roof_age_model(self):
+        assert lookup_column("roof_age_installation_date").source == "roof age model"
+        assert lookup_column("roof_age_trust_score").source == "roof age model"
+
+    def test_pack_columns_are_base_ai_model(self):
+        assert lookup_column("tile_area_sqft", area_unit="sqft").source == "base ai model"
+        assert lookup_column("gable_ratio", area_unit="sqft").source == "base ai model"
+
+    def test_rsi_is_score_model(self):
+        assert lookup_column("roof_spotlight_index").source == "score model"
+        assert lookup_column("roof_spotlight_index_confidence").source == "score model"
+
+
+# ---------------------------------------------------------------------------
+# 6. Order preservation + per-file generation
+# ---------------------------------------------------------------------------
+
+
+class TestColumnOrderPreservation:
+    def test_dictionary_rows_match_source_column_order(self, tmp_path):
+        # Shuffled order, deliberately not alphabetical.
+        cols = ["zip", "aoi_id", "tile_area_sqft", "mesh_date", "roof_age_kind"]
+        _write_csv(tmp_path / "rollup.csv", cols)
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv")
+        assert list(dd["column_name"]) == cols
+
+
+# ---------------------------------------------------------------------------
+# 7. File discovery
+# ---------------------------------------------------------------------------
+
+
+class TestFileDiscovery:
+    def test_skips_operational_and_error_files(self, tmp_path):
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
+        _write_parquet(tmp_path / "roof_features.parquet", ["aoi_id", "tile_area_sqft"])
+        _write_csv(tmp_path / "latency_stats.csv", ["chunk_id", "p50"])
+        _write_csv(tmp_path / "feature_api_errors.csv", ["aoi_id", "status_code"])
+        _write_csv(tmp_path / "roof_age_errors.csv", ["aoi_id", "status_code"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        # Only rollup and roof_features should have dictionaries.
+        existing = sorted(p.name for p in tmp_path.iterdir() if p.suffix == ".csv" and p.name.endswith("_data_dictionary.csv"))
+        assert set(existing) == {"roof_features_data_dictionary.csv", "rollup_data_dictionary.csv"}
+
+    def test_does_not_recursively_dictionary_existing_dictionaries(self, tmp_path):
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
+        # Pre-create a stray dictionary file as if from a prior run.
+        _write_csv(tmp_path / "stale_data_dictionary.csv", ["column_name", "dtype"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+        # No "stale_data_dictionary_data_dictionary.csv" should be produced.
+        assert not (tmp_path / "stale_data_dictionary_data_dictionary.csv").exists()
+
+    def test_all_per_class_files_get_dictionaries(self, tmp_path):
+        per_class = [
+            "building_lifecycle.csv", "building.csv", "roof.csv", "roof_instance.csv",
+            "swimming_pool.csv", "solar_panel.csv",
+            "building_lifecycle_features.parquet", "building_features.parquet",
+            "roof_features.parquet", "roof_instance_features.parquet",
+            "swimming_pool_features.parquet", "solar_panel_features.parquet",
+        ]
+        for name in per_class:
+            (tmp_path / name).touch()
+            if name.endswith(".csv"):
+                _write_csv(tmp_path / name, ["aoi_id"])
+            else:
+                _write_parquet(tmp_path / name, ["aoi_id"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+        for name in per_class:
+            stem = name.rsplit(".", 1)[0]
+            dd = tmp_path / f"{stem}_data_dictionary.csv"
+            assert dd.exists(), f"missing dictionary for {name}"
+
+
+# ---------------------------------------------------------------------------
+# 9. Atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    def test_does_not_clobber_existing_dictionary_on_failure(self, tmp_path, monkeypatch):
+        """If row generation throws mid-file, the previous dictionary stays intact."""
+        # Pre-existing dictionary content.
+        existing_dd = tmp_path / "rollup_data_dictionary.csv"
+        existing_dd.write_text("column_name,description\nlegacy_col,prior content\n")
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
+
+        # Force the write helper to fail mid-flight.
+        from nmaipy import data_dictionary_generator as ddg
+
+        def _boom(path, rows):
+            raise OSError("simulated mid-write failure")
+
+        monkeypatch.setattr(ddg.DataDictionaryGenerator, "_write_csv", _boom)
+        # Should not raise (failures are caught per-file in generate_and_save).
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        # Existing dictionary content is preserved.
+        assert existing_dd.read_text().startswith("column_name,description\nlegacy_col,prior content")
+
+
+# ---------------------------------------------------------------------------
+# 10. JSON round-trip and validation
+# ---------------------------------------------------------------------------
+
+
+class TestJsonConfig:
+    def test_round_trip_edit_appears_in_output(self, tmp_path, monkeypatch):
+        """Editing the JSON, reloading, and regenerating reflects the change."""
+        # Load real config, mutate one description, write it to a temp file, point loader at it.
+        import importlib.resources as resources
+
+        with resources.files("nmaipy.data").joinpath("column_metadata.json").open() as fh:
+            payload = json.load(fh)
+        payload["exact_matches"]["aoi_id"]["description"] = "EDITED IN TEST"
+        custom_path = tmp_path / "custom_metadata.json"
+        custom_path.write_text(json.dumps(payload))
+
+        # Force loader to use the custom path.
+        reload_metadata()
+        from nmaipy import column_metadata as col_mod
+
+        col_mod.load_metadata.cache_clear()
+        original = col_mod.load_metadata
+
+        def _patched(json_path=None):
+            return original(str(custom_path))
+
+        monkeypatch.setattr(col_mod, "load_metadata", _patched)
+
+        meta = col_mod.lookup_column("aoi_id")
+        assert "EDITED IN TEST" in meta.description
+
+    def test_malformed_json_raises_friendly_error(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not: valid json")
+        with pytest.raises(json.JSONDecodeError):
+            cm.load_metadata.cache_clear()
+            cm.load_metadata(str(bad))
+
+    def test_missing_required_key_raises_friendly_error(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps({"exact_matches": {}}))  # missing 'patterns'
+        with pytest.raises(ValueError, match="patterns"):
+            cm.load_metadata.cache_clear()
+            cm.load_metadata(str(bad))
+
+    def test_invalid_pattern_regex_raises_friendly_error(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps({"exact_matches": {}, "patterns": [{"regex": "(unclosed"}]}))
+        with pytest.raises(ValueError, match="regex is invalid"):
+            cm.load_metadata.cache_clear()
+            cm.load_metadata(str(bad))
+
+
+# ---------------------------------------------------------------------------
+# 11. Output schema
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSchema:
+    def test_dictionary_csv_has_expected_columns_in_order(self, tmp_path):
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv")
+        assert list(dd.columns) == _DD_COLUMNS

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -68,7 +68,6 @@ class TestExporter:
             parcel_mode=True,
             system_version_prefix="gen6-",
             processes=8,
-            save_buildings=True,
         )
         my_exporter.process_chunk(
             chunk_id=chunk_id,

--- a/tests/test_integration_rollup_features.py
+++ b/tests/test_integration_rollup_features.py
@@ -70,7 +70,6 @@ def test_rollup_and_features_consistency(integration_test_dir, test_aoi_with_fea
         country="us",
         packs=["building", "building_char", "roof_char"],
         save_features=True,  # Generate features GeoParquet
-        save_buildings=True,  # Generate building rollups
         no_cache=True,
         processes=1,
     )
@@ -81,7 +80,7 @@ def test_rollup_and_features_consistency(integration_test_dir, test_aoi_with_fea
     final_dir = integration_test_dir / "final"
 
     # 1. Check rollup CSV
-    rollup_file = final_dir / "buildings.csv"
+    rollup_file = final_dir / "rollup.csv"
     if rollup_file.exists():
         rollup_df = pd.read_csv(rollup_file)
 
@@ -187,7 +186,6 @@ def test_features_without_rollup(integration_test_dir):
         country="us",
         packs=["building", "roof_char"],
         save_features=True,
-        save_buildings=False,  # No rollup
         no_cache=True,
         processes=1,
     )
@@ -196,12 +194,8 @@ def test_features_without_rollup(integration_test_dir):
 
     final_dir = integration_test_dir / "final"
 
-    # Should have features but no buildings CSV
     features_file = final_dir / "features.parquet"
-    buildings_file = final_dir / "buildings.csv"
-
     assert features_file.exists(), "Features file should exist"
-    assert not buildings_file.exists(), "Buildings rollup should not exist"
 
     # Verify features have proper flattening
     features_gdf = gpd.read_parquet(features_file)
@@ -247,7 +241,6 @@ def test_full_export_with_all_includes_and_chunks(integration_test_dir):
         packs=["building", "vegetation", "roof_cond", "roof_char", "building_char"],
         include=["all"],  # Get all available includes
         save_features=True,  # Test both features and rollup output
-        save_buildings=True,
         chunk_size=2,  # Force multiple chunks for testing
         no_cache=True,
         processes=1,
@@ -357,7 +350,6 @@ def test_parquet_deserialization_of_include_params(integration_test_dir):
         packs=["building", "roof_char"],
         include=["hurricaneScore", "defensibleSpace", "roofSpotlightIndex"],
         save_features=True,
-        save_buildings=False,
         no_cache=True,
         processes=1,
     )
@@ -464,7 +456,6 @@ def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_fea
         # the AOI happens to contain solar panels.
         packs=["building", "roof_char", "solar"],
         save_features=True,
-        save_buildings=True,
         class_level_files=True,
         no_cache=True,
         processes=1,
@@ -476,10 +467,10 @@ def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_fea
 
     exclude_patterns = [
         "rollup",
-        "buildings",
         "latency_stats",
         "feature_api_errors",
         "roof_age_errors",
+        "_data_dictionary",
     ]
     per_class_csvs = [f for f in final_dir.glob("*.csv") if not any(pattern in f.name for pattern in exclude_patterns)]
     assert len(per_class_csvs) > 0, f"Should have per-class CSV files. Files in final: {list(final_dir.glob('*'))}"
@@ -522,7 +513,7 @@ def test_is_primary_in_per_class_exports(integration_test_dir, test_aoi_with_fea
         _expect_columns(class_gdf, parquet_path.name)
 
     # Cross-verify: primary features in per-class parquets match rollup IDs.
-    rollup_file = final_dir / "buildings.csv"
+    rollup_file = final_dir / "rollup.csv"
     if rollup_file.exists():
         rollup_df = pd.read_csv(rollup_file, index_col="aoi_id")
         for col_name, class_id in PRIMARY_FEATURE_COLUMN_TO_CLASS.items():

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -244,8 +244,9 @@ class TestGenerateEmptyDirectory:
 class TestColumnMetadataTables:
     """The README's column tables emit six columns: Column | Type | Min | Max | Unit | Description."""
 
-    def test_column_dicts_are_tuples_of_five(self):
-        """Each entry is a (dtype, min, max, unit, description) tuple."""
+    def test_column_dicts_are_columnmeta_instances(self):
+        """Each entry is a ColumnMeta dataclass with required fields populated."""
+        from nmaipy.column_metadata import ColumnMeta
         from nmaipy.readme_generator import (
             DEFENSIBLE_SPACE_ZONE_COLUMNS,
             DOMINANT_ROOF_MATERIAL_COLUMNS,
@@ -262,17 +263,17 @@ class TestColumnMetadataTables:
             ("DEFENSIBLE_SPACE_ZONE_COLUMNS", DEFENSIBLE_SPACE_ZONE_COLUMNS),
         ):
             for col, meta in columns.items():
-                assert isinstance(meta, tuple) and len(meta) == 5, f"{label}[{col!r}] must be a 5-tuple"
-                for i, field in enumerate(meta):
-                    assert (
-                        isinstance(field, str) and field
-                    ), f"{label}[{col!r}] field {i} must be a non-empty string, got {field!r}"
+                assert isinstance(meta, ColumnMeta), f"{label}[{col!r}] must be a ColumnMeta instance, got {type(meta)}"
+                assert meta.dtype, f"{label}[{col!r}] must have a non-empty dtype"
+                assert meta.description, f"{label}[{col!r}] must have a non-empty description"
 
     def test_render_columns_table_emits_six_column_markdown(self):
         """_render_columns_table produces a 6-column markdown table with one row per entry."""
+        from nmaipy.column_metadata import ColumnMeta
+
         sample = {
-            "score": ("float", "0", "100", "—", "Some score"),
-            "flag": ("Y/N", "—", "—", "—", "Some flag"),
+            "score": ColumnMeta(dtype="float", min="0", max="100", description="Some score"),
+            "flag": ColumnMeta(dtype="Y/N", description="Some flag"),
         }
         rendered = _render_columns_table(sample)
         # Header + separator + 2 rows = 4 lines
@@ -284,7 +285,9 @@ class TestColumnMetadataTables:
 
     def test_render_columns_table_substitutes_unit_placeholders(self):
         """`{unit}` (column name) and `{unit_name}` (Unit cell) substitute on render."""
-        sample = {"area_{unit}": ("float", "0", "—", "{unit_name}", "Area of feature")}
+        from nmaipy.column_metadata import ColumnMeta
+
+        sample = {"area_{unit}": ColumnMeta(dtype="float", min="0", unit="{unit_name}", description="Area of feature")}
         us_rows = _render_columns_table(sample, area_unit="sqft")
         au_rows = _render_columns_table(sample, area_unit="sqm")
         # US: column name uses sqft suffix, Unit cell uses spelled-out form.
@@ -298,7 +301,7 @@ class TestColumnMetadataTables:
         """The aoi_id `string | int` dtype escapes the markdown pipe so it doesn't break the table."""
         # aoi_id legitimately can be either string or int depending on input. The dtype string
         # must use an escaped backslash-pipe so markdown doesn't treat it as a column delimiter.
-        dtype = COMMON_COLUMNS["aoi_id"][0]
+        dtype = COMMON_COLUMNS["aoi_id"].dtype
         assert "\\|" in dtype, (
             f"aoi_id dtype should contain a backslash-escaped pipe, got {dtype!r}. "
             "An unescaped `|` inside a markdown table cell will be parsed as a column boundary."
@@ -308,7 +311,7 @@ class TestColumnMetadataTables:
         """Confidence scores are stored as uint8 on the wire even though the value space is 0.0–1.0."""
         # The dtype label calls this out so downstream consumers know to expect 256 distinct values
         # rather than continuous floats.
-        assert "quantised uint8" in RSI_COLUMNS["roof_spotlight_index_confidence"][0]
+        assert "quantised uint8" in RSI_COLUMNS["roof_spotlight_index_confidence"].dtype
 
     def test_rendered_section_includes_min_max_and_unit(self, tmp_path):
         """End-to-end: a rendered RSI section contains the new Min/Max/Unit columns."""

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -105,9 +105,9 @@ class TestDetectClasses:
         class_columns = [c["column"] for c in classes]
         assert "feature_api_errors" not in class_columns
 
-    def test_detect_classes_skips_buildings_file(self, tmp_path):
+    def test_detect_classes_skips_operational_files(self, tmp_path):
         (tmp_path / "rollup.csv").write_text("col1\n1")
-        (tmp_path / "buildings.csv").write_text("col1\n1")
+        (tmp_path / "latency_stats.csv").write_text("col1\n1")
         (tmp_path / "roof.csv").write_text("col1\n1")
 
         gen = ReadmeGenerator(output_dir=tmp_path)
@@ -115,7 +115,7 @@ class TestDetectClasses:
         classes = gen._detect_classes(files)
 
         class_columns = [c["column"] for c in classes]
-        assert "buildings" not in class_columns
+        assert "latency_stats" not in class_columns
         assert "roof" in class_columns
 
     def test_detect_classes_formats_display_name(self, tmp_path):
@@ -291,13 +291,19 @@ class TestColumnMetadataTables:
         assert any("`dominant_roof_material_area_sqm`" in row for row in au_rows)
         assert any("square metres" in row for row in au_rows)
 
-    def test_render_columns_table_substitutes_class_label(self):
-        """{class_label} in JSON descriptions is substituted at render time, not leaked."""
-        # The `link` entry's description references {class_label} — must be resolved.
-        rendered = _render_columns_table(["link"], class_label="property")
+    def test_render_columns_table_substitutes_class_label_primary(self):
+        """{class_label_primary} in JSON descriptions is substituted, not leaked.
+
+        Several JSON entries (e.g. ``feature_id``, ``area_sqft``) reference
+        ``{class_label_primary}``; routing through ``lookup_column`` resolves
+        them. Previously the README's bespoke renderer ignored these placeholders
+        and shipped them literally to customers.
+        """
+        rendered = _render_columns_table(
+            ["feature_id", "area_sqft"], area_unit="sqft", class_label="building"
+        )
         for row in rendered:
-            assert "{class_label}" not in row, f"unsubstituted placeholder leaked: {row!r}"
-        assert any("URL to view the property" in row for row in rendered)
+            assert "{" not in row, f"unsubstituted placeholder leaked: {row!r}"
 
     def test_aoi_id_dtype_pipe_is_escaped(self):
         """The aoi_id `string | int` dtype escapes the markdown pipe so it doesn't break the table."""

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -269,14 +269,10 @@ class TestColumnMetadataTables:
 
     def test_render_columns_table_emits_six_column_markdown(self):
         """_render_columns_table produces a 6-column markdown table with one row per entry."""
-        from nmaipy.column_metadata import ColumnMeta
-
-        sample = {
-            "score": ColumnMeta(dtype="float", min="0", max="100", description="Some score"),
-            "flag": ColumnMeta(dtype="Y/N", description="Some flag"),
-        }
-        rendered = _render_columns_table(sample)
-        # Header + separator + 2 rows = 4 lines
+        # Use columns whose dtype/description don't contain escaped pipes so the
+        # raw pipe-count check is a clean structural test.
+        rendered = _render_columns_table(["roof_spotlight_index", "mesh_date"])
+        # Header + separator + 2 rows = 4 lines.
         assert len(rendered) == 4
         assert rendered[0] == "| Column | Type | Min | Max | Unit | Description |"
         # Each row has exactly 7 pipes (delimiting 6 columns).
@@ -284,18 +280,24 @@ class TestColumnMetadataTables:
             assert row.count("|") == 7
 
     def test_render_columns_table_substitutes_unit_placeholders(self):
-        """`{unit}` (column name) and `{unit_name}` (Unit cell) substitute on render."""
-        from nmaipy.column_metadata import ColumnMeta
-
-        sample = {"area_{unit}": ColumnMeta(dtype="float", min="0", unit="{unit_name}", description="Area of feature")}
-        us_rows = _render_columns_table(sample, area_unit="sqft")
-        au_rows = _render_columns_table(sample, area_unit="sqm")
+        """`{unit}` in column names is resolved to the area suffix; `{unit_name}` is filled by lookup_column."""
+        # `dominant_roof_material_area_{unit}` is a templated entry in the JSON.
+        us_rows = _render_columns_table(["dominant_roof_material_area_{unit}"], area_unit="sqft")
+        au_rows = _render_columns_table(["dominant_roof_material_area_{unit}"], area_unit="sqm")
         # US: column name uses sqft suffix, Unit cell uses spelled-out form.
-        assert any("`area_sqft`" in row for row in us_rows)
+        assert any("`dominant_roof_material_area_sqft`" in row for row in us_rows)
         assert any("square feet" in row for row in us_rows)
         # AU: column name uses sqm suffix, Unit cell spelled out.
-        assert any("`area_sqm`" in row for row in au_rows)
+        assert any("`dominant_roof_material_area_sqm`" in row for row in au_rows)
         assert any("square metres" in row for row in au_rows)
+
+    def test_render_columns_table_substitutes_class_label(self):
+        """{class_label} in JSON descriptions is substituted at render time, not leaked."""
+        # The `link` entry's description references {class_label} — must be resolved.
+        rendered = _render_columns_table(["link"], class_label="property")
+        for row in rendered:
+            assert "{class_label}" not in row, f"unsubstituted placeholder leaked: {row!r}"
+        assert any("URL to view the property" in row for row in rendered)
 
     def test_aoi_id_dtype_pipe_is_escaped(self):
         """The aoi_id `string | int` dtype escapes the markdown pipe so it doesn't break the table."""
@@ -321,6 +323,35 @@ class TestColumnMetadataTables:
         assert "| Column | Type | Min | Max | Unit | Description |" in content
         # RSI score's bounds are split across Min and Max cells.
         assert "| 0 | 100 |" in content
+
+    def test_rendered_readme_has_no_unresolved_placeholders(self, tmp_path):
+        """Regression test: no {placeholder} survives into the rendered README.
+
+        Previously the JSON description for `link` contained ``{class_label}``
+        which `_render_columns_table` did not substitute, so it shipped to
+        customers as a literal placeholder. Routing rendering through
+        ``column_metadata.lookup_column`` fixes it; this test guards the fix.
+        """
+        import re
+
+        # Realistic exporter output: rollup with roof age + RSI columns plus per-class files.
+        (tmp_path / "rollup.csv").write_text(
+            "aoi_id,link,roof_spotlight_index,roof_age_installation_date,"
+            "primary_roof_staining_area_sqft\n"
+            "0,https://example,85,2019-06,12.3\n"
+        )
+        (tmp_path / "roof.csv").write_text("aoi_id,link\n0,https://example\n")
+        (tmp_path / "roof_instance.csv").write_text("aoi_id\n0\n")
+        content = ReadmeGenerator(output_dir=tmp_path)._generate()
+
+        # `{class}_*` and `primary_{class}_*` placeholders ARE expected in the
+        # "Column Naming Patterns" section as illustrative templates, so we
+        # restrict the check to lowercase-letter placeholders that are NOT
+        # within backticks (i.e. table cells, not the pattern docs).
+        # Strip code blocks first so backtick-quoted patterns don't trigger.
+        without_code = re.sub(r"`[^`]*`", "", content)
+        leaks = re.findall(r"\{[a-z_]+\}", without_code)
+        assert not leaks, f"unsubstituted placeholders leaked into README: {sorted(set(leaks))}"
 
 
 class TestLoadExportConfig:


### PR DESCRIPTION
## Summary
- Generates a `<filename>_data_dictionary.csv` next to every CSV/parquet AI-data output in `final/` (rollup, per-class building/roof/roof_instance/swimming_pool/solar_panel/building_lifecycle, plus features.parquet). Each lists column name, description, allowed values, dtype, source, min, max, and precision per the ticket schema. Failure is isolated and logged — the data files themselves remain the export's contract.
- PM-editable config at `nmaipy/data/column_metadata.json` (curated `exact_matches` + ordered `patterns`). Lookup precedence: exact match → scope-stripped exact match → first matching regex → `?` sentinel.
- `ROOF_AGE_PREFIX_COLUMNS` becomes an ordered tuple; canonical roof-age column order is now applied across `roof_instance.csv`, rollup `primary_roof_instance_*`, `roof.csv` `primary_child_roof_age_*`, and `building.csv` chained `primary_child_roof_*_*`. `flatten_roof_instance_attributes` always emits every canonical key (None when missing) so column order survives DataFrame assembly across rows with missing fields.
- `nmaipy/readme_generator.py` migrated to `ColumnMeta` dataclass — same render output, single source of truth shared with the dictionaries.

## Test plan
- [x] `pytest -m "not live_api"` (549 passed, 11 skipped)
- [x] E2E unified exporter — `building` pack + `--roof-age` + `--save-features` (US): all four files (rollup, roof_instance, roof, building) ship roof-age columns in canonical order; capture-date columns contiguous (`before` → `after` → `min` → `max` → `number_of_captures`)
- [x] E2E unified exporter — full pack list + all peril/score includes + `--roof-age` + `--only3d` (US): all per-class data dictionaries materialise; scope-aware descriptions render correctly across rollup, per-class, and child-scope contexts
- [x] PM-editability check: editing JSON descriptions reloads via `reload_metadata()` and propagates to regenerated dictionaries

## Out of scope
- README extensions (PR2): primary feature selection logic, dominant material/shape rules, BL→Building→Roof→Roof Instance hierarchy section. Will follow in a separate PR.
- Standalone `python -m nmaipy.roof_age_exporter` outputs are unchanged; per user direction, this PR focuses on the unified `NearmapAIExporter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)