### PR TITLE
[TRO-4353] Apply spec_drift audit findings: cleaner override stack, split area pattern

### DIFF
--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -726,7 +726,7 @@
       "source": "base ai model"
     },
     {
-      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)(?<!_clipped)(?<!_total_clipped)(?<!_total_unclipped)(?<!_unclipped)_area_(?P<unit>sqft|sqm)$",
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)(?<!_clipped)(?<!_unclipped)_area_(?P<unit>sqft|sqm)$",
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -710,7 +710,23 @@
       "source": "model metadata"
     },
     {
-      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_area_(?P<unit>sqft|sqm)$",
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_clipped_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of {class} (clipped to parcel boundary) detected {scope_phrase}, in {unit_name}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_unclipped_area_(?P<unit>sqft|sqm)$",
+      "dtype": "float",
+      "min": "0",
+      "unit": "{unit_name}",
+      "description": "Total area of {class} (before parcel clipping) detected {scope_phrase}, in {unit_name}.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)(?<!_clipped)(?<!_total_clipped)(?<!_total_unclipped)(?<!_unclipped)_area_(?P<unit>sqft|sqm)$",
       "dtype": "float",
       "min": "0",
       "unit": "{unit_name}",

--- a/nmaipy/data/column_metadata_overrides.json
+++ b/nmaipy/data/column_metadata_overrides.json
@@ -1,6 +1,9 @@
 {
   "_doc": "Human-edited overrides layered over auto-generated spec_raw_fields.json. Per-field overlay: keys present here override the corresponding field on the spec-sourced base; absent fields inherit (e.g. an entry with only a `description` change leaves spec's `example`/`source` intact). Audit redundancy with `python -m ai_offline_export_pipelines.spec_drift compare-overrides` — every remaining entry should genuinely improve on spec (richer dtype, override-only min/max, customer-facing terminology). To elaborate a description, copy the entry from spec_raw_fields.json and edit. Do not invent keys here without a corresponding raw field — those belong in column_metadata.json. The drift checker flags overrides whose keys no longer exist in spec_raw_fields.json (rename/removal signal).",
   "exact_matches": {
+    "area_{unit}": {
+      "description": "Area of the {class_label_primary}, in {unit_name}."
+    },
     "attributes": {
       "dtype": "JSON",
       "description": "Raw API attributes payload for this feature (used during processing; preserved on raw feature outputs)."

--- a/nmaipy/data/column_metadata_overrides.json
+++ b/nmaipy/data/column_metadata_overrides.json
@@ -18,6 +18,9 @@
       "dtype": "UUID",
       "source": "model metadata"
     },
+    "clipped_area_{unit}": {
+      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in {unit_name}."
+    },
     "confidence": {
       "dtype": "float (quantised uint8)",
       "min": "0.0",
@@ -42,6 +45,9 @@
     },
     "survey_date": {
       "description": "Capture date of the 2D aerial imagery this feature was extracted from. Use as the canonical 'as-of' date for AI-derived attributes (counts, areas, materials, RSI, damage). May differ from mesh_date when 3D attributes draw on a different survey window."
+    },
+    "unclipped_area_{unit}": {
+      "description": "Total area of the {class_label_primary} before parcel clipping, in {unit_name}."
     }
   }
 }

--- a/nmaipy/data/column_metadata_overrides.json
+++ b/nmaipy/data/column_metadata_overrides.json
@@ -1,88 +1,44 @@
 {
-  "_doc": "Human-edited overrides layered over auto-generated spec_raw_fields.json. Per-field overlay: keys present here override the corresponding field on the spec-sourced base; absent fields inherit (e.g. an entry with only a `description` change leaves spec's `example`/`source` intact). Starts as a conservative full set covering all 12 spec-overlap entries — the comparison tool (planned: `spec_drift compare-overrides`) will surface which can be removed when their content matches the generated base. To elaborate a description, copy the entry from spec_raw_fields.json and edit. Do not invent keys here without a corresponding raw field — those belong in column_metadata.json. The drift checker flags overrides whose keys no longer exist in spec_raw_fields.json (rename/removal signal).",
+  "_doc": "Human-edited overrides layered over auto-generated spec_raw_fields.json. Per-field overlay: keys present here override the corresponding field on the spec-sourced base; absent fields inherit (e.g. an entry with only a `description` change leaves spec's `example`/`source` intact). Audit redundancy with `python -m ai_offline_export_pipelines.spec_drift compare-overrides` — every remaining entry should genuinely improve on spec (richer dtype, override-only min/max, customer-facing terminology). To elaborate a description, copy the entry from spec_raw_fields.json and edit. Do not invent keys here without a corresponding raw field — those belong in column_metadata.json. The drift checker flags overrides whose keys no longer exist in spec_raw_fields.json (rename/removal signal).",
   "exact_matches": {
-    "area_{unit}": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "{unit_name}",
-      "description": "Area of the {class_label_primary}, in {unit_name}.",
-      "source": "base ai model"
-    },
     "attributes": {
-      "group": "feature_meta",
       "dtype": "JSON",
-      "description": "Raw API attributes payload for this feature (used during processing; preserved on raw feature outputs).",
-      "source": "base ai model"
+      "description": "Raw API attributes payload for this feature (used during processing; preserved on raw feature outputs)."
     },
     "belongs_to_parcel": {
-      "group": "feature_meta",
-      "dtype": "binary",
       "description": "Whether this feature is contained within (rather than spanning beyond) the AOI parcel.",
       "allowed_values": "Y | N",
-      "source": "base ai model",
       "min": "N",
       "max": "Y"
     },
     "class_id": {
-      "group": "feature_meta",
       "dtype": "UUID",
-      "description": "AI feature class UUID for this row.",
       "source": "model metadata"
     },
-    "clipped_area_{unit}": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "{unit_name}",
-      "description": "Area of the {class_label_primary} clipped to the parcel boundary, in {unit_name}.",
-      "source": "base ai model"
-    },
     "confidence": {
-      "group": "feature_meta",
       "dtype": "float (quantised uint8)",
       "min": "0.0",
       "max": "1.0",
-      "description": "Confidence in detection of the {class_label_primary} (single feature, not combined).",
-      "source": "base ai model"
+      "description": "Confidence in detection of the {class_label_primary} (single feature, not combined)."
     },
     "description": {
-      "group": "feature_meta",
-      "dtype": "string",
-      "description": "Human-readable name of this feature's class.",
       "source": "model metadata"
     },
     "geometry": {
-      "group": "feature_meta",
       "dtype": "WKT \\| GeoParquet",
-      "description": "Feature geometry. WKT in CSVs, native GeoParquet geometry in `_features.parquet`.",
-      "source": "base ai model"
+      "description": "Feature geometry. WKT in CSVs, native GeoParquet geometry in `_features.parquet`."
     },
     "mesh_date": {
       "group": "common",
       "dtype": "date",
-      "description": "Date of the 3D mesh used for 3D attributes (height, pitch, etc.). The mesh is usually comprised of a number of overlapping surveys captured at a similar time of year, so this date represents that capture window rather than a single survey.",
-      "source": "image metadata"
+      "description": "Date of the 3D mesh used for 3D attributes (height, pitch, etc.). The mesh is usually comprised of a number of overlapping surveys captured at a similar time of year, so this date represents that capture window rather than a single survey."
     },
     "parent_id": {
-      "group": "feature_meta",
       "dtype": "UUID",
-      "description": "Feature ID of this feature's parent in the API hierarchy. For the new Building class, this points to the Building Lifecycle ancestor.",
-      "source": "base ai model"
+      "description": "Feature ID of this feature's parent in the API hierarchy. For the new Building class, this points to the Building Lifecycle ancestor."
     },
     "survey_date": {
-      "group": "feature_meta",
-      "dtype": "date",
-      "description": "Capture date of the 2D aerial imagery this feature was extracted from. Use as the canonical 'as-of' date for AI-derived attributes (counts, areas, materials, RSI, damage). May differ from mesh_date when 3D attributes draw on a different survey window.",
-      "source": "image metadata"
-    },
-    "unclipped_area_{unit}": {
-      "group": "feature_meta",
-      "dtype": "float",
-      "min": "0",
-      "unit": "{unit_name}",
-      "description": "Total area of the {class_label_primary} before parcel clipping, in {unit_name}.",
-      "source": "base ai model"
+      "description": "Capture date of the 2D aerial imagery this feature was extracted from. Use as the canonical 'as-of' date for AI-derived attributes (counts, areas, materials, RSI, damage). May differ from mesh_date when 3D attributes draw on a different survey window."
     }
   }
 }


