### PR TITLE
aoi_io: guard against aoi_id as both index name and column

### DIFF
--- a/nmaipy/aoi_io.py
+++ b/nmaipy/aoi_io.py
@@ -214,15 +214,23 @@ def read_from_file(
     if len(parcels_gdf) == 0:
         raise RuntimeError(f"No valid parcels in {path=}")
 
-    # Parquet round-trip artifact: pandas writes the index name into the parquet's
-    # pandas metadata even for a RangeIndex carrying no data. Reading the file back
-    # then yields index.name == id_column AND a separate id_column carrying the
-    # actual values — and any downstream merge(on=id_column) raises
-    # "is both an index level and a column label, which is ambiguous". The column
-    # is authoritative; drop the misleading index name so the block below
-    # promotes the column to the index cleanly.
+    # Resolve "aoi_id is both an index level and a column label" up-front: a
+    # downstream merge(on=id_column) would raise ValueError on this shape, and
+    # pandas commonly produces it via parquet round-trip — pandas writes the
+    # index name into parquet metadata even for a RangeIndex carrying no values,
+    # and the read back materialises a named-but-data-less index alongside the
+    # real column. The two ways to produce this shape need opposite resolutions:
+    #   * RangeIndex named id_column: the index has no information, the column
+    #     is authoritative — drop the index.
+    #   * Real-data index named id_column with a same-named column: the index
+    #     has values that may differ from the column; preserving the index is
+    #     the only conservative choice — drop the column. (No known producer
+    #     hits this path; if you find one, please open an issue.)
     if parcels_gdf.index.name == id_column and id_column in parcels_gdf.columns:
-        parcels_gdf = parcels_gdf.reset_index(drop=True)
+        if isinstance(parcels_gdf.index, pd.RangeIndex):
+            parcels_gdf = parcels_gdf.reset_index(drop=True)
+        else:
+            parcels_gdf = parcels_gdf.drop(columns=[id_column])
 
     # Check that identifier is unique
     if parcels_gdf.index.name != id_column:

--- a/nmaipy/aoi_io.py
+++ b/nmaipy/aoi_io.py
@@ -214,6 +214,16 @@ def read_from_file(
     if len(parcels_gdf) == 0:
         raise RuntimeError(f"No valid parcels in {path=}")
 
+    # Parquet round-trip artifact: pandas writes the index name into the parquet's
+    # pandas metadata even for a RangeIndex carrying no data. Reading the file back
+    # then yields index.name == id_column AND a separate id_column carrying the
+    # actual values — and any downstream merge(on=id_column) raises
+    # "is both an index level and a column label, which is ambiguous". The column
+    # is authoritative; drop the misleading index name so the block below
+    # promotes the column to the index cleanly.
+    if parcels_gdf.index.name == id_column and id_column in parcels_gdf.columns:
+        parcels_gdf = parcels_gdf.reset_index(drop=True)
+
     # Check that identifier is unique
     if parcels_gdf.index.name != id_column:
         if parcels_gdf.index.name is not None:

--- a/tests/test_robust_file_reading.py
+++ b/tests/test_robust_file_reading.py
@@ -352,6 +352,44 @@ class TestRobustFileReading:
         finally:
             Path(parquet_path).unlink()
 
+    def test_parquet_with_real_aoi_id_index_and_same_named_column_prefers_index(self):
+        """Companion to the RangeIndex case: if the index is NOT a RangeIndex but
+        is named aoi_id AND there's also an aoi_id column, the index carries real
+        values that may not match the column. The conservative resolution is to
+        keep the index and drop the column. No known producer hits this path, but
+        the explicit branch documents the asymmetric handling."""
+        gdf = gpd.GeoDataFrame(
+            {
+                AOI_ID_COLUMN_NAME: [999, 999, 999],  # deliberately wrong values
+                "name": ["A", "B", "C"],
+                "geometry": [
+                    Polygon([(144.9, -37.8), (145.0, -37.8), (145.0, -37.9), (144.9, -37.9)]),
+                    Polygon([(144.9, -37.7), (145.0, -37.7), (145.0, -37.8), (144.9, -37.8)]),
+                    Polygon([(144.9, -37.6), (145.0, -37.6), (145.0, -37.7), (144.9, -37.7)]),
+                ],
+            },
+            crs="EPSG:4326",
+        )
+        # Int64Index (real data, not a RangeIndex) named aoi_id, alongside a column
+        # of the same name carrying different values.
+        gdf.index = pd.Index([100, 200, 300], name=AOI_ID_COLUMN_NAME)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            parquet_path = f.name
+
+        try:
+            gdf.to_parquet(parquet_path)
+
+            result = parcels.read_from_file(Path(parquet_path))
+
+            assert result.index.name == AOI_ID_COLUMN_NAME
+            assert AOI_ID_COLUMN_NAME not in result.columns
+            # Index values (real data) preferred over column values (which might
+            # have been clobbered by a separate operation).
+            assert list(result.index) == [100, 200, 300]
+        finally:
+            Path(parquet_path).unlink()
+
     def test_parquet_with_user_index_column_preserved(self):
         """If the input has an unnamed RangeIndex AND a pre-existing column called
         'index' (e.g. from a lazy pd.to_parquet()), the user's column must survive

--- a/tests/test_robust_file_reading.py
+++ b/tests/test_robust_file_reading.py
@@ -301,6 +301,57 @@ class TestRobustFileReading:
         finally:
             Path(parquet_path).unlink()
 
+    def test_parquet_with_aoi_id_as_both_index_name_and_column(self):
+        """Regression: a parquet whose pandas metadata names the RangeIndex 'aoi_id'
+        AND also stores an aoi_id column must not pass through with both. The downstream
+        merge(on='aoi_id') in process_chunk would raise
+        'aoi_id is both an index level and a column label, which is ambiguous'.
+
+        This shape is produced by callers that forget to reset_index(drop=True) before
+        to_parquet when the GeoDataFrame inherited a named RangeIndex (e.g. reusing an
+        nmaipy output as the next input, or pipelines that add aoi_id as a column on
+        top of an already-named index).
+        """
+        gdf = gpd.GeoDataFrame(
+            {
+                AOI_ID_COLUMN_NAME: [10, 20, 30],
+                "name": ["A", "B", "C"],
+                "geometry": [
+                    Polygon([(144.9, -37.8), (145.0, -37.8), (145.0, -37.9), (144.9, -37.9)]),
+                    Polygon([(144.9, -37.7), (145.0, -37.7), (145.0, -37.8), (144.9, -37.8)]),
+                    Polygon([(144.9, -37.6), (145.0, -37.6), (145.0, -37.7), (144.9, -37.7)]),
+                ],
+            },
+            crs="EPSG:4326",
+        )
+        # Named RangeIndex that shares the name of an existing column — the exact
+        # shape parquet preserves verbatim through the round-trip.
+        gdf.index = pd.RangeIndex(0, 3, name=AOI_ID_COLUMN_NAME)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            parquet_path = f.name
+
+        try:
+            gdf.to_parquet(parquet_path)
+
+            # Confirm the parquet has the broken shape we're guarding against
+            roundtrip = pd.read_parquet(parquet_path)
+            assert roundtrip.index.name == AOI_ID_COLUMN_NAME
+            assert AOI_ID_COLUMN_NAME in roundtrip.columns
+
+            result = parcels.read_from_file(Path(parquet_path))
+
+            assert result.index.name == AOI_ID_COLUMN_NAME, "aoi_id should be the index"
+            assert AOI_ID_COLUMN_NAME not in result.columns, (
+                "aoi_id must appear only as the index, not also as a column"
+            )
+            assert list(result.index) == [10, 20, 30], "aoi_id values should be preserved"
+            # And the merge that previously raised must now succeed.
+            other = pd.DataFrame({"extra": [1, 2, 3]}, index=pd.Index([10, 20, 30], name=AOI_ID_COLUMN_NAME))
+            result.merge(other, on=AOI_ID_COLUMN_NAME, how="left")
+        finally:
+            Path(parquet_path).unlink()
+
     def test_parquet_with_user_index_column_preserved(self):
         """If the input has an unnamed RangeIndex AND a pre-existing column called
         'index' (e.g. from a lazy pd.to_parquet()), the user's column must survive


### PR DESCRIPTION
## Summary
- A parquet whose pandas metadata names the (Range)Index `aoi_id` while also storing an `aoi_id` column round-trips through `pd.read_parquet` with both intact. `read_from_file`'s `if index.name != id_column` guard then skips the promotion block, leaving the column in place — and every downstream `merge(on="aoi_id")` raises `ValueError: 'aoi_id' is both an index level and a column label, which is ambiguous`. In bulk-mode exports this took out every chunk at `exporter.py:3291`.
- Fix: detect that shape early in `read_from_file` and drop the misleading index name so the existing block re-promotes the `aoi_id` column cleanly. The column carries the values; the named-but-data-less RangeIndex is the spurious side.

## Known producers of this shape
1. Users reusing an nmaipy output as the next input (rollup outputs have `aoi_id` as the index, and a downstream copy that adds `aoi_id` back as a column without resetting yields exactly this).
2. Upstream tooling that adds `aoi_id` as a column on top of an already-named RangeIndex inherited from a prior parquet round-trip.

## Test plan
- [x] New regression in `tests/test_robust_file_reading.py::test_parquet_with_aoi_id_as_both_index_name_and_column` builds a parquet with the broken shape, confirms it survives `pd.read_parquet` unchanged, then asserts `read_from_file` returns `aoi_id` as the index only and a follow-up `merge(on="aoi_id")` succeeds.
- [x] Full `tests/test_robust_file_reading.py` + `tests/test_parcels.py` run cleanly (76 passed, 4 unrelated skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)