### PR TITLE
[TRO-4392] Make API warmup interval configurable; bump default to 60s

### DIFF
--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -135,6 +135,11 @@ class BaseExporter(ABC):
                 to API_WARMUP_INTERVAL_SECONDS from constants — override here
                 or via the CLI flag to experiment without rebuilding.
         """
+        if api_warmup_interval_seconds < 0:
+            raise ValueError(
+                f"api_warmup_interval_seconds must be >= 0 (got {api_warmup_interval_seconds}). "
+                f"Use 0 to disable warmup."
+            )
         self.output_dir = str(output_dir)
         self.is_s3_output = storage.is_s3_path(self.output_dir)
         self.processes = processes

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -120,6 +120,7 @@ class BaseExporter(ABC):
         processes: int = 4,
         chunk_size: int = 500,
         log_level: str = "INFO",
+        api_warmup_interval_seconds: float = API_WARMUP_INTERVAL_SECONDS,
     ):
         """
         Initialize BaseExporter.
@@ -129,12 +130,17 @@ class BaseExporter(ABC):
             processes: Number of parallel processes for chunk processing
             chunk_size: Number of AOIs to process in a single chunk
             log_level: Logging level
+            api_warmup_interval_seconds: Seconds between adding each parallel
+                worker during API warmup. Set to 0 to disable warmup. Defaults
+                to API_WARMUP_INTERVAL_SECONDS from constants — override here
+                or via the CLI flag to experiment without rebuilding.
         """
         self.output_dir = str(output_dir)
         self.is_s3_output = storage.is_s3_path(self.output_dir)
         self.processes = processes
         self.chunk_size = chunk_size
         self.log_level = log_level
+        self.api_warmup_interval_seconds = api_warmup_interval_seconds
 
         # Configure logging
         log.configure_logger(self.log_level)
@@ -399,8 +405,8 @@ class BaseExporter(ABC):
                             warmup_start_time = time.time()
 
                             # Log warmup plan once at the start
-                            if API_WARMUP_INTERVAL_SECONDS > 0 and self.processes > 1:
-                                warmup_duration = (self.processes - 1) * API_WARMUP_INTERVAL_SECONDS
+                            if self.api_warmup_interval_seconds > 0 and self.processes > 1:
+                                warmup_duration = (self.processes - 1) * self.api_warmup_interval_seconds
                                 self.logger.info(
                                     f"API warmup: ramping parallel workers from 1 to {self.processes} "
                                     f"over {warmup_duration:.0f}s"
@@ -428,12 +434,12 @@ class BaseExporter(ABC):
                                 # API warmup: ramp up concurrency one worker at a time. Gate on
                                 # position (not the original chunk index `i`) so resumed runs,
                                 # where `i` skips past cached chunks, still warm up.
-                                if API_WARMUP_INTERVAL_SECONDS > 0 and position < self.processes:
+                                if self.api_warmup_interval_seconds > 0 and position < self.processes:
                                     while True:
                                         elapsed = time.time() - warmup_start_time
                                         # Max allowed concurrent = 1 + floor(elapsed / interval), capped at processes
                                         max_concurrent = min(
-                                            1 + int(elapsed // API_WARMUP_INTERVAL_SECONDS),
+                                            1 + int(elapsed // self.api_warmup_interval_seconds),
                                             self.processes,
                                         )
                                         active_jobs = sum(1 for j in jobs if not j.done())

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -167,10 +167,12 @@ DUMMY_STATUS_CODE = -1
 
 # Seconds to wait between adding each parallel worker during the warmup
 # period. Applied to the first N chunks, where N = number of parallel
-# processes. With the current 40s value, a 12-process run reaches full
-# concurrency at 7:20 and an 8-process run at 4:40 — both well within the
-# API's typical autoscale response window. Set to 0 to disable warmup.
-API_WARMUP_INTERVAL_SECONDS = 40.0
+# processes. With the current 60s value, a 12-process run reaches full
+# concurrency at 11:00 and an 8-process run at 7:00. Bumped from 40s
+# after observing sustained HTTP 500s past the 6-minute mark on larger
+# workloads — the API autoscaler needed more headroom before saturation.
+# Set to 0 to disable warmup.
+API_WARMUP_INTERVAL_SECONDS = 60.0
 
 # ============================================================================
 # Post-Processing Parallelism Configuration

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -75,6 +75,7 @@ from nmaipy.constants import (
     ADDRESS_FIELDS,
     AOI_ID_COLUMN_NAME,
     API_CRS,
+    API_WARMUP_INTERVAL_SECONDS,
     AREA_CRS,
     BUILDING_LIFECYCLE_ID,
     BUILDING_NEW_ID,
@@ -2156,6 +2157,18 @@ def parse_arguments():
         default=MAX_RETRIES,
     )
     parser.add_argument(
+        "--api-warmup-interval",
+        help=(
+            f"Seconds between adding each parallel worker during API warmup "
+            f"(default: {API_WARMUP_INTERVAL_SECONDS}). Set to 0 to disable warmup. "
+            f"Increase if the autoscaler still sees burst HTTP 500s; decrease "
+            f"to spend less wall-clock in the ramp."
+        ),
+        type=float,
+        required=False,
+        default=API_WARMUP_INTERVAL_SECONDS,
+    )
+    parser.add_argument(
         "--api-key",
         help="API key to use (overrides API_KEY environment variable)",
         type=str,
@@ -2281,6 +2294,7 @@ class NearmapAIExporter(BaseExporter):
         roof_age_dataset="latest",  # Roof Age dataset alias or resource UUID
         class_level_files=True,  # Export per-feature-class CSV files (attributes only)
         max_retries=MAX_RETRIES,  # Maximum retry attempts for failed API requests
+        api_warmup_interval_seconds=API_WARMUP_INTERVAL_SECONDS,  # Seconds between worker ramp-up; 0 disables
     ):
         # Initialize base exporter first
         super().__init__(
@@ -2288,6 +2302,7 @@ class NearmapAIExporter(BaseExporter):
             processes=processes,
             chunk_size=chunk_size,
             log_level=log_level,
+            api_warmup_interval_seconds=api_warmup_interval_seconds,
         )
 
         # Assign NearmapAIExporter-specific parameters to instance variables
@@ -4332,6 +4347,7 @@ def main():
         class_level_files=not args.no_class_level_files,
         aoi_grid_cell_size=args.aoi_grid_cell_size,
         max_retries=args.max_retries,
+        api_warmup_interval_seconds=args.api_warmup_interval,
     )
     exporter.run()
 

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2160,9 +2160,7 @@ def parse_arguments():
         "--api-warmup-interval",
         help=(
             f"Seconds between adding each parallel worker during API warmup "
-            f"(default: {API_WARMUP_INTERVAL_SECONDS}). Set to 0 to disable warmup. "
-            f"Increase if the autoscaler still sees burst HTTP 500s; decrease "
-            f"to spend less wall-clock in the ramp."
+            f"(default: {API_WARMUP_INTERVAL_SECONDS}). Set to 0 to disable warmup."
         ),
         type=float,
         required=False,

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -43,6 +43,7 @@ from nmaipy.base_exporter import BaseExporter
 from nmaipy.constants import (
     AOI_ID_COLUMN_NAME,
     API_CRS,
+    API_WARMUP_INTERVAL_SECONDS,
     ROOF_AGE_NO_CUTOFF_RESOURCE_IDS,
     ROOF_AGE_PREFIX_COLUMNS,
     SINCE_COL_NAME,
@@ -132,6 +133,15 @@ def parse_arguments():
         help="Number of AOIs to process in a single chunk (default: 500)",
         type=int,
         default=500,
+    )
+    parser.add_argument(
+        "--api-warmup-interval",
+        help=(
+            f"Seconds between adding each parallel worker during API warmup "
+            f"(default: {API_WARMUP_INTERVAL_SECONDS}). Set to 0 to disable warmup."
+        ),
+        type=float,
+        default=API_WARMUP_INTERVAL_SECONDS,
     )
     parser.add_argument(
         "--country",
@@ -226,6 +236,7 @@ class RoofAgeExporter(BaseExporter):
         roof_age_dataset: str = "latest",
         until: str = None,
         since: str = None,
+        api_warmup_interval_seconds: float = API_WARMUP_INTERVAL_SECONDS,
     ):
         """
         Initialize RoofAgeExporter.
