### PR TITLE
Stop the progress counter freezing under burst write load

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.9"
+__version__ = "5.0.10"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -382,6 +382,17 @@ def clean_api_key_from_string(text: str) -> str:
     return text
 
 
+# Per-thread batching cap for `_increment_progress`. Increments accumulate in
+# thread-local state and flush opportunistically (non-blocking) on each call,
+# then unconditionally when the local buffer hits this size. Keeps the shared
+# Manager.Lock() from being a contention bottleneck under burst patterns
+# (gridding fan-outs, prefer3d retries). The drift between batched local count
+# and the shared counter is bounded above by (PROGRESS_BATCH_SIZE - 1) per
+# active thread; `flush_progress()` is called at chunk-end via `cleanup()` so
+# the displayed total catches up before the worker process exits.
+PROGRESS_BATCH_SIZE = 50
+
+
 class BaseApiClient:
     """
     Base class for Nearmap AI API clients.
@@ -391,6 +402,7 @@ class BaseApiClient:
     - Request retry logic
     - Caching infrastructure
     - API key handling
+    - Per-thread batched progress accounting (see PROGRESS_BATCH_SIZE)
     """
 
     def __init__(
@@ -417,6 +429,14 @@ class BaseApiClient:
         self._sessions = []
         self._thread_local = threading.local()
         self._lock = threading.Lock()
+
+        # Progress-counter plumbing. `progress_counters` is overridden by
+        # subclasses that accept it as a constructor arg. The registry holds
+        # one (buffer, lock) tuple per thread that has called
+        # `_increment_progress`; `flush_progress()` drains them.
+        self.progress_counters: Optional[dict] = None
+        self._progress_buffers: List = []
+        self._progress_buffers_registry_lock = threading.Lock()
 
         # API key handling
         if api_key:
@@ -463,6 +483,14 @@ class BaseApiClient:
 
     def cleanup(self):
         """Clean up all sessions and cached adapters"""
+        # Drain any pending per-thread progress buffers first so the displayed
+        # counter catches up before the worker process exits. Diagnostic only —
+        # never let it fail cleanup if the shared Manager.Lock is already gone.
+        try:
+            self.flush_progress()
+        except Exception:
+            pass
+
         if hasattr(self, "_lock") and hasattr(self, "_sessions"):
             with self._lock:
                 for session in self._sessions:
@@ -483,6 +511,78 @@ class BaseApiClient:
         # but other threads' adapters are already closed via self._sessions above)
         if hasattr(self, "_thread_local") and hasattr(self._thread_local, "adapters"):
             self._thread_local.adapters.clear()
+
+    def _increment_progress(self):
+        """Increment progress counter after each request, batched per-thread.
+
+        Hot path. Acquires only the per-thread `buf_lock` (uncontested in
+        steady state) and attempts a non-blocking acquire of the shared
+        Manager.Lock. When the local buffer hits PROGRESS_BATCH_SIZE the
+        flush becomes blocking; `flush_progress()` drains everything at
+        chunk end.
+
+        Thread safety: each worker thread reads/writes only its own buffer
+        (under its own lock). `flush_progress()` acquires the same per-buf
+        locks one at a time. Lock ordering: buf_lock → shared_lock in both
+        increment and forced flush; flush_progress acquires buf_locks then
+        shared_lock separately (no overlap).
+        """
+        if self.progress_counters is None:
+            return
+
+        if not hasattr(self._thread_local, "progress_buffer"):
+            buf = [0]
+            buf_lock = threading.Lock()
+            self._thread_local.progress_buffer = (buf, buf_lock)
+            with self._progress_buffers_registry_lock:
+                self._progress_buffers.append((buf, buf_lock))
+
+        buf, buf_lock = self._thread_local.progress_buffer
+        shared_lock = self.progress_counters["lock"]
+
+        with buf_lock:
+            buf[0] += 1
+            pending = buf[0]
+
+            if pending >= PROGRESS_BATCH_SIZE:
+                # Forced flush — blocking acquire of shared lock.
+                with shared_lock:
+                    self.progress_counters["completed"] += pending
+                buf[0] = 0
+                return
+
+            # Opportunistic flush — non-blocking. If contested, accumulate
+            # and try again on the next increment.
+            if shared_lock.acquire(blocking=False):
+                try:
+                    self.progress_counters["completed"] += pending
+                    buf[0] = 0
+                finally:
+                    shared_lock.release()
+
+    def flush_progress(self):
+        """Drain all per-thread progress buffers into the shared counter.
+
+        Called from `cleanup()` at chunk end so any residue from threads
+        whose last increment was during a contention burst makes it into
+        the displayed total. Safe to call from any thread.
+        """
+        if self.progress_counters is None:
+            return
+        if not hasattr(self, "_progress_buffers"):
+            return  # __del__ paths during partial construction
+        with self._progress_buffers_registry_lock:
+            buffers = list(self._progress_buffers)
+
+        total = 0
+        for buf, buf_lock in buffers:
+            with buf_lock:
+                total += buf[0]
+                buf[0] = 0
+
+        if total > 0:
+            with self.progress_counters["lock"]:
+                self.progress_counters["completed"] += total
 
     @contextlib.contextmanager
     def _session_scope(self, status_forcelist=None):

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -531,21 +531,20 @@ class BaseExporter(ABC):
         Called while waiting to submit more chunks during API warmup.
         Shows current progress even though not all chunks are submitted yet.
         """
-        lock_acquired = progress_counters["lock"].acquire(timeout=0.01)
-        if lock_acquired:
-            try:
-                requests_completed = progress_counters["completed"]
-                requests_total = progress_counters["total"]
-            finally:
-                progress_counters["lock"].release()
+        # Blocking acquire — under burst write pressure the reader may wait
+        # briefly for the lock, which is better than the previous bounded
+        # timeout that consistently lost and left the displayed counter stale.
+        with progress_counters["lock"]:
+            requests_completed = progress_counters["completed"]
+            requests_total = progress_counters["total"]
 
-            if pbar.total != requests_total:
-                pbar.total = requests_total
-            pbar.n = requests_completed
+        if pbar.total != requests_total:
+            pbar.total = requests_total
+        pbar.n = requests_completed
 
-            warmup_str = f"Warmup ({chunks_submitted}/{self.processes})"
-            pbar.set_description(self._format_progress_description(chunks_completed, total_chunks, lat_str=warmup_str))
-            pbar.refresh()
+        warmup_str = f"Warmup ({chunks_submitted}/{self.processes})"
+        pbar.set_description(self._format_progress_description(chunks_completed, total_chunks, lat_str=warmup_str))
+        pbar.refresh()
 
     def _monitor_progress_with_tqdm(
         self,
@@ -609,18 +608,16 @@ class BaseExporter(ABC):
                                     all_latency_stats.append(latency_stats)
                                     latest_latency_stats = latency_stats
 
-                            # Update progress bar immediately
-                            lock_acquired = progress_counters["lock"].acquire(timeout=0.01)
-                            if lock_acquired:
-                                try:
-                                    requests_completed = progress_counters["completed"]
-                                    requests_total = progress_counters["total"]
-                                finally:
-                                    progress_counters["lock"].release()
+                            # Update progress bar immediately. Blocking acquire
+                            # so the displayed counter actually tracks the
+                            # shared state under burst write pressure.
+                            with progress_counters["lock"]:
+                                requests_completed = progress_counters["completed"]
+                                requests_total = progress_counters["total"]
 
-                                if pbar.total != requests_total:
-                                    pbar.total = requests_total
-                                pbar.n = requests_completed
+                            if pbar.total != requests_total:
+                                pbar.total = requests_total
+                            pbar.n = requests_completed
 
                             # Build latency string for progress bar
                             if latest_latency_stats:
@@ -648,36 +645,32 @@ class BaseExporter(ABC):
                         finally:
                             jobs.remove(j)  # Remove from pending jobs list
 
-                # Periodically check shared counters and update progress bar
+                # Periodically check shared counters and update progress bar.
+                # Blocking acquire — under burst writes the monitor may wait a
+                # few seconds for the lock, but that's strictly better than the
+                # previous bounded-timeout that lost the race and left the
+                # displayed counter frozen for minutes.
                 current_time = time.time()
                 if current_time - last_progress_check >= PROGRESS_CHECK_INTERVAL:
-                    # Try to acquire lock with timeout
-                    lock_acquired = progress_counters["lock"].acquire(timeout=0.1)
+                    with progress_counters["lock"]:
+                        requests_completed = progress_counters["completed"]
+                        requests_total = progress_counters["total"]
 
-                    if lock_acquired:
-                        try:
-                            requests_completed = progress_counters["completed"]
-                            requests_total = progress_counters["total"]
-                        finally:
-                            progress_counters["lock"].release()
+                    # Update total if it changed (due to gridding)
+                    if pbar.total != requests_total:
+                        pbar.total = requests_total
 
-                        # Update total if it changed (due to gridding)
-                        if pbar.total != requests_total:
-                            pbar.total = requests_total
+                    # Build latency string for progress bar
+                    if latest_latency_stats:
+                        lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
+                    else:
+                        lat_str = "Lat: ---"
 
-                        # Build latency string for progress bar
-                        if latest_latency_stats:
-                            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
-                        else:
-                            lat_str = "Lat: ---"
-
-                        # Update position and description
-                        pbar.n = requests_completed
-                        pbar.set_description(
-                            self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str)
-                        )
-
-                    # Always refresh, even if we couldn't get the lock
+                    # Update position and description
+                    pbar.n = requests_completed
+                    pbar.set_description(
+                        self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str)
+                    )
                     pbar.refresh()
                     last_progress_check = current_time
 

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -668,9 +668,7 @@ class BaseExporter(ABC):
 
                     # Update position and description
                     pbar.n = requests_completed
-                    pbar.set_description(
-                        self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str)
-                    )
+                    pbar.set_description(self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str))
                     pbar.refresh()
                     last_progress_check = current_time
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -241,44 +241,6 @@ class FeatureApi(GriddedApiClient):
         # Keep grid_size for backward compatibility (GriddedApiClient uses grid_cell_size internally)
         self.grid_size = grid_size
 
-    # Per-thread batching cap. Increments are accumulated in thread-local
-    # state and flushed opportunistically (without blocking) on each call,
-    # plus unconditionally when the local buffer hits this size. This keeps
-    # the shared Manager.Lock from being a contention bottleneck under burst
-    # patterns (gridding fan-outs, prefer3d retries). The reported count can
-    # drift from the true count by up to (batch_size - 1) per active worker
-    # thread until the next flush — that's an accepted approximation for a
-    # diagnostic counter.
-    _PROGRESS_BATCH_SIZE = 50
-
-    def _increment_progress(self):
-        """Increment progress counter after each request, batched per-thread."""
-        if self.progress_counters is None:
-            return
-
-        tl = self._thread_local
-        pending = getattr(tl, "progress_buffer", 0) + 1
-
-        if pending >= self._PROGRESS_BATCH_SIZE:
-            # Buffer is full — flush unconditionally (blocking).
-            with self.progress_counters["lock"]:
-                self.progress_counters["completed"] += pending
-            tl.progress_buffer = 0
-            return
-
-        # Opportunistic flush — if the lock is free right now, dump the buffer
-        # so the displayed counter tracks reality. If it's contended, accumulate
-        # and try again on the next increment.
-        lock = self.progress_counters["lock"]
-        if lock.acquire(blocking=False):
-            try:
-                self.progress_counters["completed"] += pending
-                tl.progress_buffer = 0
-            finally:
-                lock.release()
-        else:
-            tl.progress_buffer = pending
-
     @contextlib.contextmanager
     def _session_scope(self, in_gridding_mode=False):
         """Context manager for session lifecycle — delegates to base class with appropriate retry config.

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -241,13 +241,43 @@ class FeatureApi(GriddedApiClient):
         # Keep grid_size for backward compatibility (GriddedApiClient uses grid_cell_size internally)
         self.grid_size = grid_size
 
+    # Per-thread batching cap. Increments are accumulated in thread-local
+    # state and flushed opportunistically (without blocking) on each call,
+    # plus unconditionally when the local buffer hits this size. This keeps
+    # the shared Manager.Lock from being a contention bottleneck under burst
+    # patterns (gridding fan-outs, prefer3d retries). The reported count can
+    # drift from the true count by up to (batch_size - 1) per active worker
+    # thread until the next flush — that's an accepted approximation for a
+    # diagnostic counter.
+    _PROGRESS_BATCH_SIZE = 50
+
     def _increment_progress(self):
-        """Increment progress counter immediately after each request completes"""
+        """Increment progress counter after each request, batched per-thread."""
         if self.progress_counters is None:
             return
 
-        with self.progress_counters["lock"]:
-            self.progress_counters["completed"] += 1
+        tl = self._thread_local
+        pending = getattr(tl, "progress_buffer", 0) + 1
+
+        if pending >= self._PROGRESS_BATCH_SIZE:
+            # Buffer is full — flush unconditionally (blocking).
+            with self.progress_counters["lock"]:
+                self.progress_counters["completed"] += pending
+            tl.progress_buffer = 0
+            return
+
+        # Opportunistic flush — if the lock is free right now, dump the buffer
+        # so the displayed counter tracks reality. If it's contended, accumulate
+        # and try again on the next increment.
+        lock = self.progress_counters["lock"]
+        if lock.acquire(blocking=False):
+            try:
+                self.progress_counters["completed"] += pending
+                tl.progress_buffer = 0
+            finally:
+                lock.release()
+        else:
+            tl.progress_buffer = pending
 
     @contextlib.contextmanager
     def _session_scope(self, in_gridding_mode=False):

--- a/nmaipy/roof_age_api.py
+++ b/nmaipy/roof_age_api.py
@@ -149,34 +149,6 @@ class RoofAgeApi(BaseApiClient):
             f"since_as_of_date: {since_as_of_date}, bulk_mode: {bulk_mode}"
         )
 
