### PR TITLE
[TRO-4382] fix: two annoying export-time warnings (silent feature loss + leaked centroid warning)

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -41,6 +41,14 @@ import shapely.geometry
 from tqdm import tqdm
 
 warnings.filterwarnings("ignore", message=".*initial implementation of Parquet.*")
+# The exporter computes geometry centroids in EPSG:4326 to feed mapbrowser URL
+# pins (see export_feature_class). For building-sized features the geographic-vs-
+# projected centroid bias is decimetric — invisible at the URL's zoom level — so
+# this warning is cosmetic. Suppression must be module-level: the in-flight
+# `with warnings.catch_warnings(): ...` form around the centroid call is not
+# thread-safe (Python docs), and concurrent ThreadPoolExecutor workers in the
+# flatten path were racing on warnings.filters, leaking this warning per export.
+warnings.filterwarnings("ignore", message=".*Geometry is in a geographic CRS.*centroid.*")
 
 import atexit
 import signal
@@ -1737,11 +1745,10 @@ def _compute_feature_class_data(
     # --- Section F: Mapbrowser link ---
     # Uses geometry centroid for location and survey_date/installation_date for date
     if "geometry" in class_features.columns:
-        # Vectorized centroid extraction (geographic CRS is fine for URL link coordinates)
+        # Geographic CRS is fine for URL link coordinates; the corresponding
+        # "Geometry is in a geographic CRS" UserWarning is suppressed at module level.
         geom_valid = class_features.geometry.notna() & ~class_features.geometry.is_empty
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*geographic CRS.*centroid.*")
-            centroids = class_features.geometry.centroid
+        centroids = class_features.geometry.centroid
         lats = centroids.y.astype(str)
         lons = centroids.x.astype(str)
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1064,13 +1064,33 @@ class FeatureApi(GriddedApiClient):
                 raise AIFeatureAPIGridError(404, message="All grid cells failed - no coverage or data available")
 
             # Create metadata.
-            # Drop `aggregate` before dedup: it is a nested dict (populated when
-            # include=defensibleSpace is set) and drop_duplicates() with no subset
-            # hashes every column, raising TypeError: unhashable type: 'dict'.
-            # The aggregate value is not consumed below.
-            metadata_df = metadata_df.drop(columns=["aggregate"], errors="ignore").drop_duplicates().iloc[0]
+            # Whitelist guaranteed-scalar columns for dedup. Payload metadata can
+            # carry nested-dict fields — `aggregate` is populated whenever
+            # include=defensibleSpace, and per the v4 API spec `postcat` can
+            # return as an object describing post-catastrophe imagery rather than
+            # a boolean. An un-subsetted drop_duplicates() would hash those and
+            # raise TypeError: unhashable type: 'dict'. Only the strings below
+            # are guaranteed hashable; the consumer reads other fields via
+            # iloc[0] which works for any value type.
+            metadata_df = metadata_df.drop_duplicates(
+                subset=[
+                    "system_version",
+                    "link",
+                    "survey_date",
+                    "survey_id",
+                    "survey_resource_id",
+                    "perspective",
+                    "mesh_date",
+                ]
+            ).iloc[0]
+            # Use the outer aoi_id (the AOI being processed) rather than reading a
+            # column from metadata_df. After set_index(AOI_ID_COLUMN_NAME) in
+            # get_features_gdf_gridded, aoi_id is the DataFrame's index, not a
+            # column — and after iloc[0] above the values left in metadata_df are
+            # per-grid-cell temp integer IDs anyway. The outer aoi_id is what the
+            # caller wants attached to the returned metadata.
             metadata = {
-                AOI_ID_COLUMN_NAME: metadata_df[AOI_ID_COLUMN_NAME],
+                AOI_ID_COLUMN_NAME: aoi_id,
                 "system_version": metadata_df["system_version"],
                 "link": metadata_df["link"],
                 "survey_date": metadata_df["survey_date"],
@@ -1099,7 +1119,12 @@ class FeatureApi(GriddedApiClient):
             }
             return features_gdf, metadata, error, None
         except Exception as grid_error:
-            logger.error(f"Gridding failed for AOI (id {aoi_id}): {grid_error}")
+            # exc_info=True so unexpected exceptions surface with a full
+            # traceback in logs instead of just a message. This is the catch-all
+            # that swallowed the dict-aggregate TypeError and a latent KeyError
+            # on aoi_id for years — silent feature loss with only a one-line
+            # message gave no clue where the failure originated.
+            logger.error(f"Gridding failed for AOI (id {aoi_id}): {grid_error}", exc_info=True)
             error = {
                 AOI_ID_COLUMN_NAME: aoi_id,
                 "status_code": None,

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1063,8 +1063,12 @@ class FeatureApi(GriddedApiClient):
             if len(metadata_df) == 0:
                 raise AIFeatureAPIGridError(404, message="All grid cells failed - no coverage or data available")
 
-            # Create metadata
-            metadata_df = metadata_df.drop_duplicates().iloc[0]
+            # Create metadata.
+            # Drop `aggregate` before dedup: it is a nested dict (populated when
+            # include=defensibleSpace is set) and drop_duplicates() with no subset
+            # hashes every column, raising TypeError: unhashable type: 'dict'.
+            # The aggregate value is not consumed below.
+            metadata_df = metadata_df.drop(columns=["aggregate"], errors="ignore").drop_duplicates().iloc[0]
             metadata = {
                 AOI_ID_COLUMN_NAME: metadata_df[AOI_ID_COLUMN_NAME],
                 "system_version": metadata_df["system_version"],

--- a/tests/test_centroid_warning_suppression.py
+++ b/tests/test_centroid_warning_suppression.py
@@ -1,0 +1,53 @@
+"""
+Regression test: importing nmaipy.exporter installs a module-level filter that
+suppresses the geographic-CRS centroid UserWarning.
+
+The exporter computes centroids in EPSG:4326 to feed mapbrowser URL pins —
+geographic CRS is intentional there and the resulting warning is cosmetic.
+A prior `with warnings.catch_warnings(): filterwarnings(...)` block around the
+centroid call appeared to suppress it but leaked under load, because
+catch_warnings is documented as not thread-safe and the exporter's
+ThreadPoolExecutor workers raced on warnings.filters. The fix promoted the
+filter to module level.
+
+This must be tested in a subprocess: pytest's own warning-capture plugin wraps
+each test in catch_warnings() and the session in its own filter state, so a
+module-level filterwarnings() call during import is invisible to assertions
+running inside the test. A subprocess runs without pytest's harness and
+matches the production CLI environment.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_centroid_warning_suppressed_in_production_environment():
+    # The script triggers the exact warning that production emits and exits 0
+    # iff no warning was raised. ``warnings.simplefilter("error")`` converts any
+    # un-suppressed warning into an exception, which makes silent leaks fatal.
+    script = textwrap.dedent(
+        """
+        import warnings
+        warnings.simplefilter("error")  # any un-ignored warning becomes an error
+        import nmaipy.exporter  # installs the module-level ignore filter
+        import geopandas as gpd
+        from shapely.geometry import Polygon
+
+        gs = gpd.GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])], crs="EPSG:4326")
+        _ = gs.centroid  # would raise UserWarning if not suppressed
+        """
+    ).strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        "Subprocess raised — module-level centroid suppression failed.\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )

--- a/tests/test_gridded_aggregate_dict_dedup.py
+++ b/tests/test_gridded_aggregate_dict_dedup.py
@@ -1,24 +1,31 @@
 """
