### PR TITLE
Slow API warmup ramp + fix bypass on resumed runs

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.6"
+__version__ = "5.0.7"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -422,12 +422,13 @@ class BaseExporter(ABC):
                                 )
 
                             chunks_submitted = 0
-                            for i, batch in chunks_to_process:
+                            for position, (i, batch) in enumerate(chunks_to_process):
                                 chunk_id = str(i).zfill(4)
 
-                                # API warmup: gradually ramp up concurrency to allow API autoscaling
-                                # Start with 1 worker, add 1 more every warmup_interval seconds
-                                if API_WARMUP_INTERVAL_SECONDS > 0 and i < self.processes:
+                                # API warmup: ramp up concurrency one worker at a time. Gate on
+                                # position (not the original chunk index `i`) so resumed runs,
+                                # where `i` skips past cached chunks, still warm up.
+                                if API_WARMUP_INTERVAL_SECONDS > 0 and position < self.processes:
                                     while True:
                                         elapsed = time.time() - warmup_start_time
                                         # Max allowed concurrent = 1 + floor(elapsed / interval), capped at processes

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -160,14 +160,17 @@ DUMMY_STATUS_CODE = -1
 # ============================================================================
 # API Warmup Configuration
 # ============================================================================
-# When running with many parallel workers (e.g. 40+), submitting all chunks
-# simultaneously can overwhelm the API before autoscaling kicks in. This
-# setting staggers initial chunk submissions to allow gradual warmup.
+# When running with many parallel workers, submitting all chunks simultaneously
+# can overwhelm the API before its autoscaling has time to respond. This
+# setting staggers initial chunk submissions so the API sees a gradually
+# rising load and can scale backend capacity along with it.
 
-# Seconds to wait between initial chunk submissions during warmup period.
-# Applied to first N chunks where N = number of parallel processes.
-# Set to 0 to disable warmup delays.
-API_WARMUP_INTERVAL_SECONDS = 20.0
+# Seconds to wait between adding each parallel worker during the warmup
+# period. Applied to the first N chunks, where N = number of parallel
+# processes. With the current 40s value, a 12-process run reaches full
+# concurrency at 7:20 and an 8-process run at 4:40 — both well within the
+# API's typical autoscale response window. Set to 0 to disable warmup.
+API_WARMUP_INTERVAL_SECONDS = 40.0
 
 # ============================================================================
 # Post-Processing Parallelism Configuration


### PR DESCRIPTION
## Summary

Two related changes to the parallel-worker warmup behaviour, bumped together as 5.0.7.

### 1. Slow the ramp: 20s → 40s per worker

The previous 20s/worker pace brought all workers online faster than the API's autoscaler could expand backend capacity, producing a sharp burst of HTTP 500 retries ~3–5 min into multi-process runs. 40s gives the API more time per increment.

Time-to-full-concurrency:

| Procs | Before | After |
|---:|---:|---:|
| 4 | 1:00 | 2:00 |
| 8 | 2:20 | 4:40 |
| 12 | 3:40 | 7:20 |
| 23 | 7:20 | 14:40 |
| 46 | 15:00 | 30:00 |

Cost is single-digit-percent of wall-clock on the multi-hour exports this matters for.

### 2. Fix: warmup pacing bypassed when resuming from cache

The warmup gate was checking `i < self.processes`, where `i` is the original chunk index from `enumerate(chunks)`. On a fresh run that matches position-in-loop and pacing engages. On a resume, the filtered to-process list keeps the original `i` values, which are mostly well past `self.processes` — the gate short-circuits and all chunks get submitted at once. The announcement log line still claims a ramp, masking the issue.

Symptoms observed:
- `tqdm` description never shows `Warmup (N/N)` on resumed runs
- Sharp HTTP 500 burst in the first ~5 minutes as the API autoscaler catches up to immediate full load

Fix: enumerate the filtered list and gate on the loop position instead.

## Test plan

- [ ] Fresh run on a multi-process box: confirm `Warmup (N/N)` shows in tqdm during ramp and full concurrency reached at expected time per the table above.
- [ ] Resumed run from cached chunks: confirm `Warmup (N/N)` now also shows (previously absent), and 500 burst is smaller/spread out vs prior behaviour.
- [ ] Single-process run: warmup logic skipped (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)