### PR DESCRIPTION
## Summary

Three coordinated metadata cleanups driven by the `spec_drift compare-overrides` and `compare-patterns` audit subcommands (shipped via [ai-offline-export-pipelines#110](https://github.com/nearmap/ai-offline-export-pipelines/pull/110)).

- **Stage A** — drop redundant non-description fields from all 12 override entries in `column_metadata_overrides.json`. Pure mechanical cleanup; the 3-layer overlay engine recovers each dropped field from the spec layer, so rendered output is byte-identical.
- **Stage B** — drop 5 description overrides where spec wording is equivalent or better. The `area_{unit}` case is the headline win: spec now explains connected-vs-discrete feature clipping semantics that the override flattened into one sentence.
- **Pattern split** — the single `*_area_{unit}` regex in `column_metadata.json` previously conflated three distinct spec fields via `{class}`-suffix string manipulation inside `_substitute`. Replaced with three explicit patterns; rendered template wording is preserved verbatim for every existing rollup column.
- **`_doc` refresh** — overrides JSON header now references the shipped audit tool.

## Why

Goal of the cleanup: maximise pass-through from the upstream API spec, minimise hand-maintained text, and make the metadata stack easier to keep in sync going forward. The audit subcommands surface these opportunities deterministically; this PR applies their findings.

## Surfaced wins

- **area_*** columns now carry the spec's rich description (explains connected vs discrete feature clipping behaviour) instead of a hand-flattened one-line summary. Visible in the data dictionary CSV and the per-class README sections.
- **`example` field** flows through from spec for every cleaned-up entry (e.g. `class_id` example `5a5cb214-eee3-4fdd-bfce-d21e9793cf6a`, `survey_date` example `2019-09-27`) — previously not surfaced for overridden columns.
- **`*_clipped_area_{unit}` / `*_unclipped_area_{unit}` rollup columns** now match an explicit regex rather than relying on suffix-stripping inside `_substitute`. Same wording; structurally cleaner; the audit can no longer flag this as a CONFLATES case.

## Diff

- `nmaipy/data/column_metadata_overrides.json`: -58 lines (entries shrunk to their actual overlay content; 3 entries collapsed to empty and removed; `_doc` refreshed)
- `nmaipy/data/column_metadata.json`: +18 lines (1 pattern → 3 patterns)
- Net: -28 lines, no code changes

## Test plan

- [x] `pytest tests/test_column_metadata_layers.py tests/test_data_dictionary_generator.py tests/test_readme_generator.py -q` — 107 pass
- [x] Phase-by-phase byte-diff verification across 77 representative column × class_label resolutions: Phase 1 byte-identical to baseline; Phase 2 shows only the expected 10-column description changes; Phase 3 byte-identical to Phase 2
- [x] Audit round-trip: `compare-overrides` shows 0 redundant fields across the remaining 9 entries; `compare-patterns --classification conflates_spec_fields` shows 0 rows
- [ ] Reviewer spot-check the rendered README/data dictionary sections for a per-class file (e.g. roof.csv) and confirm the spec-sourced area description reads naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)