-Regression test: gridded metadata dedup must survive dict-valued payload fields.
+Regression tests: gridded metadata dedup must survive dict-valued payload fields.
 
 When an AOI is large enough to be gridded and ``include=["defensibleSpace"]`` is
 requested, each grid-cell response carries a populated nested ``aggregate``
 object. ``payload_gdf`` copies that into per-grid-cell metadata; the gridded
-caller then assembles those dicts into ``metadata_df`` and runs
+caller then assembles those dicts into ``metadata_df`` and previously ran
 ``metadata_df.drop_duplicates().iloc[0]``. With no ``subset=``, pandas hashes
-every column — including ``aggregate`` — and previously crashed with
+every column — including ``aggregate`` — and crashed with
 ``TypeError: unhashable type: 'dict'``. The error was swallowed by the
 bare-Exception handler in ``_attempt_gridding`` and the AOI silently lost all
 its features.
+
+The same failure mode would also surface if ``postcat`` returns its object form
+(per the v4 API spec it may be either a boolean or a nested object describing
+post-catastrophe imagery). The fix uses ``subset=`` whitelisting of
+guaranteed-scalar columns rather than relying on dropping any one column.
 """
 
 import json
 from pathlib import Path
 
+import geopandas as gpd
 import pandas as pd
 import pytest
+from shapely.geometry import Polygon
 
-from nmaipy.constants import AOI_ID_COLUMN_NAME
+from nmaipy.constants import AOI_ID_COLUMN_NAME, API_CRS
 from nmaipy.feature_api import FeatureApi
 
 data_directory = Path(__file__).parent / "data"
@@ -33,35 +40,64 @@ def defensible_space_payload():
         return json.load(f)
 
 
+def _build_gridded_metadata_df(payload, n_cells=3):
+    """Build a metadata_df shaped like the one get_features_gdf_gridded produces."""
+    metadata = [FeatureApi.payload_gdf(payload, aoi_id=i)[1] for i in range(n_cells)]
+    return pd.DataFrame(metadata).set_index(AOI_ID_COLUMN_NAME)
+
+
 def test_aggregate_is_dict_in_payload(defensible_space_payload):
     """Precondition: the cached defensibleSpace payload has a dict aggregate.
