### PR TITLE
perf: default zstd compression for write_parquet

### DIFF
--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -348,11 +348,19 @@ def write_parquet(data, path: str, **kwargs) -> None:
     pyarrow's non-fork-safe native S3FileSystem. For local paths, delegates
     directly to the appropriate writer.
 
+    Defaults `compression="zstd"` when no compression is specified. zstd at
+    pyarrow's default level produces ~27 % smaller files than snappy at the
+    same encoding wall time (the structural ~12 s/1.6 M-row encoding cost
+    dominates, the codec CPU is in the noise). The win shows up in S3
+    upload time (less data to push) and ongoing storage cost. Callers that
+    pass `compression=...` explicitly override this.
+
     Args:
         data: pandas DataFrame, geopandas GeoDataFrame, or pyarrow Table
         path: Output file path (local or S3 URI)
         **kwargs: Additional arguments passed to the underlying writer
     """
+    kwargs.setdefault("compression", "zstd")
     if is_s3_path(path):
         with open_file(path, "wb") as f:
             if isinstance(data, pa.Table):


### PR DESCRIPTION
## Summary

`storage.write_parquet` now defaults `compression="zstd"` when callers don't specify one.

## Microbench (1.6 M-row, 25-pack feature chunk)

| Codec | write_s | size MB |
|---|---|---|
| **snappy (was)** | 12.4 | 744 |
| zstd | 13.2 | **545** (-27 %) |
| lz4 | 12.4 | 766 |
| uncompressed | 11.9 | 1315 |

Encoding cost is structural (~12 s for 1.6 M geometries), so codec choice is essentially free on the write side. The 27 % size reduction shows up in:

1. **S3 upload time**. Production `features_write` is 17-30 s for ~165 MB chunks vs local-only encode of ~12 s; the remainder is upload. Smaller file → less to push.
2. **Ongoing S3 storage cost** across the export.

## Compat

- `schema_version="1.0.0"` is **untouched** — verified by reading parquet metadata after the change.
- Existing callers that pass `compression=` explicitly keep their value via `setdefault`.
- pyarrow auto-detects compression on read; no consumer-side changes for any in-repo readers.
- **Out of scope**: `coverage_utils.py` calls `df.to_parquet(...)` directly (legacy path) and bypasses this default — those files remain snappy until that module is migrated to `storage.write_parquet`.

## Test plan

- [x] Full test suite passes: `pytest -m "not live_api"` → 617 passed, 11 skipped.
- [x] New tests in `tests/test_storage.py` pin the behaviour explicitly:
  - `test_default_compression_is_zstd` — asserts default codec is ZSTD by reading parquet metadata after a write.
  - `test_explicit_compression_overrides_default` — asserts `compression="snappy"` round-trips.
- [x] Existing S3-routing mock test loosened: it was over-specified on the exact forwarded kwargs, so the `setdefault` addition broke it. Now verifies the intent (mock file routed through, index forwarded) without pinning the codec.
- [x] End-to-end sanity: 1.6 M-row chunk written via `storage.write_parquet` produces a 545 MB zstd parquet with `geo.version="1.0.0"`; rows + columns round-trip intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)