-    # Per-thread batching cap. See FeatureApi._increment_progress for the
-    # rationale; same approach mirrored here.
-    _PROGRESS_BATCH_SIZE = 50
-
-    def _increment_progress(self):
-        """Increment progress counter after each request, batched per-thread."""
-        if self.progress_counters is None:
-            return
-
-        tl = self._thread_local
-        pending = getattr(tl, "progress_buffer", 0) + 1
-
-        if pending >= self._PROGRESS_BATCH_SIZE:
-            with self.progress_counters["lock"]:
-                self.progress_counters["completed"] += pending
-            tl.progress_buffer = 0
-            return
-
-        lock = self.progress_counters["lock"]
-        if lock.acquire(blocking=False):
-            try:
-                self.progress_counters["completed"] += pending
-                tl.progress_buffer = 0
-            finally:
-                lock.release()
-        else:
-            tl.progress_buffer = pending
-
     def _qualifier_subdir(self, until_as_of_date: Optional[str], since_as_of_date: Optional[str]) -> str:
         """Build the cache sub-directory that scopes a request by dataset and cutoffs.
 

--- a/nmaipy/roof_age_api.py
+++ b/nmaipy/roof_age_api.py
@@ -149,13 +149,33 @@ class RoofAgeApi(BaseApiClient):
             f"since_as_of_date: {since_as_of_date}, bulk_mode: {bulk_mode}"
         )
 
+    # Per-thread batching cap. See FeatureApi._increment_progress for the
+    # rationale; same approach mirrored here.
+    _PROGRESS_BATCH_SIZE = 50
+
     def _increment_progress(self):
-        """Increment progress counter immediately after each request completes."""
+        """Increment progress counter after each request, batched per-thread."""
         if self.progress_counters is None:
             return
 
-        with self.progress_counters["lock"]:
-            self.progress_counters["completed"] += 1
+        tl = self._thread_local
+        pending = getattr(tl, "progress_buffer", 0) + 1
+
+        if pending >= self._PROGRESS_BATCH_SIZE:
+            with self.progress_counters["lock"]:
+                self.progress_counters["completed"] += pending
+            tl.progress_buffer = 0
+            return
+
+        lock = self.progress_counters["lock"]
+        if lock.acquire(blocking=False):
+            try:
+                self.progress_counters["completed"] += pending
+                tl.progress_buffer = 0
+            finally:
+                lock.release()
+        else:
+            tl.progress_buffer = pending
 
     def _qualifier_subdir(self, until_as_of_date: Optional[str], since_as_of_date: Optional[str]) -> str:
         """Build the cache sub-directory that scopes a request by dataset and cutoffs.

