### PR TITLE
[TRO-4354] Add --prefer3d for 3D-first exports with per-AOI 2D fallback

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2066,6 +2066,15 @@ def parse_arguments():
         action="store_true",
     )
     parser.add_argument(
+        "--prefer3d",
+        help=(
+            "Prefer 3D surveys but fall back to 2D per AOI when no 3D coverage is "
+            "available in the date window. Mutually exclusive with --only3d. "
+            "No-op for AOIs pinned to a survey_resource_id."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
         "--since",
         help="Bulk limit on date for responses (earliest inclusive date returned). Presence of 'since' column in data takes precedent.",
         required=False,
@@ -2137,6 +2146,9 @@ def parse_arguments():
         type=str,
     )
     args = parser.parse_args()
+
+    if args.only3d and args.prefer3d:
+        parser.error("--only3d and --prefer3d are mutually exclusive")
 
     if args.roof_age:
         resolved = resolve_roof_age_dataset(args.roof_age_dataset)
@@ -2230,6 +2242,7 @@ class NearmapAIExporter(BaseExporter):
         beta=False,
         prerelease=False,
         only3d=False,
+        prefer3d=False,
         since=None,
         until=None,
         url_root=DEFAULT_URL_ROOT,
@@ -2276,7 +2289,10 @@ class NearmapAIExporter(BaseExporter):
         self.alpha = alpha
         self.beta = beta
         self.prerelease = prerelease
+        if only3d and prefer3d:
+            raise ValueError("only3d and prefer3d are mutually exclusive")
         self.only3d = only3d
+        self.prefer3d = prefer3d
         self.since = since
         self.until = until
         self.url_root = url_root
@@ -2345,6 +2361,7 @@ class NearmapAIExporter(BaseExporter):
             "beta": beta,
             "prerelease": prerelease,
             "only3d": only3d,
+            "prefer3d": prefer3d,
             "since": since,
             "until": until,
             "url_root": url_root,
@@ -2930,6 +2947,7 @@ class NearmapAIExporter(BaseExporter):
                 beta=self.beta,
                 prerelease=self.prerelease,
                 only3d=self.only3d,
+                prefer3d=self.prefer3d,
                 url_root=self.url_root,
                 system_version_prefix=self.system_version_prefix,
                 system_version=self.system_version,
@@ -3235,6 +3253,7 @@ class NearmapAIExporter(BaseExporter):
                 "survey_resource_id",
                 "perspective",
                 "postcat",
+                "mesh_date",
             ]
             # Rename metadata columns that clash with user's AOI columns
             conflicting_columns = [c for c in meta_data_columns if c in aoi_gdf.columns]
@@ -3279,10 +3298,11 @@ class NearmapAIExporter(BaseExporter):
                     f"Chunk {chunk_id}: Failed writing errors_df ({len(errors_df)} rows) to {outfile_errors}."
                 )
                 self.logger.error(f"Error: {type(e).__name__}: {str(e)}")
-            # Drop survey_date from metadata_df to avoid collision with features_gdf
-            # (features_gdf has per-feature survey_date which is more accurate for gridded AOIs)
+            # Drop survey_date/mesh_date from metadata_df to avoid collision with features_gdf
+            # (features_gdf has per-feature survey_date/mesh_date which is more accurate for gridded AOIs).
+            # The AOI-level mesh_date in metadata acts as a fallback for AOIs with zero features.
             metadata_cols_to_drop = [
-                c for c in ["survey_date"] if c in metadata_df.columns and c in features_gdf.columns
+                c for c in ["survey_date", "mesh_date"] if c in metadata_df.columns and c in features_gdf.columns
             ]
             if metadata_cols_to_drop:
                 metadata_df = metadata_df.drop(columns=metadata_cols_to_drop)
@@ -4220,6 +4240,7 @@ def main():
         beta=args.beta,
         prerelease=args.prerelease,
         only3d=args.only3d,
+        prefer3d=args.prefer3d,
         since=args.since,
         until=args.until,
         url_root=args.url_root,

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -3266,6 +3266,13 @@ class NearmapAIExporter(BaseExporter):
                 columns=[c for c in metadata_df.columns if c not in meta_data_columns + [AOI_ID_COLUMN_NAME]],
                 errors="ignore",
             )
+            # rollup_df already carries mesh_date when features exist (set by parcels.parcel_rollup
+            # from per-feature meshDate) — same value as the top-level 3dDate in metadata. Drop the
+            # metadata copy before the rollup merge to avoid a _x/_y suffix collision; the rollup's
+            # mesh_date wins. For AOIs without features (no rollup mesh_date column), metadata's
+            # mesh_date stays and serves as the AOI-level 3D/2D signal.
+            if "mesh_date" in rollup_df.columns and "mesh_date" in metadata_df.columns:
+                metadata_df = metadata_df.drop(columns=["mesh_date"])
             # Use rollup_df as base to preserve all AOIs (including those where Feature API
             # failed but Roof Age API succeeded). Left-merge with metadata_df to add
             # survey metadata where available.

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -145,6 +145,7 @@ class FeatureApi(GriddedApiClient):
         beta: Optional[bool] = False,
         prerelease: Optional[bool] = False,
         only3d: Optional[bool] = False,