-    If this fails the regression test below is no longer exercising the bug."""
+    If this fails the regression tests below are no longer exercising the bug."""
     assert isinstance(defensible_space_payload.get("aggregate"), dict)
     assert defensible_space_payload["aggregate"], "aggregate must be non-empty"
 
 
-def test_gridded_metadata_dedup_survives_dict_aggregate(defensible_space_payload):
-    """Simulate the metadata path through get_features_gdf_gridded for a gridded
-    AOI where every cell returns a populated `aggregate` dict, then run the same
-    dedup step `_attempt_gridding` runs. Must not raise."""
-    # Each grid cell yields one metadata dict from payload_gdf. Simulate three
-    # cells of the same AOI (a real grid would produce >=4; three is enough to
-    # exercise drop_duplicates with identical rows).
-    metadata = []
-    for cell_idx in range(3):
-        _, cell_metadata = FeatureApi.payload_gdf(defensible_space_payload, aoi_id=cell_idx)
-        metadata.append(cell_metadata)
+def test_raw_drop_duplicates_on_dict_column_would_raise(defensible_space_payload):
+    """Negative control: without subset=, drop_duplicates() raises TypeError on
+    the dict column. Pins the failure mode the fix addresses."""
+    metadata_df = _build_gridded_metadata_df(defensible_space_payload, n_cells=2)
+    with pytest.raises(TypeError, match="unhashable type: 'dict'"):
+        metadata_df.drop_duplicates()
 
-    # Sanity: the bug requires aggregate to actually be a dict in metadata.
-    assert all(isinstance(m["aggregate"], dict) for m in metadata)
 
-    # Mirror get_features_gdf_gridded's construction at feature_api.py:1911.
-    metadata_df = pd.DataFrame(metadata).set_index(AOI_ID_COLUMN_NAME)
+def test_attempt_gridding_does_not_swallow_dict_aggregate(monkeypatch, defensible_space_payload):
+    """End-to-end regression: ``_attempt_gridding`` must succeed when grid-cell
+    metadata contains dict-valued ``aggregate``. Before the fix, the inner
+    ``drop_duplicates()`` raised TypeError, the bare-Exception handler turned it
+    into a per-AOI grid error with message ``"Gridding failed: unhashable type:
+    'dict'"``, and the AOI silently lost all features.
 
-    # The line that crashed: feature_api.py:1067. Must succeed.
-    deduped_row = metadata_df.drop(columns=["aggregate"], errors="ignore").drop_duplicates().iloc[0]
+    This test patches ``get_features_gdf_gridded`` so we exercise the dedup-and-
+    consume logic in ``_attempt_gridding`` directly, without making any HTTP
+    calls. If [feature_api.py:1067-1078] is reverted, this test catches it.
+    """
+    api = FeatureApi(api_key="fake")
 