--- a/tests/test_progress_tracking.py
+++ b/tests/test_progress_tracking.py
@@ -7,8 +7,9 @@ across process boundaries on all platforms (both fork and spawn modes).
 
 import multiprocessing
 import pickle
+import threading
 import time
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 import pytest
 
@@ -169,6 +170,82 @@ def test_progress_counters_picklable():
         assert unpickled["completed"] == 0
     except Exception as e:
         pytest.fail(f"Progress counters should be picklable: {e}")
+
+
+def _writer_blast(progress_counters, num_threads, increments_per_thread):
+    """Worker that runs num_threads × increments_per_thread plain `lock + +=1`
+    increments — the *unbatched* worst case for lock contention. Used by the
+    blocking-reader regression test below.
+    """
+    def thread_loop():
+        for _ in range(increments_per_thread):
+            with progress_counters["lock"]:
+                progress_counters["completed"] += 1
+            time.sleep(0.0005)
+
+    with ThreadPoolExecutor(max_workers=num_threads) as pool:
+        futures = [pool.submit(thread_loop) for _ in range(num_threads)]
+        for f in futures:
+            f.result()
+    return True
+
+
+def test_blocking_reader_not_starved_under_burst_writes():
+    """Regression test for the displayed-counter freeze.
+
+    The previous implementation read the counter via
+    ``progress_counters["lock"].acquire(timeout=0.1)`` and skipped the update
+    when the bounded timeout expired. Under realistic export load (many
+    writer threads across multiple worker processes hammering a shared
+    Manager.Lock()) the bounded acquire consistently lost — the displayed
+    counter froze at the same value for many minutes despite work continuing,
+    catching up only when worker pressure dropped at the end of the run.
+
+    The fix switches the monitor to a blocking acquire (no timeout). It may
+    wait a few seconds during burst windows but always eventually gets a
+    fresh value. This test drives the worst-case unbatched write pattern
+    from multiple processes and asserts the reader (using blocking acquire)
+    observes many intermediate values and the final tally is exact.
+    """
+    manager = multiprocessing.Manager()
+    NUM_WRITER_PROCESSES = 4
+    THREADS_PER_PROCESS = 20
+    INC_PER_THREAD = 50
+    expected = NUM_WRITER_PROCESSES * THREADS_PER_PROCESS * INC_PER_THREAD
+    progress_counters = manager.dict({"total": expected, "completed": 0, "lock": manager.Lock()})
+
+    observed: list = []
+    stop = threading.Event()
+
+    def reader():
+        while not stop.is_set():
+            with progress_counters["lock"]:
+                observed.append(progress_counters["completed"])
+            time.sleep(0.02)
+        with progress_counters["lock"]:
+            observed.append(progress_counters["completed"])
+
+    reader_thread = threading.Thread(target=reader)
+    reader_thread.start()
+    try:
+        with ProcessPoolExecutor(max_workers=NUM_WRITER_PROCESSES) as pool:
+            futures = [
+                pool.submit(_writer_blast, progress_counters, THREADS_PER_PROCESS, INC_PER_THREAD)
+                for _ in range(NUM_WRITER_PROCESSES)
+            ]
+            for f in futures:
+                assert f.result() is True
+    finally:
+        stop.set()
+        reader_thread.join()
+
+    assert progress_counters["completed"] == expected
+    distinct = sorted(set(observed))
+    assert observed == sorted(observed), "counter must be monotonic from reader's view"
+    assert len(distinct) >= 20, (
+        f"reader observed only {len(distinct)} distinct values "
+        f"({distinct[:5]}..{distinct[-5:]}) — blocking-acquire reader appears starved"
+    )
 
 
 def test_progress_counters_with_skipped_work():

