### PR TITLE
[TRO-4375] docs: add RCCS to data dictionary and auto-generated README

### DIFF
--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -44,6 +44,13 @@ _SCOPE_PHRASES: dict[str, str] = {
 }
 _DEFAULT_SCOPE_PHRASE = "across the entire parcel"
 
+# Public tuple of scope prefixes in declaration order. Downstream code that
+# needs to recognise primary-feature scope on a column name (e.g. README
+# generation, audit tooling) should import this rather than maintaining its
+# own copy — keeps the recognised scope set in lock-step with ``_SCOPE_PHRASES``
+# above.
+SCOPE_PREFIXES: tuple[str, ...] = tuple(_SCOPE_PHRASES.keys())
+
 # Suffix-stripping rules applied to pattern-matched ``{class}`` values inside
 # ``_substitute``. Order is significant — longer suffixes must come first so
 # ``_total_clipped`` is preferred over ``_clipped``. Each entry pairs a suffix

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -801,7 +801,7 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "Roof Condition Confidence Stats (RCCS) `default` histogram, bin {bin_idx} — fraction of roof pixels {scope_phrase} whose per-pixel damage-confidence score for {class} falls in this bin. The `default` histogram has 18 bins (0–17) ordered from least to most evidence of damage; bins are evenly spaced except the outer two edges, which are narrower to surface high- and low-extreme detail. Bin ratios for one `binType` on one component sum to ~1.0. RCCS is opt-in via `include=roofConditionConfidenceStats` (Gen6, US/AU/NZ). A higher confidence indicates a higher likelihood of damage being present, but the relationship between confidence and damage severity is not quantitatively measurable. See https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs and https://help.nearmap.com/kb/articles/1752-rccs-output.",
+      "description": "RCCS `default` histogram, bin {bin_idx} of 18 (0–17, ordered from lowest to highest confidence) — fraction of roof pixels {scope_phrase} whose per-pixel confidence that {class} is present falls in this bin. See README for the full RCCS interpretation guide.",
       "source": "base ai model"
     },
     {
@@ -809,7 +809,7 @@
       "dtype": "float",
       "min": "0.0",
       "max": "1.0",
-      "description": "Roof Condition Confidence Stats (RCCS) `extreme` histogram, bin {bin_idx} — fraction of roof pixels {scope_phrase} whose per-pixel damage-confidence score for {class} falls in this bin. The `extreme` histogram has 3 bins (0 = high-confidence not-damaged extreme, 1 = wide middle band covering ~0.992 of the confidence range, 2 = high-confidence damaged extreme); bins 0 and 2 are the narrow tails that isolate strongly confident detections at either end. Bin ratios for one `binType` on one component sum to ~1.0. RCCS is opt-in via `include=roofConditionConfidenceStats` (Gen6, US/AU/NZ). See https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs and https://help.nearmap.com/kb/articles/1752-rccs-output.",
+      "description": "RCCS `extreme` histogram, bin {bin_idx} of 3 (0 = lowest-confidence extreme, 1 = wide middle band, 2 = highest-confidence extreme) — fraction of roof pixels {scope_phrase} whose per-pixel confidence that {class} is present falls in this bin. See README for the full RCCS interpretation guide.",
       "source": "base ai model"
     }
   ],

--- a/nmaipy/data/column_metadata.json
+++ b/nmaipy/data/column_metadata.json
@@ -795,6 +795,22 @@
       "dtype": "UUID",
       "description": "Feature ID of the primary {class} {scope_phrase}.",
       "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_confidence_stats_default_bin_(?P<bin_idx>\\d+)$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Roof Condition Confidence Stats (RCCS) `default` histogram, bin {bin_idx} — fraction of roof pixels {scope_phrase} whose per-pixel damage-confidence score for {class} falls in this bin. The `default` histogram has 18 bins (0–17) ordered from least to most evidence of damage; bins are evenly spaced except the outer two edges, which are narrower to surface high- and low-extreme detail. Bin ratios for one `binType` on one component sum to ~1.0. RCCS is opt-in via `include=roofConditionConfidenceStats` (Gen6, US/AU/NZ). A higher confidence indicates a higher likelihood of damage being present, but the relationship between confidence and damage severity is not quantitatively measurable. See https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs and https://help.nearmap.com/kb/articles/1752-rccs-output.",