-    # Confirm the fields _attempt_gridding actually consumes are intact.
+    fake_metadata_df = _build_gridded_metadata_df(defensible_space_payload, n_cells=3)
+    fake_features_gdf = gpd.GeoDataFrame(columns=["geometry"], crs=API_CRS)
+    fake_errors_df = pd.DataFrame([])
+
+    def fake_gridded(**kwargs):
+        return fake_features_gdf, fake_metadata_df, fake_errors_df
+
+    monkeypatch.setattr(api, "get_features_gdf_gridded", fake_gridded)
+
+    features_gdf, metadata, error, errors_df = api._attempt_gridding(
+        geometry=Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+        region="us",
+        aoi_id=999,
+    )
+
+    # Pre-fix symptom: error dict populated with "Gridding failed: unhashable type: 'dict'".
+    assert error is None, f"_attempt_gridding silently absorbed an error: {error}"
+
+    # Post-fix: metadata is a real dict the consumer can use.
+    assert metadata is not None, "expected real metadata, got None"
+    # The outer aoi_id must be attached — not the per-grid-cell temp id assigned
+    # internally by get_features_gdf_gridded.
+    assert metadata[AOI_ID_COLUMN_NAME] == 999
+    # Spot-check that scalar consumer fields are intact.
     for field in (
         "system_version",
         "link",
@@ -72,15 +108,4 @@ def test_gridded_metadata_dedup_survives_dict_aggregate(defensible_space_payload
         "postcat",
         "mesh_date",
     ):
-        assert field in deduped_row.index, f"{field} should survive dedup"
-
-
-def test_raw_drop_duplicates_on_dict_column_would_raise(defensible_space_payload):
-    """Negative control: without dropping `aggregate`, drop_duplicates() raises
-    TypeError on the dict column. This pins the failure mode the fix addresses.
-    """
-    metadata = [FeatureApi.payload_gdf(defensible_space_payload, aoi_id=i)[1] for i in range(2)]
-    metadata_df = pd.DataFrame(metadata).set_index(AOI_ID_COLUMN_NAME)
-
-    with pytest.raises(TypeError, match="unhashable type: 'dict'"):
-        metadata_df.drop_duplicates()
+        assert field in metadata, f"{field} missing from metadata"

--- a/tests/test_gridded_aggregate_dict_dedup.py
+++ b/tests/test_gridded_aggregate_dict_dedup.py
@@ -1,0 +1,86 @@
+"""
+Regression test: gridded metadata dedup must survive dict-valued payload fields.
+
+When an AOI is large enough to be gridded and ``include=["defensibleSpace"]`` is
+requested, each grid-cell response carries a populated nested ``aggregate``
+object. ``payload_gdf`` copies that into per-grid-cell metadata; the gridded
+caller then assembles those dicts into ``metadata_df`` and runs
+``metadata_df.drop_duplicates().iloc[0]``. With no ``subset=``, pandas hashes
+every column — including ``aggregate`` — and previously crashed with
+``TypeError: unhashable type: 'dict'``. The error was swallowed by the
+bare-Exception handler in ``_attempt_gridding`` and the AOI silently lost all
+its features.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from nmaipy.constants import AOI_ID_COLUMN_NAME
+from nmaipy.feature_api import FeatureApi
+
+data_directory = Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def defensible_space_payload():
+    raw_payload_file = data_directory / "test_defensible_space_raw_payload.json"
+    if not raw_payload_file.exists():
+        pytest.skip(f"Raw payload file {raw_payload_file} does not exist.")
+    with open(raw_payload_file, "r") as f:
+        return json.load(f)
+
+
+def test_aggregate_is_dict_in_payload(defensible_space_payload):
+    """Precondition: the cached defensibleSpace payload has a dict aggregate.
+    If this fails the regression test below is no longer exercising the bug."""
+    assert isinstance(defensible_space_payload.get("aggregate"), dict)
+    assert defensible_space_payload["aggregate"], "aggregate must be non-empty"
+
+
+def test_gridded_metadata_dedup_survives_dict_aggregate(defensible_space_payload):
+    """Simulate the metadata path through get_features_gdf_gridded for a gridded
+    AOI where every cell returns a populated `aggregate` dict, then run the same
+    dedup step `_attempt_gridding` runs. Must not raise."""
+    # Each grid cell yields one metadata dict from payload_gdf. Simulate three
+    # cells of the same AOI (a real grid would produce >=4; three is enough to
+    # exercise drop_duplicates with identical rows).
+    metadata = []
+    for cell_idx in range(3):
+        _, cell_metadata = FeatureApi.payload_gdf(defensible_space_payload, aoi_id=cell_idx)
+        metadata.append(cell_metadata)
+
+    # Sanity: the bug requires aggregate to actually be a dict in metadata.
+    assert all(isinstance(m["aggregate"], dict) for m in metadata)
+
+    # Mirror get_features_gdf_gridded's construction at feature_api.py:1911.
+    metadata_df = pd.DataFrame(metadata).set_index(AOI_ID_COLUMN_NAME)
+
+    # The line that crashed: feature_api.py:1067. Must succeed.
+    deduped_row = metadata_df.drop(columns=["aggregate"], errors="ignore").drop_duplicates().iloc[0]
+
+    # Confirm the fields _attempt_gridding actually consumes are intact.
+    for field in (
+        "system_version",
+        "link",
+        "survey_date",
+        "survey_id",
+        "survey_resource_id",
+        "perspective",
+        "postcat",
+        "mesh_date",
+    ):
+        assert field in deduped_row.index, f"{field} should survive dedup"
+
+
+def test_raw_drop_duplicates_on_dict_column_would_raise(defensible_space_payload):
+    """Negative control: without dropping `aggregate`, drop_duplicates() raises
+    TypeError on the dict column. This pins the failure mode the fix addresses.
+    """
+    metadata = [FeatureApi.payload_gdf(defensible_space_payload, aoi_id=i)[1] for i in range(2)]
+    metadata_df = pd.DataFrame(metadata).set_index(AOI_ID_COLUMN_NAME)
+
+    with pytest.raises(TypeError, match="unhashable type: 'dict'"):
+        metadata_df.drop_duplicates()


### PR DESCRIPTION
## Summary

Three related export-time issues — bundling because review uncovered a chain of latent bugs and they share the same operator-experience theme ("noisy or silently-incorrect exporter behavior").

### 1. Silent feature loss on gridded AOIs with `include=defensibleSpace`

Large AOIs that needed gridding and requested `defensibleSpace` were silently losing all features (`failure_type=grid`). The bare-`Exception` handler in `_attempt_gridding` was swallowing a `TypeError: unhashable type: 'dict'` raised one line earlier by `metadata_df.drop_duplicates()`.

**Root cause:** `payload_gdf` copies the raw API `aggregate` field into each grid cell's metadata. Per the v4 API spec, `aggregate` is a nested object — populated whenever `defensibleSpace` is requested. The dedup at `feature_api.py:1067` ran without a `subset=`, hashing every column including the dict-valued `aggregate`.

**Fix:** dedup with an explicit `subset=` whitelist of guaranteed-scalar columns. Also robust to `postcat` returning its object form (per the v4 spec it can be either a boolean or a nested object) — the original `drop(columns=["aggregate"])` form would have crashed again on that case.

### 2. Latent `KeyError: 'aoi_id'` in the gridded metadata consumer (broken since TRO-3854)

Adding a real end-to-end regression test for (1) — calling `_attempt_gridding` with a monkeypatched `get_features_gdf_gridded` — exposed a second bug at `feature_api.py:1087`: `metadata_df[AOI_ID_COLUMN_NAME]` looks up `aoi_id` as a column, but `get_features_gdf_gridded` sets it as the DataFrame's index. After `.iloc[0]` above, the resulting Series doesn't have `aoi_id` at all.

This has been silently broken since gridding was introduced in TRO-3854. The aggregate-dict `TypeError` from (1) crashed earlier so it never surfaced. The (1) fix alone would have changed the error message from `"unhashable type: 'dict'"` to `"'aoi_id'"` without restoring the lost features.

**Fix:** use the outer `aoi_id` parameter (already in scope) directly. Semantically correct anyway, since the values in the index were per-grid-cell temp integer IDs assigned by `get_features_gdf_gridded`, not the AOI's real id.

### 3. `Geometry is in a geographic CRS ... centroid` warning leaking under load

The exporter computes centroids in EPSG:4326 to feed mapbrowser URL pins — geographic CRS is fine for that purpose (sub-meter bias at zoom 21), so the warning is cosmetic. There was already a local `with warnings.catch_warnings(): filterwarnings(...)` intended to suppress it.

**Root cause:** `warnings.catch_warnings()` is documented as not thread-safe. The flatten path runs from a `ThreadPoolExecutor`; concurrent workers race on `warnings.filters` and one thread can observe the filter mid-mutation by another, letting the warning through. Single-threaded tests don't reproduce — only surfaces under load.

**Fix:** promote the filter to module-level next to the existing Parquet filter, which is unaffected by the race.

### 4. Bare-Exception handler now logs with full traceback

The catch-all at `feature_api.py:1121` is what swallowed bugs (1) and (3) silently for an unknown duration. Adding `exc_info=True` makes future failures of this class discoverable in logs without changing failure semantics — the minimum defensible change to the recovery path itself. A more thorough narrowing of the catch is separate-PR territory.

## Test plan

- [x] Regression tests in `tests/test_gridded_aggregate_dict_dedup.py`:
  - precondition that `aggregate` is a dict in the cached `test_defensible_space_raw_payload.json`
  - negative control: raw `drop_duplicates()` on the dict column raises `TypeError` — pins the failure mode
  - **end-to-end regression** that calls `_attempt_gridding` via monkeypatched `get_features_gdf_gridded`, verifying no silent error and that the outer `aoi_id` is correctly attached (catches a revert of either (1) or (2))
- [x] Subprocess-based test in `tests/test_centroid_warning_suppression.py` that runs the centroid call with `warnings.simplefilter("error")` after `import nmaipy.exporter` — leak → non-zero exit → test fails. Subprocess required because pytest's warning-capture plugin wipes module-level filters during test execution.
- [x] Manual verification of the threading fix: 16 threads × 100 centroid calls, zero leaks
- [x] Full non-live-API suite: 615 passed, 11 skipped
- [x] `black -l 120` clean