+        prefer3d: Optional[bool] = False,
         url_root: Optional[str] = "api.nearmap.com/ai/features/v4/bulk",
         system_version_prefix: Optional[str] = "gen6-",
         system_version: Optional[str] = None,
@@ -170,7 +171,11 @@ class FeatureApi(GriddedApiClient):
             alpha: Include alpha features
             beta: Include beta features
             prerelease: Include prerelease features
-            only3d: Only return features with 3D coverage
+            only3d: Only return features with 3D coverage. Mutually exclusive with prefer3d.
+            prefer3d: Prefer 3D surveys but fall back to 2D per-AOI when no 3D coverage is
+                available in the date window. Implies only3d=True for the first pass; AOIs that
+                return 404 are retried with only3d=False via a sibling FeatureApi. Mutually
+                exclusive with only3d. No-op for AOIs pinned to a survey_resource_id.
             url_root: The root URL for the API. Default is the bulk API.
             system_version_prefix: Prefix for the system version (e.g. "gen6-" to restrict to gen 6 results)
             system_version: System version to use (e.g. "gen6-glowing_grove-1.0" to restrict to exact version matches)
@@ -204,6 +209,9 @@ class FeatureApi(GriddedApiClient):
         if not bulk_mode:
             url_root = "api.nearmap.com/ai/features/v4"
 
+        # Preserve resolved url_root so _clone_for_2d_fallback can construct a sibling
+        # FeatureApi that talks to the same endpoint as self.
+        self.url_root = url_root
         URL_ROOT = f"https://{url_root}"
         self.FEATURES_URL = URL_ROOT + "/features.json"
         self.FEATURES_SURVEY_RESOURCE_URL = URL_ROOT + "/surveyresources"
@@ -215,7 +223,12 @@ class FeatureApi(GriddedApiClient):
         self.alpha = alpha
         self.beta = beta
         self.prerelease = prerelease
-        self.only3d = only3d
+        if only3d and prefer3d:
+            raise ValueError("only3d and prefer3d are mutually exclusive")
+        self.prefer3d = prefer3d
+        # When prefer3d is set, the first pass behaves as only3d=True; the bulk method
+        # constructs a sibling FeatureApi with only3d=False for the 2D fallback pass.
+        self.only3d = only3d or prefer3d
         self.system_version_prefix = system_version_prefix
         self.system_version = system_version
         self.aoi_grid_min_pct = aoi_grid_min_pct
@@ -865,6 +878,7 @@ class FeatureApi(GriddedApiClient):
             "survey_resource_id": payload["resourceId"],
             "perspective": payload["perspective"],
             "postcat": payload["postcat"],
+            "mesh_date": payload.get("3dDate", ""),
             "aggregate": payload.get("aggregate"),
         }
 
@@ -1060,6 +1074,7 @@ class FeatureApi(GriddedApiClient):
                 "survey_resource_id": metadata_df["survey_resource_id"],
                 "perspective": metadata_df["perspective"],
                 "postcat": metadata_df["postcat"],
+                "mesh_date": metadata_df.get("mesh_date", ""),
             }
 
             # Return grid cell errors as 4th element (may include geometry for failed grid squares)