--- a/tests/test_progress_tracking.py
+++ b/tests/test_progress_tracking.py
@@ -13,6 +13,27 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 import pytest
 
+from nmaipy.api_common import PROGRESS_BATCH_SIZE, BaseApiClient
+
+
+class _ProgressOnlyClient:
+    """Minimal stub exposing BaseApiClient's progress methods.
+
+    Constructing a full FeatureApi/BaseApiClient requires API key plumbing
+    and pulls in unrelated init. This stub binds only the attributes the
+    progress methods actually read, so we can exercise the real batched
+    code path without standing up the rest of the client.
+    """
+
+    _increment_progress = BaseApiClient._increment_progress
+    flush_progress = BaseApiClient.flush_progress
+
+    def __init__(self, progress_counters):
+        self._thread_local = threading.local()
+        self.progress_counters = progress_counters
+        self._progress_buffers = []
+        self._progress_buffers_registry_lock = threading.Lock()
+
 
 def worker_increment_counter(progress_counters, num_increments=5, simulate_gridding=False):
     """
@@ -177,6 +198,7 @@ def _writer_blast(progress_counters, num_threads, increments_per_thread):
     increments — the *unbatched* worst case for lock contention. Used by the
     blocking-reader regression test below.
     """
+
     def thread_loop():
         for _ in range(increments_per_thread):
             with progress_counters["lock"]:
@@ -246,6 +268,103 @@ def test_blocking_reader_not_starved_under_burst_writes():
         f"reader observed only {len(distinct)} distinct values "
         f"({distinct[:5]}..{distinct[-5:]}) — blocking-acquire reader appears starved"
     )
+
+
+def test_flush_progress_drains_residue_per_thread_buffers():
+    """flush_progress must drain pending per-thread buffers into the shared counter.
+
+    Forces every opportunistic flush in `_increment_progress` to fail by
+    holding the shared lock externally for the duration of the writes. With
+    per-thread increments kept below PROGRESS_BATCH_SIZE, the forced flush
+    inside `_increment_progress` never fires either, so all 50 increments
+    end up trapped in per-thread buffers. The shared counter stays at 0
+    until `flush_progress()` runs.
+
+    This is the exact failure mode that produces "tqdm bar jumps to 100%
+    at the end" on real exports — and the test that protects the fix
+    from regressing.
+    """
+    manager = multiprocessing.Manager()
+    progress_counters = manager.dict({"total": 100, "completed": 0, "lock": manager.Lock()})
+    client = _ProgressOnlyClient(progress_counters)
+
+    shared_lock = progress_counters["lock"]
+    held = threading.Event()
+    release = threading.Event()
+
+    def holder():
+        shared_lock.acquire()
+        held.set()
+        release.wait()
+        shared_lock.release()
+
+    holder_thread = threading.Thread(target=holder)
+    holder_thread.start()
+    held.wait()
+
+    NUM_THREADS = 5
+    # Stay strictly below PROGRESS_BATCH_SIZE so the forced flush inside
+    # _increment_progress never fires (it would block on the held lock).
+    INC_PER_THREAD = PROGRESS_BATCH_SIZE - 1
+    expected = NUM_THREADS * INC_PER_THREAD
+
+    try:
+
+        def worker():
+            for _ in range(INC_PER_THREAD):
+                client._increment_progress()
+
+        threads = [threading.Thread(target=worker) for _ in range(NUM_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        release.set()
+        holder_thread.join()
+
+    # All increments are trapped in per-thread buffers — shared counter is still 0.
+    assert progress_counters["completed"] == 0, (
+        f"expected all {expected} increments to be buffered, but shared counter is " f"{progress_counters['completed']}"
+    )
+
+    client.flush_progress()
+
+    # After flush: every increment is accounted for.
+    assert progress_counters["completed"] == expected
+
+    # And buffers are empty (calling flush again is a no-op).
+    client.flush_progress()
+    assert progress_counters["completed"] == expected
+
+
+def test_increment_progress_eventually_consistent_under_contention():
+    """Under realistic contention, batched writers + per-call opportunistic flush
+    eventually account for every increment after flush_progress.
+
+    Doesn't assert anything about the running drift (timing-dependent) — only
+    that the post-flush total is exact. Validates the batched-writer path
+    end-to-end through the actual BaseApiClient methods.
+    """
+    manager = multiprocessing.Manager()
+    NUM_THREADS = 12
+    INC_PER_THREAD = 200
+    expected = NUM_THREADS * INC_PER_THREAD
+    progress_counters = manager.dict({"total": expected, "completed": 0, "lock": manager.Lock()})
+    client = _ProgressOnlyClient(progress_counters)
+
+    def worker():
+        for _ in range(INC_PER_THREAD):
+            client._increment_progress()
+
+    threads = [threading.Thread(target=worker) for _ in range(NUM_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    client.flush_progress()
+    assert progress_counters["completed"] == expected
 
 
 def test_progress_counters_with_skipped_work():


### PR DESCRIPTION
## Summary

The `API requests` tqdm counter could appear stuck at the same value for many minutes during exports with frequent gridding fan-outs or prefer3d retries — even though chunks were completing fine. It only caught up near the end of the run, by which point it was no longer useful for diagnostics.

Two small changes:

- **`_increment_progress` batches per worker thread.** Each call accumulates in thread-local state and tries an opportunistic non-blocking `lock.acquire(blocking=False)` to flush. When the lock is contended we accumulate and try again next call. A buffer cap of 50 forces a blocking flush when the local count grows that high. This reduces shared `Manager.Lock()` pressure by roughly the batch size under burst load. The reported count is approximate by up to `(batch - 1)` per active thread at any instant — accepted for a diagnostic counter. Mirrored in `feature_api.py` and `roof_age_api.py`.

- **Monitor reads switch to blocking acquire.** The three counter-read sites in `base_exporter.py` (`_update_pbar_during_warmup`, the chunk-completion update inside `_monitor_progress_with_tqdm`, and its periodic check) previously used `acquire(timeout=0.01)` / `acquire(timeout=0.1)` and silently skipped the pbar update on contention. They now use plain `with lock:`. Under burst writes the monitor may wait briefly for the lock — strictly better than displaying a stale value for minutes.

Adds a cross-process regression test (`test_blocking_reader_not_starved_under_burst_writes`) that drives the worst-case unbatched write pattern from multiple worker processes and asserts the blocking reader observes many distinct intermediate values and the final count is exact.

## Why not switch to `multiprocessing.Value`?

That was the first approach (cleaner primitive, no shared `Manager.Lock()` between `completed` and `total`) but requires plumbing Synchronized objects through `ProcessPoolExecutor`'s `initializer`/`initargs` because they reject pickling through `submit()` kwargs — which meant a new module, signature changes in two subclass `process_chunk` methods, and a much larger diff. The counter only needs to be *reasonably reliable* for diagnostics, so a smaller fix that keeps the Manager but uses it more carefully (batching writers + patient reader) is the better trade.

## Test plan

- [x] `pytest tests/test_progress_tracking.py -q` — 7 passed (6 existing + new regression test)
- [x] `pytest tests/ --ignore=tests/test_progress_tracking.py -q` — 668 passed, 12 skipped, no regressions
- [ ] Smoke test against a real export with frequent gridding fan-outs: per-request counter should advance smoothly through every 5s heartbeat instead of freezing for minutes, and the displayed `requests/s` should stabilise near the chunk-derived throughput rather than decaying to near-zero