### PR TITLE
[TRO-4363] Fix TypeError on null confidenceStats histograms / ratios

### DIFF
--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -833,10 +833,13 @@ def flatten_roof_attributes(
                         component_columns[f"{name}_dominant"] = TRUE_STRING if component["dominant"] else FALSE_STRING
                     if "confidenceStats" in component:
                         confidence_stats = component["confidenceStats"]
-                        histograms = confidence_stats.get("histograms", [])
+                        # API may return histograms/ratios as null (key present, value None) for
+                        # features without confidence data; dict.get's default only fires when the
+                        # key is absent, so coalesce None to [].
+                        histograms = confidence_stats.get("histograms") or []
                         for histogram in histograms:
                             bin_type = histogram.get("binType", "unknown")
-                            ratios = histogram.get("ratios", [])
+                            ratios = histogram.get("ratios") or []
                             for bin_idx, ratio_value in enumerate(ratios):
                                 component_columns[f"{name}_confidence_stats_{bin_type}_bin_{bin_idx}"] = ratio_value
 

--- a/tests/test_roof_condition_confidence_stats.py
+++ b/tests/test_roof_condition_confidence_stats.py
@@ -285,3 +285,46 @@ def test_handles_missing_rccs_gracefully():
     assert (
         "roof_condition_confidence_stats" not in result
     ), "roof_condition_confidence_stats should not be present when not in source data"
+
+
+def test_flatten_roof_attributes_handles_null_histograms():
+    """Regression: API can return confidenceStats.histograms (or histogram.ratios) as null.
+
+    dict.get's default only fires when the key is absent — a present-but-null value
+    returns None. flatten_roof_attributes must coalesce to [] before iterating.
+    """
+    roof = {
+        "feature_id": "test-roof-null-histograms",
+        "class_id": ROOF_ID,
+        "attributes": [
+            {
+                "description": "Roof Condition",
+                "components": [
+                    {
+                        "description": "Structural Damage",
+                        "confidence": None,
+                        "areaSqm": 0,
+                        "areaSqft": 0,
+                        "ratio": 0,
+                        "confidenceStats": {"histograms": None},
+                    },
+                    {
+                        "description": "Tile Discolouration",
+                        "confidence": None,
+                        "areaSqm": 0,
+                        "areaSqft": 0,
+                        "ratio": 0,
+                        "confidenceStats": {
+                            "histograms": [{"binType": "default", "ratios": None}]
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+
+    result = flatten_roof_attributes([roof], country="us")
+
+    assert not any("confidence_stats_" in k for k in result), (
+        "No histogram bin columns should be emitted when histograms/ratios are null"
+    )


### PR DESCRIPTION
## Summary

Fixes a chunk-killing `TypeError` in `flatten_roof_attributes` when the Feature API returns `confidenceStats.histograms` (or a histogram's `ratios`) as explicit `null` rather than omitting the key.

`dict.get("key", [])` only returns the default when the key is **absent** — a present-but-null value yields `None`, which then crashes the downstream `for histogram in histograms:` iteration. Production-observed: every chunk fails on exports that include `roofConditionConfidenceStats` against AOIs where the API emits null histograms (e.g. features with no confidence data).

Two-line fix: switch from `.get(key, [])` to `.get(key) or []` so the iteration is a no-op when the API returns null.

## Test plan

- [x] New regression test in `tests/test_roof_condition_confidence_stats.py::test_flatten_roof_attributes_handles_null_histograms` exercises both `confidenceStats: {"histograms": None}` and `histograms: [{"ratios": None}]` shapes — confirms no histogram-bin columns are emitted and no exception is raised.
- [x] `pytest tests/test_roof_condition_confidence_stats.py -q` — 4 passed, 1 skipped (existing fixture-gated test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)