@@ -1492,6 +1507,200 @@ class FeatureApi(GriddedApiClient):
     ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[pd.DataFrame], pd.DataFrame]:
         """
         Get features data for many AOIs.
+
+        When ``self.prefer3d`` is set, this method orchestrates a two-pass run: first
+        with only3d=True (3D coverage required), then a 2D fallback for AOIs that 404'd
+        in pass 1 (no 3D survey available in the date window). Gridded recursion from
+        ``get_features_gdf_gridded`` (``in_gridding_mode=True``) bypasses the prefer3d
+        dispatch — grid cells always run in the same mode as their parent pass.
+
+        See :py:meth:`_get_features_gdf_bulk_inner` for the underlying single-pass
+        implementation.
+        """
+        if not self.prefer3d or in_gridding_mode:
+            return self._get_features_gdf_bulk_inner(
+                gdf=gdf,
+                region=region,
+                packs=packs,
+                classes=classes,
+                include=include,
+                since_bulk=since_bulk,
+                until_bulk=until_bulk,
+                survey_resource_id_bulk=survey_resource_id_bulk,
+                max_allowed_error_pct=max_allowed_error_pct,
+                fail_hard_regrid=fail_hard_regrid,
+                in_gridding_mode=in_gridding_mode,
+                disable_parcel_mode=disable_parcel_mode,
+            )
+        return self._run_prefer3d_passes(
+            gdf=gdf,
+            region=region,
+            packs=packs,
+            classes=classes,
+            include=include,
+            since_bulk=since_bulk,
+            until_bulk=until_bulk,
+            survey_resource_id_bulk=survey_resource_id_bulk,
+            max_allowed_error_pct=max_allowed_error_pct,
+            fail_hard_regrid=fail_hard_regrid,
+            disable_parcel_mode=disable_parcel_mode,
+        )
+
+    def _run_prefer3d_passes(
+        self,
+        gdf: gpd.GeoDataFrame,
+        region: str,
+        packs: Optional[List[str]] = None,
+        classes: Optional[List[str]] = None,
+        include: Optional[List[str]] = None,
+        since_bulk: Optional[str] = None,
+        until_bulk: Optional[str] = None,
+        survey_resource_id_bulk: Optional[str] = None,
+        max_allowed_error_pct: Optional[int] = 100,
+        fail_hard_regrid: Optional[bool] = False,
+        disable_parcel_mode: bool = False,
+    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[pd.DataFrame], pd.DataFrame]:
+        """Two-pass prefer3d orchestrator: 3D-only, then 2D fallback for 404s."""
+        # Pass 1: 3D-only. self.only3d is already True (set in __init__ when prefer3d).
+        features_3d, meta_3d, errors_3d = self._get_features_gdf_bulk_inner(
+            gdf=gdf,
+            region=region,
+            packs=packs,
+            classes=classes,
+            include=include,
+            since_bulk=since_bulk,
+            until_bulk=until_bulk,
+            survey_resource_id_bulk=survey_resource_id_bulk,
+            max_allowed_error_pct=max_allowed_error_pct,
+            fail_hard_regrid=fail_hard_regrid,
+            in_gridding_mode=False,
+            disable_parcel_mode=disable_parcel_mode,
+        )
+
+        if len(errors_3d) == 0 or survey_resource_id_bulk is not None:
+            # Either nothing failed, or the bulk run is pinned to a specific survey
+            # resource (so 3D-vs-2D isn't a choice we can make).
+            return features_3d, meta_3d, errors_3d
+
+        # Retry candidates: AOIs that 404'd (no 3D coverage in window). Includes both
+        # plain 404s (single-AOI, no gridding) and grid failures where insufficient
+        # cells had 3D coverage to pass aoi_grid_min_pct — the grid error propagates
+        # the underlying 404 status_code.
+        retry_mask = errors_3d["status_code"] == 404
+        retry_ids = errors_3d.index[retry_mask].unique().tolist()
+
+        # Exclude any AOIs pinned to a survey_resource_id via per-row column.
+        if SURVEY_RESOURCE_ID_COL_NAME in gdf.columns and retry_ids:
+            retry_ids = [
+                aoi_id
+                for aoi_id in retry_ids
+                if aoi_id in gdf.index and not isinstance(gdf.loc[aoi_id, SURVEY_RESOURCE_ID_COL_NAME], str)
+            ]
+
+        if not retry_ids:
+            return features_3d, meta_3d, errors_3d
+
+        logger.info(f"prefer3d: retrying {len(retry_ids)} AOI(s) with only3d=False after 3D-only 404s.")
+
+        # Bump progress total to cover the extra 2D requests (mirrors the dynamic-total
+        # adjustment in get_features_gdf_gridded).
+        if self.progress_counters is not None:
+            with self.progress_counters["lock"]:
+                self.progress_counters["total"] += len(retry_ids)
+
+        fallback_api = self._clone_for_2d_fallback()
+        retry_gdf = gdf.loc[gdf.index.isin(retry_ids)]
+
+        features_2d, meta_2d, errors_2d = fallback_api._get_features_gdf_bulk_inner(
+            gdf=retry_gdf,
+            region=region,
+            packs=packs,
+            classes=classes,
+            include=include,
+            since_bulk=since_bulk,
+            until_bulk=until_bulk,
+            survey_resource_id_bulk=survey_resource_id_bulk,
+            max_allowed_error_pct=max_allowed_error_pct,
+            fail_hard_regrid=fail_hard_regrid,
+            in_gridding_mode=False,
+            disable_parcel_mode=disable_parcel_mode,
+        )
+
+        # Merge: drop 3D errors for AOIs that have been retried; carry forward the rest;
+        # append 2D-pass errors (AOIs that failed both passes).
+        surviving_errors_3d = errors_3d.drop(index=retry_ids, errors="ignore")
+        merged_errors_parts = [df for df in [surviving_errors_3d, errors_2d] if len(df) > 0]
+        if merged_errors_parts:
+            merged_errors = pd.concat(merged_errors_parts)
+        else:
+            merged_errors = pd.DataFrame([])
+            merged_errors.index.name = AOI_ID_COLUMN_NAME
+
+        if len(features_2d) > 0 and len(features_3d) > 0:
+            merged_features = gpd.GeoDataFrame(pd.concat([features_3d, features_2d]), geometry="geometry", crs=API_CRS)
+        elif len(features_2d) > 0:
+            merged_features = features_2d
+        else:
+            merged_features = features_3d
+
+        if len(meta_2d) > 0 and len(meta_3d) > 0:
+            merged_meta = pd.concat([meta_3d, meta_2d])
+        elif len(meta_2d) > 0:
+            merged_meta = meta_2d
+        else:
+            merged_meta = meta_3d
+
+        return merged_features, merged_meta, merged_errors
+
+    def _clone_for_2d_fallback(self) -> "FeatureApi":
+        """Return a sibling FeatureApi configured for the 2D fallback pass of prefer3d.
+
+        Shares cache_dir, api_key, progress_counters etc. with self, but with
+        only3d=False and prefer3d=False so the fallback runs as a normal 2D query.
+        """
+        return FeatureApi(
+            api_key=self.api_key,
+            bulk_mode=self.bulk_mode,
+            cache_dir=self.cache_dir,
+            overwrite_cache=self.overwrite_cache,
+            compress_cache=self.compress_cache,
+            threads=self.threads,
+            alpha=self.alpha,
+            beta=self.beta,
+            prerelease=self.prerelease,
+            only3d=False,
+            prefer3d=False,
+            url_root=self.url_root,
+            system_version_prefix=self.system_version_prefix,
+            system_version=self.system_version,
+            aoi_grid_min_pct=self.aoi_grid_min_pct,
+            aoi_grid_inexact=self.aoi_grid_inexact,
+            parcel_mode=self.parcel_mode,
+            maxretry=self.maxretry,
+            rapid=self.rapid,
+            order=self.order,
+            exclude_tiles_with_occlusion=self.exclude_tiles_with_occlusion,
+            progress_counters=self.progress_counters,
+            grid_size=self.grid_size,
+        )
+
+    def _get_features_gdf_bulk_inner(
+        self,
+        gdf: gpd.GeoDataFrame,
+        region: str,
+        packs: Optional[List[str]] = None,
+        classes: Optional[List[str]] = None,
+        include: Optional[List[str]] = None,
+        since_bulk: Optional[str] = None,
+        until_bulk: Optional[str] = None,
+        survey_resource_id_bulk: Optional[str] = None,
+        max_allowed_error_pct: Optional[int] = 100,
+        fail_hard_regrid: Optional[bool] = False,
+        in_gridding_mode: bool = False,
+        disable_parcel_mode: bool = False,
+    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[pd.DataFrame], pd.DataFrame]:
+        """Single-pass bulk feature fetch — see ``get_features_gdf_bulk`` for the
+        public, prefer3d-aware wrapper.
 
         Args:
             gdf: GeoDataFrame with AOIs

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1560,22 +1560,53 @@ class FeatureApi(GriddedApiClient):
         fail_hard_regrid: Optional[bool] = False,
         disable_parcel_mode: bool = False,
     ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[pd.DataFrame], pd.DataFrame]:
-        """Two-pass prefer3d orchestrator: 3D-only, then 2D fallback for 404s."""
+        """Two-pass prefer3d orchestrator: 3D-only, then 2D fallback.
+
+        Per-AOI fallback handles the common case where most AOIs have 3D coverage and
+        only a few need 2D. The wholesale fallback (when the 3D-only pass exceeds
+        ``max_allowed_error_pct``) catches the case where 3D coverage is too patchy to
+        be useful at all — rather than abort the entire export, we discard the 3D
+        attempt and run the bulk as a standard 2D query.
+        """
         # Pass 1: 3D-only. self.only3d is already True (set in __init__ when prefer3d).
-        features_3d, meta_3d, errors_3d = self._get_features_gdf_bulk_inner(
-            gdf=gdf,
-            region=region,
-            packs=packs,
-            classes=classes,
-            include=include,
-            since_bulk=since_bulk,
-            until_bulk=until_bulk,
-            survey_resource_id_bulk=survey_resource_id_bulk,
-            max_allowed_error_pct=max_allowed_error_pct,
-            fail_hard_regrid=fail_hard_regrid,
-            in_gridding_mode=False,
-            disable_parcel_mode=disable_parcel_mode,
-        )
+        # If 3D coverage is too patchy and exceeds max_allowed_error_pct, the inner
+        # method raises AIFeatureAPIError mid-flight — catch it and degrade to a
+        # wholesale 2D run for the entire bulk.
+        try:
+            features_3d, meta_3d, errors_3d = self._get_features_gdf_bulk_inner(
+                gdf=gdf,
+                region=region,
+                packs=packs,
+                classes=classes,
+                include=include,
+                since_bulk=since_bulk,
+                until_bulk=until_bulk,
+                survey_resource_id_bulk=survey_resource_id_bulk,
+                max_allowed_error_pct=max_allowed_error_pct,
+                fail_hard_regrid=fail_hard_regrid,
+                in_gridding_mode=False,
+                disable_parcel_mode=disable_parcel_mode,
+            )
+        except AIFeatureAPIError as e:
+            logger.info(
+                f"prefer3d: 3D-only pass exceeded max_allowed_error_pct={max_allowed_error_pct}% "
+                f"(status {e.status_code}); falling back to standard 2D for the whole bulk."
+            )
+            fallback_api = self._clone_for_2d_fallback()
+            return fallback_api._get_features_gdf_bulk_inner(
+                gdf=gdf,
+                region=region,
+                packs=packs,
+                classes=classes,
+                include=include,
+                since_bulk=since_bulk,
+                until_bulk=until_bulk,
+                survey_resource_id_bulk=survey_resource_id_bulk,
+                max_allowed_error_pct=max_allowed_error_pct,
+                fail_hard_regrid=fail_hard_regrid,
+                in_gridding_mode=False,
+                disable_parcel_mode=disable_parcel_mode,
+            )
 
         if len(errors_3d) == 0 or survey_resource_id_bulk is not None:
             # Either nothing failed, or the bulk run is pinned to a specific survey

--- a/tests/test_3d_attributes.py
+++ b/tests/test_3d_attributes.py
@@ -129,10 +129,14 @@ def test_3d_attributes_flattening(test_output_dir, salt_lake_aoi):
 
 @pytest.mark.integration
 @pytest.mark.live_api
-def test_prefer3d_end_to_end(test_output_dir, salt_lake_aoi):
-    """End-to-end run with --prefer3d. Confirms the unified export path produces
-    a mesh_date column and the AOI is resolved (either from 3D or 2D)."""
+def test_prefer3d_end_to_end_3d_path(test_output_dir, salt_lake_aoi):
+    """End-to-end run with --prefer3d against an AOI/window known to have 3D coverage.
 
