### PR TITLE
[TRO-4354] prefer3d: dedupe partial-gridded AOIs across 3D and 2D passes

### DIFF
--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1657,9 +1657,23 @@ class FeatureApi(GriddedApiClient):
             disable_parcel_mode=disable_parcel_mode,
         )
 
-        # Merge: drop 3D errors for AOIs that have been retried; carry forward the rest;
-        # append 2D-pass errors (AOIs that failed both passes).
+        # Merge: drop 3D results for AOIs that have been retried (errors, metadata, and
+        # features alike); carry forward the rest; append the 2D-pass results.
+        #
+        # Dropping retry_ids from meta_3d/features_3d is essential when an AOI is
+        # gridded with partial 3D coverage: some cells return 3D data (populating
+        # meta_3d and features_3d for that aoi_id) while others 404 (populating
+        # errors_3d for the same aoi_id, which lands the AOI in retry_ids). Without
+        # this drop, pd.concat([meta_3d, meta_2d]) produces duplicate aoi_id index
+        # entries, which later breaks rollup-merge code paths like
+        # `rollup_df["mesh_date"].fillna(metadata_df["mesh_date"])`. Semantically,
+        # the 2D fallback supersedes the partial 3D coverage for that AOI.
         surviving_errors_3d = errors_3d.drop(index=retry_ids, errors="ignore")
+        surviving_meta_3d = meta_3d.drop(index=retry_ids, errors="ignore") if len(meta_3d) > 0 else meta_3d
+        surviving_features_3d = (
+            features_3d.drop(index=retry_ids, errors="ignore") if len(features_3d) > 0 else features_3d
+        )
+
         merged_errors_parts = [df for df in [surviving_errors_3d, errors_2d] if len(df) > 0]
         if merged_errors_parts:
             merged_errors = pd.concat(merged_errors_parts)
@@ -1667,19 +1681,21 @@ class FeatureApi(GriddedApiClient):
             merged_errors = pd.DataFrame([])
             merged_errors.index.name = AOI_ID_COLUMN_NAME
 
-        if len(features_2d) > 0 and len(features_3d) > 0:
-            merged_features = gpd.GeoDataFrame(pd.concat([features_3d, features_2d]), geometry="geometry", crs=API_CRS)
+        if len(features_2d) > 0 and len(surviving_features_3d) > 0:
+            merged_features = gpd.GeoDataFrame(
+                pd.concat([surviving_features_3d, features_2d]), geometry="geometry", crs=API_CRS
+            )
         elif len(features_2d) > 0:
             merged_features = features_2d
         else:
-            merged_features = features_3d
+            merged_features = surviving_features_3d
 
-        if len(meta_2d) > 0 and len(meta_3d) > 0:
-            merged_meta = pd.concat([meta_3d, meta_2d])
+        if len(meta_2d) > 0 and len(surviving_meta_3d) > 0:
+            merged_meta = pd.concat([surviving_meta_3d, meta_2d])
         elif len(meta_2d) > 0:
             merged_meta = meta_2d
         else:
-            merged_meta = meta_3d
+            merged_meta = surviving_meta_3d
 
         return merged_features, merged_meta, merged_errors
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1668,11 +1668,11 @@ class FeatureApi(GriddedApiClient):
         # entries, which later breaks rollup-merge code paths like
         # `rollup_df["mesh_date"].fillna(metadata_df["mesh_date"])`. Semantically,
         # the 2D fallback supersedes the partial 3D coverage for that AOI.
+        # .drop(errors="ignore") is a no-op on an empty DataFrame and preserves type,
+        # so no len() guard is needed.
         surviving_errors_3d = errors_3d.drop(index=retry_ids, errors="ignore")
-        surviving_meta_3d = meta_3d.drop(index=retry_ids, errors="ignore") if len(meta_3d) > 0 else meta_3d
-        surviving_features_3d = (
-            features_3d.drop(index=retry_ids, errors="ignore") if len(features_3d) > 0 else features_3d
-        )
+        surviving_meta_3d = meta_3d.drop(index=retry_ids, errors="ignore")
+        surviving_features_3d = features_3d.drop(index=retry_ids, errors="ignore")
 
         merged_errors_parts = [df for df in [surviving_errors_3d, errors_2d] if len(df) > 0]
         if merged_errors_parts:

--- a/tests/test_3d_attributes.py
+++ b/tests/test_3d_attributes.py
@@ -56,6 +56,33 @@ def salt_lake_aoi(test_output_dir):
     return aoi_file
 
 
+@pytest.fixture
+def salt_lake_aoi_large(test_output_dir):
+    """A ~1.2km x 1.2km AOI centered on (40.7611, -111.8904).
+
+    Area ≈ 1.44 sqkm, comfortably above MAX_AOI_AREA_SQM_BEFORE_GRIDDING (1 sqkm),
+    so any export of this AOI triggers gridding (~3x3 = 9 cells at the default
+    GRID_SIZE_DEGREES). Used to exercise the gridded prefer3d code path that the
+    unit-test suite (single-AOI, no gridding) doesn't reach.
+    """
+    test_polygon = Polygon(
+        [
+            (-111.8975, 40.7557),
+            (-111.8833, 40.7557),
+            (-111.8833, 40.7665),
+            (-111.8975, 40.7665),
+            (-111.8975, 40.7557),
+        ]
+    )
+
+    test_aoi = gpd.GeoDataFrame({"aoi_id": ["salt_lake_3d_test_large"], "geometry": [test_polygon]}, crs="EPSG:4326")
+
+    aoi_file = test_output_dir / "test_aoi_large.geojson"
+    test_aoi.to_file(aoi_file, driver="GeoJSON")
+
+    return aoi_file
+
+
 @pytest.mark.integration
 @pytest.mark.live_api
 def test_3d_attributes_flattening(test_output_dir, salt_lake_aoi):
@@ -205,6 +232,54 @@ def test_prefer3d_end_to_end_2d_fallback(test_output_dir, salt_lake_aoi):
     assert "survey_date" in rollup.columns
     survey_date = str(rollup["survey_date"].iloc[0])
     assert survey_date.startswith("2026-03-04"), f"expected the 2026-03-04 2D survey, got survey_date={survey_date!r}"
+
+
+@pytest.mark.integration
+@pytest.mark.live_api
+def test_prefer3d_end_to_end_gridded(test_output_dir, salt_lake_aoi_large):
+    """End-to-end gridded prefer3d run on a ~1.44 sqkm Salt Lake AOI.
+
+    Exercises the gridded prefer3d code path that the unit-test suite (all single
+    AOIs, no gridding) doesn't reach — gridded sub-requests bypassing the prefer3d
+    dispatch via `in_gridding_mode=True`, the multi-cell metadata reconstruction in
+    `_attempt_gridding`, and the merged-rollup write through `exporter._process_chunk`.
+
+    Uses the 2D-only date window from `test_prefer3d_end_to_end_2d_fallback` so the
+    3D-only first pass produces a wholesale grid failure for the AOI and the entire
+    bulk falls back to a gridded 2D run. This catches regressions in the broader
+    gridded prefer3d flow.
+
+    Note: this does NOT exercise the specific partial-3D-coverage case that the
+    unit-test `test_prefer3d_dedupes_partial_gridded_aoi_across_passes` covers —
+    reproducing it live would require a region known to have mixed coverage AND
+    `aoi_grid_min_pct < 100`, which we don't have a reliable fixture for.
+    """
+    exporter = AOIExporter(
+        aoi_file=str(salt_lake_aoi_large),
+        output_dir=str(test_output_dir),
+        country="us",
+        packs=["building"],
+        save_features=True,
+        no_cache=True,
+        processes=1,
+        prefer3d=True,
+        since="2025-09-04",
+        until="2026-03-31",
+    )
+
+    exporter.run()
+
+    rollup_files = list((test_output_dir / "final").glob("rollup.*"))
+    assert rollup_files, "rollup file should be created"
+    rollup_path = rollup_files[0]
+    rollup = pd.read_parquet(rollup_path) if rollup_path.suffix == ".parquet" else pd.read_csv(rollup_path)
+
+    assert "mesh_date" in rollup.columns
+    assert len(rollup) == 1, "single gridded AOI should produce a single rollup row, not duplicates"
+    # 2D-only window → mesh_date must be empty (no 3D survey could be returned).
+    mesh_date = rollup["mesh_date"].iloc[0]
+    is_empty = (mesh_date == "") or pd.isna(mesh_date)
+    assert is_empty, f"window contains only 2D coverage; mesh_date should be empty, got {mesh_date!r}"
 
 
 @pytest.mark.integration

