### PR TITLE
[TRO-4360] Make nmaipy importable on Windows

### DIFF
--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -23,6 +23,13 @@ import tempfile
 import time
 import traceback
 import warnings
+
+# resource is a Unix-only stdlib module; on Windows we set the attribute to None
+# and gate every call site below.
+try:
+    import resource
+except ImportError:  # pragma: no cover — Windows
+    resource = None
 from abc import ABC, abstractmethod
 from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from concurrent.futures.process import BrokenProcessPool
@@ -742,18 +749,17 @@ class BaseExporter(ABC):
             max_retries: Maximum number of retry attempts
             retry_delay: Seconds to wait before retrying
         """
-        import resource
-
         mem = psutil.virtual_memory()
         swap = psutil.swap_memory()
 
-        # Get resource limits
-        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        # Get resource limits (Unix only — `resource` is None on Windows).
+        if resource is not None:
+            soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        else:
+            soft_limit = "unknown"
 
-        # Count open file descriptors (Linux/Mac)
+        # Count open file descriptors (Linux only — /proc is absent on macOS and Windows)
         try:
-            import os
-
             pid = os.getpid()
             if os.path.exists(f"/proc/{pid}/fd"):
                 fd_count = len(os.listdir(f"/proc/{pid}/fd"))

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -418,7 +418,7 @@ def refresh_class_descriptions(api_key: str = None):
 def _write_class_descriptions(descriptions: dict):
     """Write class descriptions dict to the JSON file."""
     try:
-        with open(_CLASS_DESCRIPTIONS_PATH, "w") as f:
+        with open(_CLASS_DESCRIPTIONS_PATH, "w", encoding="utf-8") as f:
             json.dump(descriptions, f, indent=2, sort_keys=True)
             f.write("\n")
     except OSError:

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -14,8 +14,15 @@ import logging
 import multiprocessing
 import pstats
 import re
-import resource
 import sys
+
+# resource is a Unix-only stdlib module; on Windows we set the attribute to None
+# and gate every call site behind sys.platform != "win32" (or `resource is not None`).
+try:
+    import resource
+except ImportError:  # pragma: no cover — Windows
+    resource = None
+
 import traceback
 import warnings
 from pathlib import Path

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -15,6 +15,7 @@ import multiprocessing
 import pstats
 import re
 import sys
+import tempfile
 
 # resource is a Unix-only stdlib module; on Windows we set the attribute to None
 # and gate every call site behind sys.platform != "win32" (or `resource is not None`).
@@ -3229,8 +3230,8 @@ class NearmapAIExporter(BaseExporter):
             )
             if chunk_id == _profile_chunk:
                 _pr.disable()
-                _profile_path = f"/tmp/nmaipy_profile_chunk_{chunk_id}.txt"
-                with open(_profile_path, "w") as _pf:
+                _profile_path = os.path.join(tempfile.gettempdir(), f"nmaipy_profile_chunk_{chunk_id}.txt")
+                with open(_profile_path, "w", encoding="utf-8") as _pf:
                     pstats.Stats(_pr, stream=_pf).sort_stats("cumulative").print_stats(40)
                 self.logger.info(f"CHUNK_PROFILE parcel_rollup stats saved to {_profile_path}")
             _t_rollup_end = time.monotonic()

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -458,7 +458,7 @@ class FeatureApi(GriddedApiClient):
                     with gzip.open(temp_path, "wb") as f:
                         f.write(json.dumps(payload).encode("utf-8"))
                 else:
-                    with open(temp_path, "w") as f:
+                    with open(temp_path, "w", encoding="utf-8") as f:
                         json.dump(payload, f)
                 temp_path.replace(path)
             finally:

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -121,7 +121,10 @@ class ReadmeGenerator:
         content = self._generate()
         readme_path = storage.join_path(self.final_dir, "README.md")
         tmp_path = readme_path + ".tmp"
-        with storage.open_file(tmp_path, "w") as f:
+        # encoding="utf-8" is required: README content contains em-dashes and
+        # other non-ASCII characters, and on Windows open() defaults to cp1252
+        # which can't encode them — would crash with UnicodeEncodeError.
+        with storage.open_file(tmp_path, "w", encoding="utf-8") as f:
             f.write(content)
         storage.move_file(tmp_path, readme_path)
         return readme_path

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -310,7 +310,7 @@ def read_json(path: str, compressed: bool = False) -> Optional[Dict]:
             with gzip.GzipFile(fileobj=raw_f) as gz_f:
                 return json.loads(gz_f.read().decode("utf-8"))
     else:
-        with open_file(path, "r") as f:
+        with open_file(path, "r", encoding="utf-8") as f:
             return json.load(f)
 
 
@@ -336,7 +336,7 @@ def write_json(
             with gzip.GzipFile(fileobj=raw_f, mode="wb") as gz_f:
                 gz_f.write(json.dumps(data, default=default).encode("utf-8"))
     else:
-        with open_file(path, "w") as f:
+        with open_file(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent, default=default)
 
 

--- a/tests/test_parcel_rollup_performance.py
+++ b/tests/test_parcel_rollup_performance.py
@@ -5,13 +5,15 @@ Run the fixture generator first (remove the skip decorator), then run the perfor
 
     NMAIPY_PROFILE_CHUNK=0 pytest tests/test_parcel_rollup_performance.py::test_parcel_rollup_performance -s
 
-cProfile output (if env var is set) is written to /tmp/nmaipy_profile_parcel_rollup.txt.
+cProfile output (if env var is set) is written to `<tempdir>/nmaipy_profile_parcel_rollup.txt`
+(via `tempfile.gettempdir()` so it works on Windows too).
 """
 
 import ast
 import cProfile
 import os
 import pstats