+    The salt_lake_aoi (~40.7611, -111.8904) has a confirmed 3D capture on 2025-09-03;
+    with no since/until restriction, the latest survey for this point is 3D, so the
+    rollup row should carry a non-empty mesh_date and the 2D fallback path is NOT
+    exercised here (covered separately by `test_prefer3d_end_to_end_2d_fallback`).
+    """
     exporter = AOIExporter(
         aoi_file=str(salt_lake_aoi),
         output_dir=str(test_output_dir),
@@ -148,16 +152,59 @@ def test_prefer3d_end_to_end(test_output_dir, salt_lake_aoi):
 
     rollup_files = list((test_output_dir / "final").glob("rollup.*"))
     assert rollup_files, "rollup file should be created"
-
-    # Read whichever format was produced.
     rollup_path = rollup_files[0]
-    if rollup_path.suffix == ".parquet":
-        rollup = pd.read_parquet(rollup_path)
-    else:
-        rollup = pd.read_csv(rollup_path)
+    rollup = pd.read_parquet(rollup_path) if rollup_path.suffix == ".parquet" else pd.read_csv(rollup_path)
 
     assert "mesh_date" in rollup.columns, "rollup must expose the mesh_date metadata column"
-    assert len(rollup) == 1, "single AOI should produce a single rollup row"
+    assert len(rollup) == 1
+    mesh_date = rollup["mesh_date"].iloc[0]
+    assert (
+        mesh_date and str(mesh_date) != "" and str(mesh_date).lower() != "nan"
+    ), f"latest survey at this AOI is the 2025-09-03 3D capture; mesh_date should be populated, got {mesh_date!r}"
+
+
+@pytest.mark.integration
+@pytest.mark.live_api
+def test_prefer3d_end_to_end_2d_fallback(test_output_dir, salt_lake_aoi):
+    """End-to-end run with --prefer3d against a date window that has only 2D coverage.
+
+    At ~40.7611, -111.8904 the 2025-09-03 capture is 3D and the next survey (2026-03-04)
+    is 2D-only. The window [2025-09-04, 2026-03-31] excludes the 3D survey and includes
+    the 2D-only one, so the 3D-only first pass must 404 and the AOI must be resolved
+    via the 2D fallback. mesh_date should be empty in the resulting rollup.
+    """
+    exporter = AOIExporter(
+        aoi_file=str(salt_lake_aoi),
+        output_dir=str(test_output_dir),
+        country="us",
+        packs=["building"],
+        save_features=True,
+        no_cache=True,
+        processes=1,
+        prefer3d=True,
+        since="2025-09-04",
+        until="2026-03-31",
+    )
+
+    exporter.run()
+
+    rollup_files = list((test_output_dir / "final").glob("rollup.*"))
+    assert rollup_files, "rollup file should be created"
+    rollup_path = rollup_files[0]
+    rollup = pd.read_parquet(rollup_path) if rollup_path.suffix == ".parquet" else pd.read_csv(rollup_path)
+
+    assert "mesh_date" in rollup.columns
+    assert len(rollup) == 1, "single AOI should produce a single rollup row even via the 2D fallback"
+    mesh_date = rollup["mesh_date"].iloc[0]
+    # Empty string from a 2D survey, or NaN if the metadata-level mesh_date was dropped
+    # in favour of an absent per-feature mesh_date — either is a valid 2D signal.
+    is_empty = (mesh_date == "") or (pd.isna(mesh_date))
+    assert is_empty, f"window contains only 2D coverage; mesh_date should be empty, got {mesh_date!r}"
+
+    # And the 2026-03-04 2D survey should be the one used.
+    assert "survey_date" in rollup.columns
+    survey_date = str(rollup["survey_date"].iloc[0])
+    assert survey_date.startswith("2026-03-04"), f"expected the 2026-03-04 2D survey, got survey_date={survey_date!r}"
 
 
 @pytest.mark.integration

--- a/tests/test_3d_attributes.py
+++ b/tests/test_3d_attributes.py
@@ -131,7 +131,7 @@ def test_3d_attributes_flattening(test_output_dir, salt_lake_aoi):
 @pytest.mark.live_api
 def test_prefer3d_end_to_end(test_output_dir, salt_lake_aoi):
     """End-to-end run with --prefer3d. Confirms the unified export path produces
