### PR TITLE
[INDS-2080] Describe pass-through user columns in data dictionary

### DIFF
--- a/nmaipy/aoi_io.py
+++ b/nmaipy/aoi_io.py
@@ -17,11 +17,46 @@ from typing import Optional, Union
 
 import geopandas as gpd
 import pandas as pd
+import pyarrow.parquet as pq
 
 from nmaipy import log
 from nmaipy.constants import ADDRESS_FIELDS, AOI_ID_COLUMN_NAME, LAT_LONG_CRS
 
 logger = log.get_logger()
+
+
+def _path_suffix(path: Union[str, Path]) -> str:
+    """Return the lowercased extension of ``path``.
+
+    Strips off any query string (``?key=val``) and fragment (``#x``) so that
+    S3-style URIs like ``s3://bucket/file.csv?x=y`` resolve to ``"csv"``.
+    Returns an empty string if the path has no extension.
+    """
+    s = str(path)
+    s = s.split("?", 1)[0].split("#", 1)[0]
+    return s.rsplit(".", 1)[-1].lower() if "." in s else ""
+
+
+def read_header_columns(path: Union[str, Path]) -> set[str]:
+    """Return the set of column names from an AOI file by reading only its header.
+
+    Mirrors the format support of :func:`read_from_file` (CSV/PSV/TSV with WKT,
+    GeoJSON, GeoPackage, Parquet/GeoParquet). Avoids materialising the full file.
+
+    Raises:
+        NotImplementedError: If the file format is not supported.
+    """
+    suffix = _path_suffix(path)
+    sep_for = {"csv": ",", "psv": "|", "tsv": "\t"}
+    if suffix in sep_for:
+        return set(pd.read_csv(path, sep=sep_for[suffix], nrows=0).columns)
+    if suffix == "parquet":
+        # Parquet schema can be read without materialising any rows.
+        return set(pq.read_schema(path).names)
+    if suffix in ("geojson", "gpkg"):
+        # geopandas reads the file; rows=0 limits to the header schema.
+        return set(gpd.read_file(path, rows=0).columns)
+    raise NotImplementedError(f"Source format not supported: {suffix=}")
 
 
 def read_from_file(

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -26,6 +26,14 @@ from typing import Optional
 # generated dictionaries so missing descriptions are easy to spot.
 UNKNOWN_SENTINEL = "?"
 
+# Description/source rendered for arbitrary columns that the user passed
+# through from their input AOI file (e.g. `external_id`, `address`). These
+# columns aren't in the seeded metadata, but they aren't truly unknown
+# either — the data dictionary generator substitutes these for the sentinel
+# when it can match the column against the input file's header.
+USER_INPUT_DESCRIPTION = "Input column provided by user (passed through from the input AOI file)."
+USER_INPUT_SOURCE = "input data"
+
 # Long-form unit names paired with their short column-suffix form.
 _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
 

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -26,14 +26,6 @@ from typing import Optional
 # generated dictionaries so missing descriptions are easy to spot.
 UNKNOWN_SENTINEL = "?"
 
-# Description/source rendered for arbitrary columns that the user passed
-# through from their input AOI file (e.g. `external_id`, `address`). These
-# columns aren't in the seeded metadata, but they aren't truly unknown
-# either — the data dictionary generator substitutes these for the sentinel
-# when it can match the column against the input file's header.
-USER_INPUT_DESCRIPTION = "Input column provided by user (passed through from the input AOI file)."
-USER_INPUT_SOURCE = "input data"
-
 # Long-form unit names paired with their short column-suffix form.
 _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
 

--- a/nmaipy/data_dictionary_generator.py
+++ b/nmaipy/data_dictionary_generator.py
@@ -15,15 +15,17 @@ from typing import Optional
 import pandas as pd
 import pyarrow.parquet as pq
 
-from nmaipy import output_files, storage
-from nmaipy.column_metadata import (
-    UNKNOWN_SENTINEL,
-    USER_INPUT_DESCRIPTION,
-    USER_INPUT_SOURCE,
-    lookup_column,
-)
+from nmaipy import aoi_io, output_files, storage
+from nmaipy.column_metadata import lookup_column
 
 logger = logging.getLogger(__name__)
+
+# Description/source rendered for arbitrary columns the user passed through
+# from their input AOI file (e.g. ``external_id``, ``address``). Recognised
+# by header-matching against the input file rather than living in the seeded
+# JSON metadata, since they vary per export.
+USER_INPUT_DESCRIPTION = "Input column provided by user (passed through from the input AOI file)."
+USER_INPUT_SOURCE = "input data"
 
 _DD_COLUMNS = [
     "column_name",
@@ -112,13 +114,13 @@ class DataDictionaryGenerator:
 
         Used to recognise pass-through user columns (e.g. ``external_id``,
         ``address``) so the data dictionary can describe them as input columns
-        rather than rendering the unknown sentinel. Reads only the header.
+        rather than rendering the unknown sentinel.
         """
         aoi_file = self._load_export_config().get("parameters", {}).get("aoi_file")
         if not aoi_file:
             return set()
         try:
-            return _read_header_columns(str(aoi_file))
+            return aoi_io.read_header_columns(str(aoi_file))
         except Exception as exc:
             logger.debug(f"Could not read input AOI columns from {aoi_file!r}: {exc}")
             return set()
@@ -200,7 +202,7 @@ class DataDictionaryGenerator:
         # Pass-through columns from the user's input file aren't in the seeded
         # metadata. Recognise them so the dictionary describes them rather
         # than surfacing the unknown sentinel.
-        if meta.description == UNKNOWN_SENTINEL and name in input_columns:
+        if meta.is_unknown() and name in input_columns:
             description = USER_INPUT_DESCRIPTION
             source = USER_INPUT_SOURCE
         else:
@@ -224,33 +226,6 @@ class DataDictionaryGenerator:
         name = storage.basename(filepath)
         stem = name.rsplit(".", 1)[0]
         return storage.join_path(directory, f"{stem}_data_dictionary.csv")
-
-
-def _read_header_columns(path: str) -> set[str]:
-    """Return the set of column names from an input AOI file by reading just the header.
-
-    Supports the same formats as ``aoi_io.read_from_file`` (CSV/PSV/TSV,
-    GeoJSON, GeoPackage, Parquet). Raises on unsupported formats; callers
-    catch and degrade gracefully.
-    """
-    suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-    sep_for = {"csv": ",", "psv": "|", "tsv": "\t"}
-    if suffix in sep_for:
-        with storage.open_file(path, "r") as fh:
-            df = pd.read_csv(fh, sep=sep_for[suffix], nrows=0)
-        return set(df.columns)
-    if suffix == "parquet":
-        with storage.open_file(path, "rb") as fh:
-            schema = pq.read_schema(fh)
-        return set(schema.names)
-    if suffix in ("geojson", "json", "gpkg"):
-        # geopandas can read these; cheaper than alternatives and the file
-        # is typically small enough that loading it once is fine.
-        import geopandas as gpd
-
-        gdf = gpd.read_file(path, rows=0)
-        return set(gdf.columns)
-    raise ValueError(f"Unsupported input AOI format: {path!r}")
 
 
 def generate_dictionaries(output_dir: str) -> list[str]:

--- a/nmaipy/data_dictionary_generator.py
+++ b/nmaipy/data_dictionary_generator.py
@@ -16,7 +16,12 @@ import pandas as pd
 import pyarrow.parquet as pq
 
 from nmaipy import output_files, storage
-from nmaipy.column_metadata import lookup_column
+from nmaipy.column_metadata import (
+    UNKNOWN_SENTINEL,
+    USER_INPUT_DESCRIPTION,
+    USER_INPUT_SOURCE,
+    lookup_column,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,10 +69,11 @@ class DataDictionaryGenerator:
         ext = self._tabular_extension()
         area_unit = self._detect_area_unit()
         extras = self._description_extras()
+        input_columns = self._input_columns()
         written: list[str] = []
         for filepath, class_label in output_files.tabular_ai_files(self.final_dir, ext):
             try:
-                out_path = self._build_and_write(filepath, class_label, area_unit, extras)
+                out_path = self._build_and_write(filepath, class_label, area_unit, extras, input_columns)
             except Exception as exc:
                 logger.warning(f"Data dictionary generation failed for {filepath}: {exc}")
                 continue
@@ -100,6 +106,22 @@ class DataDictionaryGenerator:
         """Return ``'csv'`` or ``'parquet'`` based on the export's tabular_file_format setting."""
         fmt = self._load_export_config().get("parameters", {}).get("tabular_file_format", "csv")
         return fmt if fmt in ("csv", "parquet") else "csv"
+
+    def _input_columns(self) -> set[str]:
+        """Return column names from the input AOI file, or empty set on any failure.
+
+        Used to recognise pass-through user columns (e.g. ``external_id``,
+        ``address``) so the data dictionary can describe them as input columns
+        rather than rendering the unknown sentinel. Reads only the header.
+        """
+        aoi_file = self._load_export_config().get("parameters", {}).get("aoi_file")
+        if not aoi_file:
+            return set()
+        try:
+            return _read_header_columns(str(aoi_file))
+        except Exception as exc:
+            logger.debug(f"Could not read input AOI columns from {aoi_file!r}: {exc}")
+            return set()
 
     def _description_extras(self) -> dict[str, str]:
         """Build the extra-substitution dict used by ``column_metadata.lookup_column``.
@@ -148,10 +170,15 @@ class DataDictionaryGenerator:
     # ------------------------------------------------------------------
 
     def _build_and_write(
-        self, filepath: str, class_label: str, area_unit: str, extras: dict[str, str]
+        self,
+        filepath: str,
+        class_label: str,
+        area_unit: str,
+        extras: dict[str, str],
+        input_columns: set[str],
     ) -> Optional[str]:
         columns = self._read_columns(filepath)
-        rows = [self._row_for_column(name, area_unit, class_label, extras) for name in columns]
+        rows = [self._row_for_column(name, area_unit, class_label, extras, input_columns) for name in columns]
         if not rows:
             return None
         out_path = self._dictionary_path_for(filepath)
@@ -160,15 +187,31 @@ class DataDictionaryGenerator:
         df.to_csv(out_path, index=False, encoding="utf-8-sig")
         return out_path
 
-    def _row_for_column(self, name: str, area_unit: str, class_label: str, extras: dict[str, str]) -> dict[str, str]:
+    def _row_for_column(
+        self,
+        name: str,
+        area_unit: str,
+        class_label: str,
+        extras: dict[str, str],
+        input_columns: set[str],
+    ) -> dict[str, str]:
         """Build a single dictionary row for one column."""
         meta = lookup_column(name, area_unit=area_unit, class_label=class_label, extras=extras)
+        # Pass-through columns from the user's input file aren't in the seeded
+        # metadata. Recognise them so the dictionary describes them rather
+        # than surfacing the unknown sentinel.
+        if meta.description == UNKNOWN_SENTINEL and name in input_columns:
+            description = USER_INPUT_DESCRIPTION
+            source = USER_INPUT_SOURCE
+        else:
+            description = meta.description
+            source = meta.source
         return {
             "column_name": name,
-            "description": meta.description,
+            "description": description,
             "allowed_values": meta.allowed_values,
             "dtype": meta.dtype,
-            "source": meta.source,
+            "source": source,
             "min": meta.min,
             "max": meta.max,
             "precision": meta.precision,
@@ -181,6 +224,33 @@ class DataDictionaryGenerator:
         name = storage.basename(filepath)
         stem = name.rsplit(".", 1)[0]
         return storage.join_path(directory, f"{stem}_data_dictionary.csv")
+
+
+def _read_header_columns(path: str) -> set[str]:
+    """Return the set of column names from an input AOI file by reading just the header.
+
+    Supports the same formats as ``aoi_io.read_from_file`` (CSV/PSV/TSV,
+    GeoJSON, GeoPackage, Parquet). Raises on unsupported formats; callers
+    catch and degrade gracefully.
+    """
+    suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    sep_for = {"csv": ",", "psv": "|", "tsv": "\t"}
+    if suffix in sep_for:
+        with storage.open_file(path, "r") as fh:
+            df = pd.read_csv(fh, sep=sep_for[suffix], nrows=0)
+        return set(df.columns)
+    if suffix == "parquet":
+        with storage.open_file(path, "rb") as fh:
+            schema = pq.read_schema(fh)
+        return set(schema.names)
+    if suffix in ("geojson", "json", "gpkg"):
+        # geopandas can read these; cheaper than alternatives and the file
+        # is typically small enough that loading it once is fine.
+        import geopandas as gpd
+
+        gdf = gpd.read_file(path, rows=0)
+        return set(gdf.columns)
+    raise ValueError(f"Unsupported input AOI format: {path!r}")
 
 
 def generate_dictionaries(output_dir: str) -> list[str]:

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -455,9 +455,9 @@ class TestUserInputColumns:
         dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
         rows = {r["column_name"]: r for _, r in dd.iterrows()}
         for col in ("external_id", "force_new", "address"):
-            assert "Input column provided by user" in rows[col]["description"], (
-                f"{col} should be labelled as user-supplied"
-            )
+            assert (
+                "Input column provided by user" in rows[col]["description"]
+            ), f"{col} should be labelled as user-supplied"
             assert rows[col]["source"] == "input data"
         # Known columns are unaffected.
         assert "?" not in rows["tile_area_sqft"]["description"]
@@ -488,3 +488,17 @@ class TestUserInputColumns:
         dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
         rows = {r["column_name"]: r for _, r in dd.iterrows()}
         assert rows["external_id"]["description"] == "?"
+
+    def test_parquet_input_columns_recognised(self, tmp_path):
+        # Parquet input files exercise a different branch of the header reader.
+        aoi_path = tmp_path / "input_aois.parquet"
+        _write_parquet(aoi_path, ["aoi_id", "external_id", "policy_number"])
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id", "external_id", "policy_number"])
+        self._write_aoi_config(tmp_path, aoi_path)
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
+        rows = {r["column_name"]: r for _, r in dd.iterrows()}
+        for col in ("external_id", "policy_number"):
+            assert "Input column provided by user" in rows[col]["description"]
+            assert rows[col]["source"] == "input data"

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -417,3 +417,74 @@ class TestCrossFileConsistency:
             assert len(entries) >= 2, f"shared column {col!r} only seen in one file: {entries}"
             unique = {struct for _, struct in entries}
             assert len(unique) == 1, f"structural metadata for {col!r} differs across files: {entries}"
+
+
+# ---------------------------------------------------------------------------
+# 13. Pass-through user input columns
+# ---------------------------------------------------------------------------
+
+
+class TestUserInputColumns:
+    """Arbitrary columns from the input AOI file should be labelled as user-supplied
+    rather than rendering as the unknown sentinel. Triggers when the input file
+    is reachable via the ``aoi_file`` recorded in ``export_config.json``.
+    """
+
+    def _write_aoi_config(self, dirpath: Path, aoi_file: Path) -> None:
+        payload = {
+            "parameters": {
+                "tabular_file_format": "csv",
+                "country": "us",
+                "aoi_file": str(aoi_file),
+            }
+        }
+        (dirpath / "export_config.json").write_text(json.dumps(payload))
+
+    def test_input_columns_described_as_user_provided(self, tmp_path):
+        # Input file with columns the metadata layer has never heard of.
+        aoi_path = tmp_path / "input_aois.csv"
+        _write_csv(aoi_path, ["aoi_id", "external_id", "force_new", "address"])
+        # Rollup carries the same columns through plus a known one.
+        _write_csv(
+            tmp_path / "rollup.csv",
+            ["aoi_id", "external_id", "force_new", "address", "tile_area_sqft"],
+        )
+        self._write_aoi_config(tmp_path, aoi_path)
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
+        rows = {r["column_name"]: r for _, r in dd.iterrows()}
+        for col in ("external_id", "force_new", "address"):
+            assert "Input column provided by user" in rows[col]["description"], (
+                f"{col} should be labelled as user-supplied"
+            )
+            assert rows[col]["source"] == "input data"
+        # Known columns are unaffected.
+        assert "?" not in rows["tile_area_sqft"]["description"]
+        assert rows["aoi_id"]["source"] == "input data"  # already curated, unchanged
+
+    def test_unknown_column_not_in_input_still_sentinel(self, tmp_path):
+        # If a column appears in output but not in the input file, it remains
+        # an unknown sentinel — the override is gated on the input file's
+        # column set, not a blanket fallback.
+        aoi_path = tmp_path / "input_aois.csv"
+        _write_csv(aoi_path, ["aoi_id"])  # only aoi_id in input
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id", "totally_unknown_xyz"])
+        self._write_aoi_config(tmp_path, aoi_path)
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
+        rows = {r["column_name"]: r for _, r in dd.iterrows()}
+        assert rows["totally_unknown_xyz"]["description"] == "?"
+        assert rows["totally_unknown_xyz"]["source"] == "?"
+
+    def test_missing_input_file_falls_back_gracefully(self, tmp_path):
+        # If aoi_file is unreadable, generator should not crash and unknown
+        # columns continue to render the sentinel (preserving prior behaviour).
+        self._write_aoi_config(tmp_path, tmp_path / "does_not_exist.csv")
+        _write_csv(tmp_path / "rollup.csv", ["aoi_id", "external_id"])
+        DataDictionaryGenerator(output_dir=tmp_path).generate_and_save()
+
+        dd = pd.read_csv(tmp_path / "rollup_data_dictionary.csv", keep_default_na=False)
+        rows = {r["column_name"]: r for _, r in dd.iterrows()}
+        assert rows["external_id"]["description"] == "?"


### PR DESCRIPTION
## Summary

- Arbitrary columns from the input AOI file (e.g. `external_id`, `address`, `force_new`) used to render as the `?` sentinel in `*_data_dictionary.csv`, indistinguishable from columns we'd genuinely failed to document.
- The dictionary generator now reads the input file's header (via `aoi_file` recorded in `export_config.json`) and substitutes a "provided by user" description and `input data` source for any unknown column that matches.
- `USER_INPUT_DESCRIPTION` / `USER_INPUT_SOURCE` live in `column_metadata.py` alongside `UNKNOWN_SENTINEL` — they're rendering primitives, not seeded metadata, so they don't fit the JSON's `exact_matches` / `patterns` shape.
- Failure modes (missing `aoi_file`, unreadable path, unsupported format) degrade silently to the prior sentinel behaviour.

## Test plan

- [x] `pytest tests/test_data_dictionary_generator.py` — 33 tests, including 3 new cases covering: input columns labelled correctly, output-only unknowns still sentinel, missing input file degrades gracefully.
- [x] Full non-live suite: 547 passed.
- [x] End-to-end exporter run with arbitrary input columns (`external_id`, `customer_account`, `priority_flag`) — confirmed all three render with the user-input description and `input data` source in `rollup_data_dictionary.csv`; curated entries like `aoi_id` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)