@@ -257,6 +268,7 @@ class RoofAgeExporter(BaseExporter):
             processes=processes,
             chunk_size=chunk_size,
             log_level=log_level,
+            api_warmup_interval_seconds=api_warmup_interval_seconds,
         )
 
         # RoofAgeExporter-specific attributes
@@ -703,6 +715,7 @@ def main():
             roof_age_dataset=args.roof_age_dataset,
             until=args.until,
             since=args.since,
+            api_warmup_interval_seconds=args.api_warmup_interval,
         )
         exporter.run()
     except Exception as e:


### PR DESCRIPTION
## Summary

Threads `api_warmup_interval_seconds` through `BaseExporter` → both
subclass constructors (`NearmapAIExporter`, `RoofAgeExporter`) → a new
`--api-warmup-interval` CLI flag on both exporter entry points. The
constant in `constants.py` remains the default; the CLI flag and
constructor parameter override it at run time.

Default bumped from 40s to 60s after sustained HTTP 500s past the
6-minute mark on larger workloads — the autoscaler needed more headroom
before saturation.

## Why

Wanted to experiment with the warmup pace on real exports without
rebuilding nmaipy. The previous setup required editing `constants.py`
and reinstalling. Now any caller can tune it per-run.

## New CLI usage

```bash
python nmaipy/exporter.py --api-warmup-interval 90 …    # 90s per worker
python nmaipy/exporter.py --api-warmup-interval 0  …    # disable warmup
```

Same flag on `python -m nmaipy.roof_age_exporter`.

## Test plan

- [x] `pytest -m "not live_api"` — 621 passed, 11 skipped, no regressions.
- [x] `python nmaipy/exporter.py --help` — flag visible, default shown as 60.0.
- [x] `python -m nmaipy.roof_age_exporter --help` — same.
- [ ] One real export with `--api-warmup-interval 60` to confirm the
      "ramping parallel workers from 1 to N over Xs" log line reports the
      new value and that an override (e.g. 90) propagates to the log.