+      "source": "base ai model"
+    },
+    {
+      "regex": "^(?P<scope>primary_roof_|primary_building_|primary_roof_instance_|primary_building_lifecycle_|primary_swimming_pool_|primary_solar_panel_|primary_child_roof_|primary_child_roof_age_)?(?P<class>.+?)_confidence_stats_extreme_bin_(?P<bin_idx>\\d+)$",
+      "dtype": "float",
+      "min": "0.0",
+      "max": "1.0",
+      "description": "Roof Condition Confidence Stats (RCCS) `extreme` histogram, bin {bin_idx} — fraction of roof pixels {scope_phrase} whose per-pixel damage-confidence score for {class} falls in this bin. The `extreme` histogram has 3 bins (0 = high-confidence not-damaged extreme, 1 = wide middle band covering ~0.992 of the confidence range, 2 = high-confidence damaged extreme); bins 0 and 2 are the narrow tails that isolate strongly confident detections at either end. Bin ratios for one `binType` on one component sum to ~1.0. RCCS is opt-in via `include=roofConditionConfidenceStats` (Gen6, US/AU/NZ). See https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs and https://help.nearmap.com/kb/articles/1752-rccs-output.",
+      "source": "base ai model"
     }
   ],
   "defensible_space_zone_distances": {

--- a/nmaipy/data/spec_raw_fields.json
+++ b/nmaipy/data/spec_raw_fields.json
@@ -213,7 +213,7 @@
     "rccs": {
       "group": "rccs",
       "dtype": "object",
-      "description": "Top-level ``RCCS`` payload (the OpenAPI spec defines the schema but with no properties — see API team).",
+      "description": "A collection of statistics that summarize the confidence levels of AI predictions for the condition of a roof.  To include this supplementary data in the response, add `roofConditionConfidenceStats` to the `include` query parameter.  This property is only present in `Roof Condition` feature attributes.  Roof features with a footprint area exceeding 100,000sqm will be skipped and be marked as such. No roof condition confidence statistics will be produced in these cases.",
       "source": "score model",
       "_spec_ref": "RCCS",
       "_warning": "spec schema has no properties; see API team"

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -23,6 +23,7 @@ from nmaipy.column_metadata import (
     DOMINANT_ROOF_TYPES_COLUMNS,
     ROOF_AGE_COLUMNS,
     RSI_COLUMNS,
+    SCOPE_PREFIXES,
     evidence_type_legend,
     lookup_column,
 )
@@ -655,20 +656,13 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
         # The component name lives between an optional scope prefix and the
         # ``_confidence_stats_..._bin_N`` suffix; recover it so we can list
         # exactly which components RCCS was returned for in this export.
-        scope_prefixes = (
-            "primary_roof_",
-            "primary_building_",
-            "primary_roof_instance_",
-            "primary_building_lifecycle_",
-            "primary_child_roof_",
-        )
         components: set[str] = set()
         for col in rollup_columns:
             for marker in ("_confidence_stats_default_bin_", "_confidence_stats_extreme_bin_"):
                 if marker not in col:
                     continue
                 prefix = col.split(marker, 1)[0]
-                for scope in scope_prefixes:
+                for scope in SCOPE_PREFIXES:
                     if prefix.startswith(scope):
                         prefix = prefix[len(scope) :]
                         break
@@ -692,7 +686,8 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
             [
                 "## Roof Condition Confidence Stats (RCCS) Columns",
                 "",
-                spec_paragraph or (
+                spec_paragraph
+                or (
                     "Present only when the export was run with "
                     "`include=roofConditionConfidenceStats` (Gen6 only; available in the US, AU, NZ)."
                 ),
@@ -705,22 +700,27 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
                 "Gen6 only; available in the US, AU, NZ.",
                 *component_lines,
                 "",
+                "Note: RCCS covers all roof condition attributes — not just structural damage. "
+                "Cosmetic / maintenance components like staining, ponding, worn shingles and "
+                "repair patches each get their own histogram, with the same `condition is "
+                "present` axis interpreted relative to that component.",
+                "",
                 "### Column shape",
                 "",
                 "For each roof condition component `<component>`, RCCS emits two histograms:",
                 "",
                 "- **`<component>_confidence_stats_default_bin_{0..17}`** — 18 bins ordered from "
-                "least to most evidence of damage. Bins are evenly spaced except the outer two "
-                "edges, which are narrower so that high- and low-extreme detail isn't lost in a "
-                "wide bucket.",
+                "least to most evidence that the component condition is present. Bins are evenly "
+                "spaced except the outer two edges, which are narrower so that high- and "
+                "low-extreme detail isn't lost in a wide bucket.",
                 "- **`<component>_confidence_stats_extreme_bin_{0..2}`** — 3 bins isolating the "
-                "tails of the same distribution. Bin 0 is the high-confidence not-damaged "
-                "extreme, bin 1 is the wide middle band covering ~0.992 of the confidence range, "
-                "bin 2 is the high-confidence damaged extreme.",
+                "tails of the same distribution. Bin 0 is the high-confidence-absent extreme, "
+                "bin 1 is the wide middle band covering ~0.992 of the confidence range, bin 2 is "
+                "the high-confidence-present extreme.",
                 "",
                 "Each bin value is a fraction in `[0, 1]` — the share of roof pixels whose "
-                "damage-confidence score for that component fell into that bin. Bin values "
-                "within one `binType` for one component sum to ~1.0.",
+                "per-pixel confidence that the component is present fell into that bin. Bin "
+                "values within one `binType` for one component sum to ~1.0.",
                 "",
                 "In the rollup, RCCS columns are scoped to the parcel's primary roof "
                 "(`primary_roof_<component>_confidence_stats_...`); per-class files (e.g. "
@@ -734,9 +734,6 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
                 "indicates strong evidence the condition is **present**.",
                 "- Mass piled into the middle (e.g. `extreme_bin_1` ≈ 1.0) means the model is "
                 "**not committed** — useful as a low-confidence flag.",
-                "- A higher confidence indicates a higher likelihood that damage is present, but "
-                "the relationship between confidence and damage severity is **not quantitatively "
-                "measurable**.",
                 "",
                 "For more details, see:",
                 "- https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs",

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -140,6 +140,7 @@ class ReadmeGenerator:
         has_rsi = self._has_rsi_columns(rollup_columns)
         has_roof_age = self._has_roof_age_columns(rollup_columns)
         has_defensible_space = self._has_defensible_space_columns(rollup_columns)
+        has_rccs = self._has_rccs_columns(rollup_columns)
         area_unit = self._detect_area_unit()
 
         sections = []
@@ -160,6 +161,8 @@ class ReadmeGenerator:
             sections.append(self._generate_roof_age_section())
         if has_defensible_space:
             sections.append(self._generate_defensible_space_section(area_unit))
+        if has_rccs:
+            sections.append(self._generate_rccs_section(rollup_columns))
 
         sections.append(self._generate_data_notes(area_unit))
         sections.append(self._generate_footer())
@@ -322,6 +325,16 @@ class ReadmeGenerator:
     def _has_defensible_space_columns(self, columns: set[str]) -> bool:
         """Check if defensible space columns are present."""
         return any("defensible_space_zone_" in c for c in columns)
+
+    def _has_rccs_columns(self, columns: set[str]) -> bool:
+        """Check if Roof Condition Confidence Stats (RCCS) histogram columns are present.
+
+        RCCS columns are emitted only when the export was run with
+        ``include=roofConditionConfidenceStats``; the suffix
+        ``_confidence_stats_default_bin_`` or ``_confidence_stats_extreme_bin_``
+        is unique to RCCS.
+        """
+        return any("_confidence_stats_default_bin_" in c or "_confidence_stats_extreme_bin_" in c for c in columns)
 
     def _generate_header(self) -> str:
         """Generate the README header."""
@@ -631,6 +644,97 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
         )
 
         return "\n".join(lines)
+
+    def _generate_rccs_section(self, rollup_columns: set[str]) -> str:
+        """Generate the Roof Condition Confidence Stats (RCCS) section.
+
+        Lists the roof condition components for which RCCS histograms are
+        present in the rollup, then explains the per-bin column shape and how
+        to interpret the `default` / `extreme` histograms.
+        """
+        # The component name lives between an optional scope prefix and the
+        # ``_confidence_stats_..._bin_N`` suffix; recover it so we can list
+        # exactly which components RCCS was returned for in this export.
+        scope_prefixes = (
+            "primary_roof_",
+            "primary_building_",
+            "primary_roof_instance_",
+            "primary_building_lifecycle_",
+            "primary_child_roof_",
+        )
+        components: set[str] = set()
+        for col in rollup_columns:
+            for marker in ("_confidence_stats_default_bin_", "_confidence_stats_extreme_bin_"):
+                if marker not in col:
+                    continue
+                prefix = col.split(marker, 1)[0]
+                for scope in scope_prefixes:
+                    if prefix.startswith(scope):
+                        prefix = prefix[len(scope) :]
+                        break
+                if prefix.startswith("low_conf_"):
+                    prefix = prefix[len("low_conf_") :]
+                components.add(prefix)
+                break
+
+        component_lines = ["", "**Roof condition components with RCCS histograms in this export:**", ""]
+        for comp in sorted(components):
+            component_lines.append(f"- `{comp}`")
+
+        return "\n".join(
+            [
+                "## Roof Condition Confidence Stats (RCCS) Columns",
+                "",
+                "RCCS surfaces the per-pixel confidence distribution that underlies each roof "
+                "condition detection (ponding, rusting, staining, structural damage, repairs, "
+                "zinc staining, etc.). The single `*_confidence` score these components also "
+                "carry collapses that distribution to one number; RCCS exposes the full shape so "
+                "downstream consumers can apply their own thresholds or roll their own scoring.",
+                "",
+                "Present only when the export was run with `include=roofConditionConfidenceStats` "
+                "(Gen6 only; available in the US, AU, NZ).",
+                *component_lines,
+                "",
+                "### Column shape",
+                "",
+                "For each roof condition component `<component>`, RCCS emits two histograms:",
+                "",
+                "- **`<component>_confidence_stats_default_bin_{0..17}`** — 18 bins ordered from "
+                "least to most evidence of damage. Bins are evenly spaced except the outer two "
+                "edges, which are narrower so that high- and low-extreme detail isn't lost in a "
+                "wide bucket.",
+                "- **`<component>_confidence_stats_extreme_bin_{0..2}`** — 3 bins isolating the "
+                "tails of the same distribution. Bin 0 is the high-confidence not-damaged "
+                "extreme, bin 1 is the wide middle band covering ~0.992 of the confidence range, "
+                "bin 2 is the high-confidence damaged extreme.",
+                "",
+                "Each bin value is a fraction in `[0, 1]` — the share of roof pixels whose "
+                "damage-confidence score for that component fell into that bin. Bin values "
+                "within one `binType` for one component sum to ~1.0.",
+                "",
+                "In the rollup, RCCS columns are scoped to the parcel's primary roof "
+                "(`primary_roof_<component>_confidence_stats_...`); per-class files (e.g. "
+                "`roof.csv`) carry the same columns unscoped, one row per feature.",
+                "",
+                "### Interpreting the histograms",
+                "",
+                "- Mass concentrated in **low-index `default` bins** (or in `extreme_bin_0`) "
+                "indicates strong evidence the condition is **absent** across the roof.",
+                "- Mass concentrated in **high-index `default` bins** (or in `extreme_bin_2`) "
+                "indicates strong evidence the condition is **present**.",
+                "- Mass piled into the middle (e.g. `extreme_bin_1` ≈ 1.0) means the model is "
+                "**not committed** — useful as a low-confidence flag.",
+                "- A higher confidence indicates a higher likelihood that damage is present, but "
+                "the relationship between confidence and damage severity is **not quantitatively "
+                "measurable**.",
+                "",
+                "For more details, see:",
+                "- https://help.nearmap.com/kb/articles/1749-roof-condition-confidence-stats-rccs",
+                "- https://help.nearmap.com/kb/articles/1752-rccs-output",
+                "- https://help.nearmap.com/kb/articles/1765-rccs-frequently-asked-questions-faq",
+                "",
+            ]
+        )
 
     def _generate_roof_age_section(self) -> str:
         """Generate the Roof Age columns section."""

--- a/nmaipy/readme_generator.py
+++ b/nmaipy/readme_generator.py
@@ -681,18 +681,28 @@ For more details, see: https://help.nearmap.com/kb/articles/1641-nearmap-roof-sp
         for comp in sorted(components):
             component_lines.append(f"- `{comp}`")
 
+        # Wrapper-level prose comes from spec_raw_fields.json so API team
+        # edits to the RCCS schema description auto-flow into this README.
+        # Falls back to the local explainer if the spec hasn't been
+        # regenerated since RCCS was added to the API.
+        rccs_meta = lookup_column("rccs")
+        spec_paragraph = "" if rccs_meta.is_unknown() else rccs_meta.description
+
         return "\n".join(
             [
                 "## Roof Condition Confidence Stats (RCCS) Columns",
+                "",
+                spec_paragraph or (
+                    "Present only when the export was run with "
+                    "`include=roofConditionConfidenceStats` (Gen6 only; available in the US, AU, NZ)."
+                ),
                 "",
                 "RCCS surfaces the per-pixel confidence distribution that underlies each roof "
                 "condition detection (ponding, rusting, staining, structural damage, repairs, "
                 "zinc staining, etc.). The single `*_confidence` score these components also "
                 "carry collapses that distribution to one number; RCCS exposes the full shape so "
-                "downstream consumers can apply their own thresholds or roll their own scoring.",
-                "",
-                "Present only when the export was run with `include=roofConditionConfidenceStats` "
-                "(Gen6 only; available in the US, AU, NZ).",
+                "downstream consumers can apply their own thresholds or roll their own scoring. "
+                "Gen6 only; available in the US, AU, NZ.",
                 *component_lines,
                 "",
                 "### Column shape",

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -161,6 +161,26 @@ class TestGenericPatterns:
         assert meta.dtype == "float (quantised uint8)"
         assert "Null when the corresponding area is 0" in meta.description
 
+    @pytest.mark.parametrize(
+        "name, bin_type, expected_bin_idx",
+        [
+            ("primary_roof_structural_damage_confidence_stats_default_bin_0", "default", "0"),
+            ("primary_roof_structural_damage_confidence_stats_default_bin_17", "default", "17"),
+            ("primary_roof_zinc_staining_confidence_stats_extreme_bin_2", "extreme", "2"),
+            # Per-class (unscoped) and low_conf variants must also resolve.
+            ("structural_damage_confidence_stats_default_bin_5", "default", "5"),
+            ("low_conf_roof_ponding_confidence_stats_extreme_bin_1", "extreme", "1"),
+        ],
+    )
+    def test_rccs_bin_pattern(self, name, bin_type, expected_bin_idx):
+        meta = lookup_column(name, area_unit="sqft", class_label="parcel")
+        assert meta.dtype == "float"
+        assert meta.min == "0.0"
+        assert meta.max == "1.0"
+        assert meta.source == "base ai model"
+        assert f"RCCS `{bin_type}` histogram" in meta.description
+        assert f"bin {expected_bin_idx}" in meta.description
+
 
 # ---------------------------------------------------------------------------
 # 4. Unknown columns

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -169,6 +169,26 @@ class TestHasRoofAgeColumns:
         assert gen._has_roof_age_columns(columns) is False
 
 
+class TestHasRccsColumns:
+    """Tests for Roof Condition Confidence Stats (RCCS) column detection."""
+
+    def test_has_rccs_columns_with_default_bin(self):
+        gen = ReadmeGenerator(output_dir=Path("."))
+        columns = {"primary_roof_structural_damage_confidence_stats_default_bin_0", "other_col"}
+        assert gen._has_rccs_columns(columns) is True
+
+    def test_has_rccs_columns_with_extreme_bin(self):
+        gen = ReadmeGenerator(output_dir=Path("."))
+        columns = {"primary_roof_zinc_staining_confidence_stats_extreme_bin_2", "other_col"}
+        assert gen._has_rccs_columns(columns) is True
+
+    def test_has_rccs_columns_without(self):
+        gen = ReadmeGenerator(output_dir=Path("."))
+        # `*_confidence` alone is not RCCS — only the histogram bin suffix counts.
+        columns = {"aoi_id", "roof_count", "structural_damage_confidence"}
+        assert gen._has_rccs_columns(columns) is False
+
+
 class TestRoofAgeDatasetSection:
     """The roof age section surfaces dataset / untilAsOfDate selection from export_config.json."""
 


### PR DESCRIPTION
## Summary

RCCS columns (`*_confidence_stats_{default|extreme}_bin_N`) have been emitted by [feature_attributes.py:834-844](nmaipy/feature_attributes.py#L834-L844) for some time, but neither the per-file `*_data_dictionary.csv` nor the auto-generated `README.md` described them — every one of the 336 RCCS columns in our test rollup resolved to the `?` sentinel.

- **`column_metadata.json`**: two new patterns covering `{scope}{component}_confidence_stats_{default|extreme}_bin_{N}`, with the standard scope-prefix alternation so they cover rollup `primary_roof_…` columns and per-class `roof.csv` unscoped variants alike.
- **`readme_generator.py`**: new `_has_rccs_columns` gate and `_generate_rccs_section`, wired into `_generate()` alongside RSI / Roof Age / Defensible Space. The section dynamically lists the components present in the export, explains both histograms, walks through how to interpret bin mass, and links the three help.nearmap.com articles.
- **`spec_raw_fields.json`**: regenerated against the upstream API spec so the `rccs` wrapper carries the API team's actual wording (including the 100,000 sqm skip threshold). `_generate_rccs_section` leads with that description via `lookup_column(\"rccs\")` so future API-team edits flow through automatically.

Refs: TRO-4375

## Test plan

- [x] `pytest -m \"not live_api\"` — 597 passed, 11 skipped, no regressions
- [x] `lookup_column` resolves all 336 RCCS columns in `tests/data/test_parcels_rollup_roof_condition_confidence_stats.csv` (0 unmatched)
- [x] `ReadmeGenerator._generate()` produces the RCCS section when RCCS columns are present, omits it when they aren't
- [x] Manually inspected the rendered RCCS section — components list, column shape, interpretation guidance, and spec-sourced wrapper paragraph all render correctly
- [ ] Reviewer eyeball: section reads well to a non-Nearmap customer

🤖 Generated with [Claude Code](https://claude.com/claude-code)