--- a/tests/test_feature_api_prefer3d.py
+++ b/tests/test_feature_api_prefer3d.py
@@ -311,3 +311,98 @@ def test_prefer3d_bypassed_when_in_gridding_mode(tmp_path, real_feature_payload)
     # With prefer3d bypassed, the single only3d=True attempt 404s and there is NO 2D retry.
     assert all("3dCoverage=true" in u for u in captured_urls)
     assert "aoi-1" in errors.index
+
+
+def test_prefer3d_dedupes_partial_gridded_aoi_across_passes(tmp_path):
+    """A gridded AOI with partial 3D coverage shows up in BOTH meta_3d (some cells
+    returned 3D data) and errors_3d (other cells 404'd). The 2D fallback retries
+    that AOI and produces its own meta_2d row. The merged metadata must not have
+    duplicate aoi_id entries — otherwise downstream rollup code that calls
+    metadata_df["mesh_date"].reindex(...) (e.g. via fillna) blows up with
+    "cannot reindex on an axis with duplicate labels".
+    """
+    api = FeatureApi(api_key="dummy", prefer3d=True, cache_dir=tmp_path, threads=1)
+
+    aoi_id = "aoi-partial-3d"
+    geom = _square(-111.926, 33.414)
+    gdf = _aoi_gdf(aoi_id, geom)
+
+    def _meta_row(survey_date: str) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [
+                {
+                    "system_version": "gen6-test",
+                    "link": "https://example/",
+                    "survey_date": survey_date,
+                    "survey_id": f"s-{survey_date}",
+                    "survey_resource_id": f"r-{survey_date}",
+                    "perspective": "Vert",
+                    "postcat": False,
+                    "mesh_date": "2025-09-03" if "2025" in survey_date else "",
+                }
+            ],
+            index=pd.Index([aoi_id], name=AOI_ID_COLUMN_NAME),
+        )
+        return df
+
+    def _features_row(survey_date: str) -> gpd.GeoDataFrame:
+        return gpd.GeoDataFrame(
+            [{"feature_id": f"f-{survey_date}", "class_id": "x", "geometry": geom}],
+            index=pd.Index([aoi_id], name=AOI_ID_COLUMN_NAME),
+            crs=API_CRS,
+        )
+
+    # 3D pass: AOI has metadata + features (some cells succeeded) AND a 404 error row
+    # in errors_3d (the failed cells were collapsed under the parent aoi_id with
+    # status_code=404, mirroring get_features_gdf_gridded's behaviour at the seam
+    # where failed grid cells get the parent AOI's aoi_id reassigned).
+    features_3d = _features_row("2025-09-03")
+    meta_3d = _meta_row("2025-09-03")
+    errors_3d = pd.DataFrame(
+        [
+            {
+                "status_code": 404,
+                "message": "No 3D coverage at this grid cell",
+                "text": "",
+                "request": "grid",
+                "failure_type": "grid",
+            }
+        ],
+        index=pd.Index([aoi_id], name=AOI_ID_COLUMN_NAME),
+    )
+
+    # 2D pass: AOI resolves fully via the 2D fallback.
+    features_2d = _features_row("2026-03-04")
+    meta_2d = _meta_row("2026-03-04")
+    errors_2d = pd.DataFrame()
+    errors_2d.index.name = AOI_ID_COLUMN_NAME
+
+    call_count = {"n": 0}
+
+    def fake_inner(self, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return features_3d, meta_3d, errors_3d
+        return features_2d, meta_2d, errors_2d
+
+    with patch.object(FeatureApi, "_get_features_gdf_bulk_inner", new=fake_inner):
+        merged_features, merged_meta, merged_errors = api.get_features_gdf_bulk(gdf=gdf, region="us")
+
+    assert call_count["n"] == 2, "should have run a 2D fallback pass after the 3D 404"
+    assert merged_meta.index.is_unique, (
+        f"metadata index must not contain duplicates after prefer3d merge — got " f"{merged_meta.index.tolist()!r}"
+    )
+    # 2D fallback wins for the retried AOI.
+    assert aoi_id in merged_meta.index
+    assert merged_meta.loc[aoi_id, "survey_date"] == "2026-03-04"
+    # The 404 error from the 3D pass is dropped (the AOI was successfully retried).
+    assert aoi_id not in merged_errors.index
+    # The retried AOI's 3D features are also dropped — 2D supersedes.
+    assert len(merged_features) == 1
+    assert merged_features["feature_id"].iloc[0] == "f-2026-03-04"
+
+    # Sanity check that the downstream fillna pattern from exporter.py works on the
+    # merged metadata — this is the operation that was throwing
+    # "cannot reindex on an axis with duplicate labels" in production.
+    rollup_mesh = pd.Series([None], index=pd.Index([aoi_id], name=AOI_ID_COLUMN_NAME))
+    rollup_mesh.fillna(merged_meta["mesh_date"])


### PR DESCRIPTION
## Summary

Fixes a real prefer3d bug that only surfaces on **gridded AOIs with partial 3D coverage** — single-AOI exports never tripped it, which is why neither the unit tests nor the live-API tests caught it before 5.0.0 / 5.0.1.

### What goes wrong

Any AOI larger than `MAX_AOI_AREA_SQM_BEFORE_GRIDDING` (1 sqkm) gets gridded. If part of that AOI has 3D coverage and part doesn't, the gridded run produces:

- A row in `meta_3d` and feature rows in `features_3d` keyed on the parent `aoi_id` (the successful cells), AND
- A 404 row in `errors_3d` also keyed on the same parent `aoi_id` (the failed cells get their per-cell IDs reassigned to the parent by `get_features_gdf_gridded`).

`_run_prefer3d_passes` correctly detects the 404 and retries the AOI in 2D, but only deduped the **errors** path before merging — `pd.concat([meta_3d, meta_2d])` then produced **duplicate `aoi_id` index entries** in the merged metadata.

The duplicate index broke the rollup merge in [`exporter.py:3286`](https://github.com/nearmap/nmaipy/blob/main/nmaipy/exporter.py#L3286) the first time `rollup_df["mesh_date"].fillna(metadata_df["mesh_date"])` tried to align the two Series:

```
ValueError: cannot reindex on an axis with duplicate labels
```

The chunk's exception then tore down the multiprocessing worker pool, producing the cascade of `FileNotFoundError` tracebacks you'll have seen in the logs.

### Fix

Mirror the existing `surviving_errors_3d` logic for metadata and features too: drop `retry_ids` from `meta_3d` and `features_3d` before concatenating with the 2D-pass results. Semantically the 2D fallback supersedes the partial 3D coverage for that AOI.

## Test plan

- [x] New regression test `test_prefer3d_dedupes_partial_gridded_aoi_across_passes` patches `_get_features_gdf_bulk_inner` to simulate "AOI in both `meta_3d` and `errors_3d`" (the gridded partial-coverage shape). **Fails without the fix** with the duplicate-index ValueError on `pd.concat` / downstream reindex; passes with the fix.
- [x] `pytest tests/test_feature_api_prefer3d.py -q` — 13 passed (12 existing + new regression).
- [ ] Reviewer note: existing prefer3d tests are all single-AOI without gridding, which is the test-coverage gap that let this slip past — worth investing in a gridded prefer3d test fixture in a follow-up if we keep finding sharp edges in this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)