### PR TITLE
Survive invalid child geometries in calculate_child_feature_attributes

### DIFF
--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -17,6 +17,8 @@ from typing import Union
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from shapely import make_valid
+from shapely.errors import GEOSException
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.strtree import STRtree
 
@@ -148,6 +150,67 @@ def _compute_iou(geom_a, geom_b) -> float:
         return 0.0
 
 
+def _safe_intersection_area(children: gpd.GeoSeries, parent, class_id=None) -> float:
+    """
+    Sum the area of children.intersection(parent), tolerating invalid geometries.
+
+    The Feature API occasionally returns geometries that GEOS rejects with
+    ``GEOSException`` (e.g., self-intersecting rings, "side location conflict")
+    when used directly in topological operations. A single bad geometry will
+    fail the vectorized ``GeoSeries.intersection`` call and, in worker
+    contexts, kill the surrounding chunk. We retry such cases per-row with
+    ``shapely.make_valid`` on both operands and skip any row that still
+    fails, logging a warning so callers can see how often this fires.
+
+    Args:
+        children: GeoSeries of child geometries (already filtered to those
+                  that intersect the parent).
+        parent: Single parent geometry.
+        class_id: Optional class id, included in the warning for debuggability.
+
+    Returns:
+        Total intersection area in the input CRS units (square meters when
+        called from ``calculate_child_feature_attributes``).
+    """
+    try:
+        return float(children.intersection(parent).area.sum())
+    except GEOSException:
+        pass
+
+    parent_fixed = parent
+    if not parent.is_valid:
+        try:
+            parent_fixed = make_valid(parent)
+        except GEOSException:
+            log.warning(
+                "Could not make parent geometry valid (class_id=%s); skipping intersection.",
+                class_id,
+            )
+            return 0.0
+
+    total = 0.0
+    skipped = 0
+    for child in children.values:
+        if child is None or child.is_empty:
+            continue
+        try:
+            total += child.intersection(parent_fixed).area
+        except GEOSException:
+            try:
+                fixed = make_valid(child)
+                total += fixed.intersection(parent_fixed).area
+            except GEOSException:
+                skipped += 1
+    if skipped:
+        log.warning(
+            "Skipped %d child geometr%s in intersection (class_id=%s) due to invalid topology after make_valid.",
+            skipped,
+            "y" if skipped == 1 else "ies",
+            class_id,
+        )
+    return total
+
+
 def calculate_child_feature_attributes(
     parent_geometry,
     components: list,
@@ -242,7 +305,9 @@ def calculate_child_feature_attributes(
         total_intersection_area = 0.0
         max_confidence = None
         if mask.any():
-            total_intersection_area = matching_projected[mask].intersection(parent_projected).area.sum()
+            total_intersection_area = _safe_intersection_area(
+                matching_projected[mask], parent_projected, class_id=class_id
+            )
             if "confidence" in matching_features.columns:
                 conf = matching_features["confidence"].values[mask.values]
                 valid = conf[pd.notna(conf)]

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from shapely.geometry import box
+from shapely.geometry import Polygon, box
 from shapely.wkt import loads
 
 from nmaipy import parcels
@@ -1466,8 +1466,6 @@ class TestCalculateChildFeatureAttributes:
         per-row with ``shapely.make_valid``; this test pins that behavior end
         to end through ``calculate_child_feature_attributes``.
         """
-        from shapely.geometry import Polygon
-
         parent = self._parent_box()
         components = self._make_components([(self.STAINING_CLASS_ID, "Roof Staining")])
 

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -1457,6 +1457,44 @@ class TestCalculateChildFeatureAttributes:
         assert 0.45 <= result["roof_staining_ratio"] <= 0.55
         assert result["roof_staining_confidence"] == 0.85
 
+    def test_invalid_child_geometry_survives_via_make_valid(self):
+        """A self-intersecting child polygon must not crash the rollup.
+
+        The Feature API occasionally returns invalid topology (e.g., a bowtie).
+        GEOS rejects ``GeoSeries.intersection(parent)`` on these inputs with
+        ``GEOSException``. The wrapper in ``_safe_intersection_area`` retries
+        per-row with ``shapely.make_valid``; this test pins that behavior end
+        to end through ``calculate_child_feature_attributes``.
+        """
+        from shapely.geometry import Polygon
+
+        parent = self._parent_box()
+        components = self._make_components([(self.STAINING_CLASS_ID, "Roof Staining")])
+
+        # Bowtie spanning the parent box — invalid topology, but make_valid
+        # splits it into two triangles whose intersection with the parent has
+        # well-defined area.
+        bowtie = Polygon(
+            [
+                (self.SYD_LON, self.SYD_LAT),
+                (self.SYD_LON + self.D, self.SYD_LAT),
+                (self.SYD_LON, self.SYD_LAT + self.D),
+                (self.SYD_LON + self.D, self.SYD_LAT + self.D),
+                (self.SYD_LON, self.SYD_LAT),
+            ]
+        )
+        assert not bowtie.is_valid
+
+        child_features = self._make_child_features([(self.STAINING_CLASS_ID, bowtie, 0.7)])
+
+        result = parcels.calculate_child_feature_attributes(parent, components, child_features, "au")
+
+        assert result is not None
+        assert result["roof_staining_present"] == "Y"
+        assert result["roof_staining_area_sqm"] > 0
+        # make_valid'd bowtie covers exactly half the parent box (two triangles).
+        assert 0.45 <= result["roof_staining_ratio"] <= 0.55
+
     def test_matching_children_no_intersection(self):
         """When matching child features exist but don't intersect, emit zeros."""
         parent = self._parent_box()


### PR DESCRIPTION
## Summary

- Catch `GEOSException` from `GeoSeries.intersection()` inside `calculate_child_feature_attributes` and retry per-row with `shapely.make_valid` on both operands.
- A single bad upstream geometry no longer takes down the surrounding worker (and therefore the whole `ProcessPoolExecutor` run via `j.result()` re-raise in `base_exporter._monitor_progress_with_tqdm`).
- Added a regression test using a bowtie polygon — the canonical invalid topology — that pins this behavior end-to-end through `calculate_child_feature_attributes`.

## Background

Hit on a pull for ~2.7M AOIs, AOI in EPSG:5070). Chunk 0067 hit `shapely.errors.GEOSException: TopologyException: side location conflict at 786893.07045587152 679242.10235396691`. The stack:

```
nmaipy/parcels.py:245 in calculate_child_feature_attributes
  total_intersection_area = matching_projected[mask].intersection(parent_projected).area.sum()
→ geopandas → shapely set_operations.intersection
→ GEOSException
```

The exception propagated up through `ProcessPoolExecutor` → `j.result()` in `base_exporter._monitor_progress_with_tqdm` (line 594) → killed the entire 14-hour run after 71 of 535 chunks had completed. One bad upstream geometry shouldn't have that blast radius.

## The fix

New helper `_safe_intersection_area(children, parent, class_id=None)`:

1. Fast path: vectorized `children.intersection(parent).area.sum()` — zero overhead on valid inputs.
2. On `GEOSException`: retry per-row with `shapely.make_valid` on the parent (once) and each problematic child. Skip any row that still fails after `make_valid` and log a `WARNING` with the count + class_id for visibility.

The previous call site in `calculate_child_feature_attributes` now delegates to it. Common path is unchanged; only the rare invalid-topology case takes the slow per-row branch.

## Test plan

- [x] New unit test `test_invalid_child_geometry_survives_via_make_valid` in `TestCalculateChildFeatureAttributes` — bowtie polygon, asserts area > 0 and ratio ≈ 0.5 (two triangles cover half the parent). Pins end-to-end behavior, not just the helper.
- [x] All 9 tests in `TestCalculateChildFeatureAttributes` pass.
- [x] Validated in production: resumed the failing beacon pull on this branch via editable install. Completed cleanly at 2,676,489 rows × 1,001 columns over a 910.8-minute exporter run with no GEOS-induced crashes (16 Feature API errors total, all real upstream issues — "no survey resources", "polygon point count limit").

🤖 Generated with [Claude Code](https://claude.com/claude-code)