+import tempfile
 import time
 from pathlib import Path
 
@@ -95,7 +97,7 @@ def test_parcel_rollup_performance(parcels_2_gdf: gpd.GeoDataFrame):
     Set NMAIPY_PROFILE_CHUNK=1 to enable cProfile around parcel_rollup():
         NMAIPY_PROFILE_CHUNK=1 pytest tests/test_parcel_rollup_performance.py::test_parcel_rollup_performance -s
 
-    cProfile output is written to /tmp/nmaipy_profile_parcel_rollup.txt.
+    cProfile output is written to `<tempdir>/nmaipy_profile_parcel_rollup.txt`.
     """
     if not PERF_FIXTURE.exists():
         pytest.skip(f"Perf fixture not generated yet — run test_gen_perf_fixture first: {PERF_FIXTURE}")
@@ -157,8 +159,8 @@ def test_parcel_rollup_performance(parcels_2_gdf: gpd.GeoDataFrame):
 
     if do_profile:
         pr.disable()
-        profile_path = "/tmp/nmaipy_profile_parcel_rollup.txt"
-        with open(profile_path, "w") as pf:
+        profile_path = os.path.join(tempfile.gettempdir(), "nmaipy_profile_parcel_rollup.txt")
+        with open(profile_path, "w", encoding="utf-8") as pf:
             pf.write("=== Top 40 by cumulative time ===\n")
             pstats.Stats(pr, stream=pf).sort_stats("cumulative").print_stats(40)
             pf.write("\n=== Top 40 by self (tottime) ===\n")
@@ -236,8 +238,8 @@ def test_parcel_rollup_performance_au(parcels_gdf: gpd.GeoDataFrame):
 
     if do_profile:
         pr.disable()
-        profile_path = "/tmp/nmaipy_profile_parcel_rollup_au.txt"
-        with open(profile_path, "w") as pf:
+        profile_path = os.path.join(tempfile.gettempdir(), "nmaipy_profile_parcel_rollup_au.txt")
+        with open(profile_path, "w", encoding="utf-8") as pf:
             pf.write("=== Top 40 by cumulative time ===\n")
             pstats.Stats(pr, stream=pf).sort_stats("cumulative").print_stats(40)
             pf.write("\n=== Top 40 by self (tottime) ===\n")


### PR DESCRIPTION
## Summary

Fixes a bug report from a Windows user: `import nmaipy.exporter` crashed with `ModuleNotFoundError: No module named 'resource'` before any user code ran. Audited and fixed all Windows-portability issues I could find.

- **`resource` stdlib (Unix-only) import gated** at module top of `exporter.py` and `base_exporter.py` via `try / except ImportError → resource = None`. Both call sites (`main()` FD-limit, `_handle_broken_process_pool` diagnostics) are guarded — Windows now reports `soft_limit = "unknown"` in the diagnostic log instead of crashing.
- **README write encoding** — `readme_generator.py` now passes `encoding="utf-8"` to `storage.open_file`. Without it the README write would crash on Windows cp1252 the first time an em-dash hit the buffer (the README definitely contains them).
- **`/tmp/...` profile paths** in `exporter.py` and `tests/test_parcel_rollup_performance.py` replaced with `os.path.join(tempfile.gettempdir(), ...)`. Opt-in via env var so production isn't affected, but no longer crashes if a Windows user enables profiling.
- **Defensive `encoding="utf-8"`** added to every text-mode JSON open() in `feature_api.py`, `constants.py`, and the `storage.read_json` / `storage.write_json` helpers. Today safe because `json.dump` defaults to `ensure_ascii=True`, but a future change to `ensure_ascii=False` (often done for readability) would silently break Windows. Tightening at the source.

Reported by: a Windows user.

## Test plan

- [x] `pytest -m "not live_api" -q` — 592 passed, 0 failed.
- [x] Simulated Windows import: monkeypatched `__import__` to raise `ImportError` on `resource`, then imported `nmaipy.exporter`, `base_exporter`, `feature_api`, `readme_generator`, `storage`, `constants` — all loaded cleanly with `resource = None`.
- [ ] Real Windows smoke test by the reporter (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)