### PR TITLE
Speed up dense-chunk features_prep + sub-timer breakdown

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.7"
+__version__ = "5.0.8"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2923,6 +2923,8 @@ class NearmapAIExporter(BaseExporter):
         _t_rollup_start = None
         _t_rollup_end = None
         _t_post_merge = None
+        _t_prep_merges = None
+        _t_prep_geom_attr = None
         _t_features_prep = None
         _t_features_write = None
         _t_per_class_start = None
@@ -3344,6 +3346,17 @@ class NearmapAIExporter(BaseExporter):
             # Check for column name collisions between any two dataframes
             final_features_df = aoi_gdf.rename(columns=dict(geometry="aoi_geometry"))
 
+            # Convert aoi_geometry to WKT now — once per AOI, before the merges
+            # duplicate it across every feature row. On dense chunks (e.g. ~17k
+            # features in a single parcel) this avoids tens of thousands of
+            # redundant per-row shapely → WKT calls. Cast to plain DataFrame so
+            # geopandas doesn't try to keep the (now string-typed) column as the
+            # active geometry; the GeoDataFrame is re-established after the merge.
+            if "aoi_geometry" in final_features_df.columns:
+                aoi_wkt = final_features_df["aoi_geometry"].to_wkt()
+                final_features_df = pd.DataFrame(final_features_df)
+                final_features_df["aoi_geometry"] = aoi_wkt
+
             metadata_cols = set(metadata_df.columns)
             features_cols = set(features_gdf.columns)
             aoi_cols = set(final_features_df.columns)
@@ -3362,6 +3375,7 @@ class NearmapAIExporter(BaseExporter):
 
             # Second merge
             merged2 = merged1.merge(final_features_df, on=AOI_ID_COLUMN_NAME)
+            _t_prep_merges = time.monotonic()
 
             # Check what geometry columns we have after the merge
             geom_cols = [col for col in merged2.columns if "geometry" in col.lower()]
@@ -3385,8 +3399,8 @@ class NearmapAIExporter(BaseExporter):
                 logger.error(error_msg)
                 raise ValueError(error_msg)
 
-            if "aoi_geometry" in final_features_df.columns:
-                final_features_df["aoi_geometry"] = final_features_df.aoi_geometry.to_wkt()
+            # aoi_geometry was converted to WKT before the merge (above) — no
+            # second pass needed here.
 
             # Apply flattening to attributes if present
             if "attributes" in final_features_df.columns:
@@ -3411,6 +3425,7 @@ class NearmapAIExporter(BaseExporter):
                 final_features_df["damage"] = final_features_df["damage"].apply(
                     lambda x: json.dumps(x) if isinstance(x, dict) else x
                 )
+            _t_prep_geom_attr = time.monotonic()
             if len(final_features_df) > 0:
                 try:
                     if not self.include_parcel_geometry and "aoi_geometry" in final_features_df.columns:
@@ -3624,7 +3639,9 @@ class NearmapAIExporter(BaseExporter):
                 _tp0 = _t_rollup_start
                 _tp1 = _t_rollup_end if _t_rollup_end is not None else _tp0
                 _tp2 = _t_post_merge if _t_post_merge is not None else _tp1
-                _tp3 = _t_features_prep if _t_features_prep is not None else _tp2
+                _tp2a = _t_prep_merges if _t_prep_merges is not None else _tp2
+                _tp2b = _t_prep_geom_attr if _t_prep_geom_attr is not None else _tp2a
+                _tp3 = _t_features_prep if _t_features_prep is not None else _tp2b
                 _tp4 = _t_features_write if _t_features_write is not None else _tp3
                 _tp5 = _t_per_class_start if _t_per_class_start is not None else _tp4
                 _tp6 = _t_per_class_compute if _t_per_class_compute is not None else _tp5
@@ -3634,6 +3651,9 @@ class NearmapAIExporter(BaseExporter):
                     f"parcel_rollup={_tp1 - _tp0:.1f}s "
                     f"post_rollup_merge={_tp2 - _tp1:.1f}s "
                     f"features_prep={_tp3 - _tp2:.1f}s "
+                    f"(prep_merges={_tp2a - _tp2:.1f}s "
+                    f"prep_geom_attr={_tp2b - _tp2a:.1f}s "
+                    f"prep_obj_json={_tp3 - _tp2b:.1f}s) "
                     f"features_write={_tp4 - _tp3:.1f}s "
                     f"per_class_compute={_tp6 - _tp5:.1f}s "
                     f"per_class_writes={_tp7 - _tp6:.1f}s "


### PR DESCRIPTION
## Summary

Two small changes to `process_chunk` closeout, bumped together as 5.0.8.

### 1. WKT conversion moved before the merge (perf, dense chunks)

`aoi_geometry → WKT` was being called *after* the two merges that duplicate each AOI's geometry across all its feature rows. For chunks with very feature-dense parcels (single AOIs can carry thousands of features), this meant thousands of redundant per-row shapely → WKT calls on the same geometry.

Move the conversion to the unmerged AOI frame so it runs once per AOI; the WKT string then propagates through the merge unchanged. Intermediate DataFrame cast is needed so geopandas doesn't try to keep the now-string-typed column as the active geometry — the active geometry is re-established after the merge from the features-side column.

### 2. Sub-timer breakdown of `features_prep`

`features_prep` was already the highest-variance phase by a wide margin (observed ~18s–520s across one resume's chunks — 29× spread). It was a single field covering ~150 lines of code, which made it hard to tell what was actually slow on a bad chunk.

Split into three sub-fields, appended in parens to the existing `features_prep=` field so back-compat / quick scanning is preserved:

```
features_prep=Xs (prep_merges=Ys prep_geom_attr=Zs prep_obj_json=Ws)
```

- `prep_merges`: errors-parquet write + the two pandas merges
- `prep_geom_attr`: geometry resolution + WKT propagation + attribute flattening + damage JSON serialization
- `prep_obj_json`: empty-geometry filter + wrong-unit drop + object-column json.dumps loop

## Test plan

- [ ] Fresh run: confirm CHUNK_TIMING line still parses (existing fields unchanged, three new in parens), and that `features_prep` ≈ sum of sub-fields.
- [ ] Dense-chunk run (e.g. retro AU urban): compare `prep_geom_attr` on this version vs prior — expect a large drop on chunks where features-per-AOI is high.
- [ ] Spot-check `parcel_features.parquet` output: `aoi_geometry` column should still be present as a WKT string column with the same content as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)