-    a 3d_date column and the AOI is resolved (either from 3D or 2D)."""
+    a mesh_date column and the AOI is resolved (either from 3D or 2D)."""
 
     exporter = AOIExporter(
         aoi_file=str(salt_lake_aoi),

--- a/tests/test_3d_attributes.py
+++ b/tests/test_3d_attributes.py
@@ -129,6 +129,39 @@ def test_3d_attributes_flattening(test_output_dir, salt_lake_aoi):
 
 @pytest.mark.integration
 @pytest.mark.live_api
+def test_prefer3d_end_to_end(test_output_dir, salt_lake_aoi):
+    """End-to-end run with --prefer3d. Confirms the unified export path produces
+    a 3d_date column and the AOI is resolved (either from 3D or 2D)."""
+
+    exporter = AOIExporter(
+        aoi_file=str(salt_lake_aoi),
+        output_dir=str(test_output_dir),
+        country="us",
+        packs=["building"],
+        save_features=True,
+        no_cache=True,
+        processes=1,
+        prefer3d=True,
+    )
+
+    exporter.run()
+
+    rollup_files = list((test_output_dir / "final").glob("rollup.*"))
+    assert rollup_files, "rollup file should be created"
+
+    # Read whichever format was produced.
+    rollup_path = rollup_files[0]
+    if rollup_path.suffix == ".parquet":
+        rollup = pd.read_parquet(rollup_path)
+    else:
+        rollup = pd.read_csv(rollup_path)
+
+    assert "mesh_date" in rollup.columns, "rollup must expose the mesh_date metadata column"
+    assert len(rollup) == 1, "single AOI should produce a single rollup row"
+
+
+@pytest.mark.integration
+@pytest.mark.live_api
 def test_attributes_list_handling():
     """Test that attributes list is properly handled in the flattening process."""
 

--- a/tests/test_feature_api_prefer3d.py
+++ b/tests/test_feature_api_prefer3d.py
@@ -1,0 +1,275 @@
+"""Unit tests for the `prefer3d` flag on FeatureApi.
+
+These tests run without API_KEY by patching ``requests.Session.post`` to return
+canned responses. They use a real cached Feature API payload from
+``tests/data/test_defensible_space_raw_payload.json`` as the 200 OK body — no
+synthetic mock data (see project memory: real data only).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+from nmaipy.constants import AOI_ID_COLUMN_NAME, API_CRS, SURVEY_RESOURCE_ID_COL_NAME
+from nmaipy.feature_api import FeatureApi
+
+
+# A representative real payload from a US 3D-capable survey. We reuse it for
+# both passes in the mock — the mesh_date value will simply reflect the canned
+# payload (empty string here, since the cached sample is from a 2D-perspective
+# capture). Tests assert on flow control, not on the 3D content of the payload.
+@pytest.fixture(scope="module")
+def real_feature_payload() -> dict:
+    path = Path(__file__).parent / "data" / "test_defensible_space_raw_payload.json"
+    return json.loads(path.read_text())
+
+
+def _aoi_gdf(aoi_id: str, polygon: Polygon, **extra_cols) -> gpd.GeoDataFrame:
+    """Build a single-row AOI GeoDataFrame indexed by aoi_id, with optional extra columns."""
+    row = {"geometry": polygon, **extra_cols}
+    gdf = gpd.GeoDataFrame([row], crs=API_CRS)
+    gdf[AOI_ID_COLUMN_NAME] = [aoi_id]
+    gdf = gdf.set_index(AOI_ID_COLUMN_NAME)
+    return gdf
+
+
+def _square(lon: float, lat: float, size: float = 0.0005) -> Polygon:
+    return Polygon(
+        [
+            (lon, lat),
+            (lon + size, lat),
+            (lon + size, lat + size),
+            (lon, lat + size),
+            (lon, lat),
+        ]
+    )
+
+
+class _MockResponse:
+    """Minimal stand-in for requests.Response used by FeatureApi._get_results."""
+
+    def __init__(self, status_code: int, body: dict | str):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._body = body
+        self.history = []
+        if isinstance(body, dict):
+            self.text = json.dumps(body)
+        else:
+            self.text = body
+
+    def json(self):
+        if isinstance(self._body, dict):
+            return self._body
+        return json.loads(self._body)
+
+
+def test_only3d_and_prefer3d_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        FeatureApi(api_key="dummy", only3d=True, prefer3d=True)
+
+
+def test_prefer3d_implies_only3d_internally():
+    api = FeatureApi(api_key="dummy", prefer3d=True)
+    assert api.only3d is True
+    assert api.prefer3d is True
+
+
+def test_prefer3d_default_false():
+    api = FeatureApi(api_key="dummy")
+    assert api.prefer3d is False
+    assert api.only3d is False
+
+
+def test_payload_gdf_extracts_mesh_date(real_feature_payload):
+    _features, metadata = FeatureApi.payload_gdf(real_feature_payload, aoi_id="aoi-1")
+    assert "mesh_date" in metadata
+    assert metadata["mesh_date"] == real_feature_payload["3dDate"]
+
+
+def test_payload_gdf_handles_missing_mesh_date():
+    payload = {
+        "systemVersion": "gen6-test",
+        "link": "https://example/",
+        "surveyDate": "2025-01-01",
+        "surveyId": "s",
+        "resourceId": "r",
+        "perspective": "Vert",
+        "postcat": False,
+        "features": [],
+    }
+    _features, metadata = FeatureApi.payload_gdf(payload, aoi_id="aoi-1")
+    assert metadata["mesh_date"] == ""
+
+
+def test_prefer3d_falls_back_to_2d_on_404(tmp_path, real_feature_payload):
+    """First pass with only3d=True gets a 404 → AOI retried without 3dCoverage param."""
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    captured_urls: list[str] = []
+
+    def fake_post(self, url, *args, **kwargs):
+        captured_urls.append(url)
+        if "3dCoverage=true" in url:
+            return _MockResponse(404, {"message": "No 3D survey available"})
+        return _MockResponse(200, real_feature_payload)
+
+    gdf = _aoi_gdf("aoi-1", _square(-111.926, 33.414))
+
+    with patch("requests.Session.post", new=fake_post):
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us")
+
+    # Two requests must have been made for the same AOI: one with 3dCoverage=true (3D pass),
+    # one without (2D fallback).
+    three_d_calls = [u for u in captured_urls if "3dCoverage=true" in u]
+    two_d_calls = [u for u in captured_urls if "3dCoverage=true" not in u]
+    assert len(three_d_calls) >= 1, "first pass should have requested with 3dCoverage=true"
+    assert len(two_d_calls) >= 1, "fallback pass should have requested without 3dCoverage=true"
+
+    # The AOI should be present in the final results, not in errors.
+    assert "aoi-1" in metadata.index
+    assert "aoi-1" not in errors.index
+    assert len(features) == len(real_feature_payload["features"])
+
+
+def test_prefer3d_no_retry_when_first_pass_succeeds(tmp_path, real_feature_payload):
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    call_count = {"n": 0}
+
+    def fake_post(self, url, *args, **kwargs):
+        call_count["n"] += 1
+        return _MockResponse(200, real_feature_payload)
+
+    gdf = _aoi_gdf("aoi-1", _square(-111.926, 33.414))
+
+    with patch("requests.Session.post", new=fake_post):
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us")
+
+    assert call_count["n"] == 1, "should not retry when first pass succeeded"
+    assert "aoi-1" in metadata.index
+    assert len(errors) == 0
+
+
+def test_prefer3d_keeps_non_404_errors_without_retry(tmp_path):
+    """A 500 in the first pass is NOT a 'no 3D coverage' signal — leave it as an error."""
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    captured_urls: list[str] = []
+
+    def fake_post(self, url, *args, **kwargs):
+        captured_urls.append(url)
+        return _MockResponse(500, {"message": "internal server error"})
+
+    gdf = _aoi_gdf("aoi-1", _square(-111.926, 33.414))
+
+    with patch("requests.Session.post", new=fake_post):
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us")
+
+    # 500s already exhaust their own urllib3 retries, so we just need to confirm
+    # no second-pass URL without 3dCoverage was issued.
+    assert all("3dCoverage=true" in u for u in captured_urls), "non-404 errors must not trigger the 2D fallback pass"
+    assert "aoi-1" in errors.index
+
+
+def test_prefer3d_skips_retry_for_survey_resource_id_aois(tmp_path):
+    """AOIs pinned to a survey_resource_id must NOT be retried — survey is already fixed."""
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    captured_urls: list[str] = []
+
+    def fake_post(self, url, *args, **kwargs):
+        captured_urls.append(url)
+        return _MockResponse(404, {"message": "no coverage"})
+
+    gdf = _aoi_gdf(
+        "aoi-1",
+        _square(-111.926, 33.414),
+        **{SURVEY_RESOURCE_ID_COL_NAME: "fixed-resource-uuid"},
+    )
+
+    with patch("requests.Session.post", new=fake_post):
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us")
+
+    # Only one request should have been made — the one with the survey_resource_id path.
+    # No 2D fallback because the AOI is pinned to a specific survey.
+    assert len(captured_urls) == 1
+    assert "aoi-1" in errors.index
+
+
+def test_clone_for_2d_fallback_preserves_config(tmp_path):
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=3,
+        alpha=True,
+        beta=True,
+        prerelease=False,
+        system_version_prefix="gen6-",
+        parcel_mode=True,
+        rapid=False,
+    )
+    sibling = api._clone_for_2d_fallback()
+    assert sibling.only3d is False
+    assert sibling.prefer3d is False
+    assert sibling.alpha is True
+    assert sibling.beta is True
+    assert sibling.system_version_prefix == "gen6-"
+    assert sibling.parcel_mode is True
+    assert sibling.api_key == "dummy"
+    # Cache dir is converted to str by BaseApiClient.__init__
+    assert str(sibling.cache_dir) == str(tmp_path)
+    assert sibling.threads == 3
+
+
+def test_prefer3d_bypassed_when_in_gridding_mode(tmp_path, real_feature_payload):
+    """Gridded sub-requests must not trigger their own prefer3d dispatch."""
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    captured_urls: list[str] = []
+
+    def fake_post(self, url, *args, **kwargs):
+        captured_urls.append(url)
+        if "3dCoverage=true" in url:
+            return _MockResponse(404, {"message": "no 3D"})
+        return _MockResponse(200, real_feature_payload)
+
+    gdf = _aoi_gdf("aoi-1", _square(-111.926, 33.414))
+
+    with patch("requests.Session.post", new=fake_post):
+        # in_gridding_mode=True must bypass the prefer3d wrapper entirely.
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us", in_gridding_mode=True)
+
+    # With prefer3d bypassed, the single only3d=True attempt 404s and there is NO 2D retry.
+    assert all("3dCoverage=true" in u for u in captured_urls)
+    assert "aoi-1" in errors.index

--- a/tests/test_feature_api_prefer3d.py
+++ b/tests/test_feature_api_prefer3d.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import geopandas as gpd
+import pandas as pd
 import pytest
 from shapely.geometry import Polygon
 
@@ -245,6 +246,43 @@ def test_clone_for_2d_fallback_preserves_config(tmp_path):
     # Cache dir is converted to str by BaseApiClient.__init__
     assert str(sibling.cache_dir) == str(tmp_path)
     assert sibling.threads == 3
+
+
+def test_prefer3d_wholesale_fallback_when_threshold_exceeded(tmp_path, real_feature_payload):
+    """When the 3D-only pass exceeds max_allowed_error_pct, the whole bulk should
+    fall back to standard 2D rather than aborting the export."""
+    api = FeatureApi(
+        api_key="dummy",
+        prefer3d=True,
+        cache_dir=tmp_path,
+        threads=1,
+    )
+
+    captured_urls: list[str] = []
+
+    def fake_post(self, url, *args, **kwargs):
+        captured_urls.append(url)
+        if "3dCoverage=true" in url:
+            # Both AOIs 404 in 3D-only mode
+            return _MockResponse(404, {"message": "no 3D"})
+        return _MockResponse(200, real_feature_payload)
+
+    # Two AOIs; with max_allowed_error_pct=0, even one 3D error trips the threshold.
+    gdf1 = _aoi_gdf("aoi-1", _square(-111.926, 33.414))
+    gdf2 = _aoi_gdf("aoi-2", _square(-111.927, 33.415))
+    gdf = gpd.GeoDataFrame(pd.concat([gdf1, gdf2]), crs=API_CRS)
+
+    with patch("requests.Session.post", new=fake_post):
+        features, metadata, errors = api.get_features_gdf_bulk(gdf=gdf, region="us", max_allowed_error_pct=0)
+
+    # Both AOIs should resolve via the wholesale 2D fallback — no AOIs in errors.
+    assert "aoi-1" in metadata.index
+    assert "aoi-2" in metadata.index
+    assert len(errors) == 0
+    # The first pass aborts as soon as the threshold trips, so we should see far fewer
+    # 3dCoverage=true calls than the 2 the per-AOI fallback path would have made.
+    two_d_calls = [u for u in captured_urls if "3dCoverage=true" not in u]
+    assert len(two_d_calls) == 2, "wholesale fallback should issue one 2D call per AOI"
 
 
 def test_prefer3d_bypassed_when_in_gridding_mode(tmp_path, real_feature_payload):


### PR DESCRIPTION
## Summary

Adds a `--prefer3d` CLI flag (and `prefer3d` kwarg on `FeatureApi`) that gives a single unified export with maximum 3D coverage and a 2D fallback per AOI — no more two-export-then-stitch dance for customers who want 3D where it exists.

**Behaviour:** first pass runs as `only3d=True`. AOIs that return 404 (no 3D survey in the date window) are retried on a sibling `FeatureApi` configured with `only3d=False`, respecting the same `since`/`until` window. Mutually exclusive with `--only3d`. No-op for AOIs pinned to a `survey_resource_id` (the survey is already fixed).

- Two-pass orchestration lives in `FeatureApi.get_features_gdf_bulk` via a new `_run_prefer3d_passes` helper; the existing single-pass code is unchanged, just moved into `_get_features_gdf_bulk_inner`.
- Gridded sub-requests (`in_gridding_mode=True`) bypass the prefer3d dispatch so an AOI never ends up with features from a mix of 3D and 2D surveys.
- Surfaces the API's top-level `3dDate` as AOI-level `mesh_date` metadata (mirrors the existing per-feature `mesh_date` from `meshDate`) so AOIs with zero features still carry the 3D/2D signal. Empty `mesh_date` = 2D survey.
- Per-feature `mesh_date` takes precedence in the rollup when both exist, via the same collision-drop pattern already used for `survey_date`.

## Test plan

- [x] 11 new unit tests in `tests/test_feature_api_prefer3d.py` covering: mutual-exclusion validation, internal `only3d` coercion, payload field extraction, the 404→2D fallback flow, no-retry on success, no-retry on non-404 errors, survey-resource-pinned exclusion, the clone helper, and gridding-mode bypass.
- [x] Full non-live test suite: 591 passed / 11 skipped / 0 failed.
- [x] Added an end-to-end live-API test in `tests/test_3d_attributes.py` that exercises `--prefer3d` against a Salt Lake City AOI and confirms the `mesh_date` column appears in the rollup.
- [ ] Live-API CI run on this branch.
- [ ] End-to-end CLI smoke against `tests/data/test_parcels_2.csv` with `--prefer3d --save-features`, verifying mixed 3D and 2D rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)