### PR TITLE
Make rollup chunk-merge resilient to transient S3 reads and stale listings

### DIFF
--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -298,6 +298,11 @@ class BaseExporter(ABC):
         if check_cache:
             # Parallelize cache checking — each check is an S3 HEAD + footer read,
             # so running them concurrently overlaps network latency.
+            # TODO: like the rollup-merge phase in exporter._run_inner, this could
+            # call storage.invalidate_cache(chunk_dir) up front so a stale s3fs
+            # listing doesn't false-negative a present chunk and trigger an
+            # unnecessary reprocess. Wasted work only, not a fail-out — separate
+            # impact from the merge case fixed in PR #191.
             def _check_cache(i_batch):
                 i, batch = i_batch
                 chunk_id = str(i).zfill(4)

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -3975,6 +3975,13 @@ class NearmapAIExporter(BaseExporter):
         errors = []
         self.logger.debug(f"Saving rollup data as {self.tabular_file_format} file to {outpath}")
 
+        # Drop any cached s3fs directory listing for the chunk dir so the
+        # existence sweep below reads S3 fresh. Earlier phases (cache-check,
+        # latency combine) may have cached a listing that predates some chunk
+        # writes; a stale listing would make a present chunk look missing and
+        # abort the merge (sys.exit below).
+        storage.invalidate_cache(self.chunk_path)
+
         # Phase 1: Check which chunk files exist (parallel for S3 HEAD requests)
         def _check_chunk_files(i):
             chunk_filename = f"rollup_{str(i).zfill(4)}.parquet"

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -12,8 +12,10 @@ or ~/.aws/credentials.
 
 import gzip
 import json
+import logging
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -23,6 +25,16 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config as BotoConfig
+
+logger = logging.getLogger(__name__)
+
+# Bounded retry for transient S3 reads. file_exists / validate_parquet are used
+# both to skip already-processed chunks and to gather chunks during the final
+# merge; a transient read or a stale s3fs directory listing must not be mistaken
+# for a missing/corrupt chunk (which aborts the whole export — see
+# AOIExporter rollup consolidation).
+_S3_READ_RETRIES = 3
+_S3_READ_BACKOFF_SECONDS = 0.5
 
 # Tuned transfer config for large files (>1GB).
 # Default boto3 uses 8MB parts / 10 threads — too conservative for multi-GB files.
@@ -117,9 +129,26 @@ def ensure_directory(path: str) -> None:
         Path(path).mkdir(parents=True, exist_ok=True)
 
 
+def invalidate_cache(path: str) -> None:
+    """Drop any cached s3fs directory listing for ``path``.
+
+    s3fs caches directory listings; a stale or partially-populated listing can
+    make an object that exists look absent. Call this before an existence sweep
+    that must be authoritative (e.g. the chunk-merge phase). No-op for local
+    paths.
+    """
+    if is_s3_path(path):
+        _get_s3_filesystem().invalidate_cache(path)
+
+
 def file_exists(path: str) -> bool:
     """
     Check if file exists. Works for both local and S3.
+
+    For S3, a transient read error (throttle, timeout, connection reset) is
+    retried rather than propagated — only a clean negative from s3fs is taken
+    as "absent". This prevents a flaky read from being mistaken for a missing
+    file by callers that treat absence as fatal.
 
     Args:
         path: File path to check
@@ -127,11 +156,22 @@ def file_exists(path: str) -> bool:
     Returns:
         True if the file exists
     """
-    if is_s3_path(path):
-        fs = _get_s3_filesystem()
-        return fs.exists(path)
-    else:
+    if not is_s3_path(path):
         return Path(path).exists()
+
+    fs = _get_s3_filesystem()
+    last_exc: Optional[Exception] = None
+    for attempt in range(_S3_READ_RETRIES + 1):
+        try:
+            return fs.exists(path)
+        except Exception as e:  # transient S3/network error — retry
+            last_exc = e
+            if attempt < _S3_READ_RETRIES:
+                time.sleep(_S3_READ_BACKOFF_SECONDS * (2**attempt))
+                fs.invalidate_cache(path)
+    # Exhausted retries: re-raise rather than silently returning False, so a
+    # genuine, persistent S3 outage surfaces as itself instead of "file missing".
+    raise last_exc
 
 
 def validate_parquet(path: str) -> bool:
@@ -142,18 +182,37 @@ def validate_parquet(path: str) -> bool:
     which reads only the footer.  This is a lightweight integrity check that
     detects truncated or corrupted files without reading column data.
 
+    A genuinely corrupt/truncated file (``pyarrow.ArrowInvalid``) returns
+    ``False`` immediately. A transient read error (S3 throttle/timeout, stale
+    s3fs listing) is retried — it must not be silently reported as corruption,
+    because callers treat an invalid chunk as missing and may abort the export.
+
     Args:
         path: File path (local or S3 URI).
 
     Returns:
         True if the file has a valid parquet footer, False otherwise.
     """
-    try:
-        with open_file(path, "rb") as f:
-            pq.ParquetFile(f)
-        return True
-    except Exception:
-        return False
+    last_exc: Optional[Exception] = None
+    for attempt in range(_S3_READ_RETRIES + 1):
+        try:
+            with open_file(path, "rb") as f:
+                pq.ParquetFile(f)
+            return True
+        except (pa.lib.ArrowInvalid, FileNotFoundError):
+            # Genuinely corrupt/truncated, or genuinely absent — retrying won't help.
+            return False
+        except Exception as e:  # transient read error — retry before giving up
+            last_exc = e
+            if attempt < _S3_READ_RETRIES:
+                time.sleep(_S3_READ_BACKOFF_SECONDS * (2**attempt))
+                if is_s3_path(path):
+                    _get_s3_filesystem().invalidate_cache(path)
+    logger.warning(
+        f"validate_parquet: treating {path} as invalid after "
+        f"{_S3_READ_RETRIES + 1} read attempts (last error: {last_exc})"
+    )
+    return False
 
 
 def glob_files(directory: str, pattern: str) -> List[str]:

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 # merge; a transient read or a stale s3fs directory listing must not be mistaken
 # for a missing/corrupt chunk (which aborts the whole export — see
 # AOIExporter rollup consolidation).
+# Total worst-case wait: ~3.5s per call (0.5 + 1.0 + 2.0 — exponential backoff).
 _S3_READ_RETRIES = 3
 _S3_READ_BACKOFF_SECONDS = 0.5
 
@@ -154,7 +155,12 @@ def file_exists(path: str) -> bool:
         path: File path to check
 
     Returns:
-        True if the file exists
+        True if the file exists, False if it does not.
+
+    Raises:
+        The underlying S3 error if reads still fail after retries. By design —
+        a persistent outage surfaces as itself rather than masquerading as
+        "file missing" to callers that proceed on a False return.
     """
     if not is_s3_path(path):
         return Path(path).exists()
@@ -199,7 +205,7 @@ def validate_parquet(path: str) -> bool:
             with open_file(path, "rb") as f:
                 pq.ParquetFile(f)
             return True
-        except (pa.lib.ArrowInvalid, FileNotFoundError):
+        except (pa.ArrowInvalid, FileNotFoundError):
             # Genuinely corrupt/truncated, or genuinely absent — retrying won't help.
             return False
         except Exception as e:  # transient read error — retry before giving up

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -476,3 +476,110 @@ class TestMoveFile:
             storage.move_file(local, "s3://bucket/dst")
         with pytest.raises(ValueError, match="cross-scheme"):
             storage.move_file("s3://bucket/src", local)
+
+
+# ---------------------------------------------------------------------------
+# Transient-read resilience (file_exists / validate_parquet / invalidate_cache)
+#
+# A transient S3 read or a stale s3fs directory listing must not be mistaken for
+# a missing/corrupt chunk — that previously aborted the whole export during the
+# rollup merge even though the chunk was present and valid on S3.
+# ---------------------------------------------------------------------------
+
+
+class TestFileExistsResilience:
+    @patch("nmaipy.storage.time.sleep", lambda *_: None)
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_retries_transient_then_succeeds(self, mock_get_fs):
+        mock_fs = MagicMock()
+        mock_fs.exists.side_effect = [OSError("connection reset"), OSError("timeout"), True]
+        mock_get_fs.return_value = mock_fs
+
+        assert storage.file_exists("s3://bucket/key.parquet") is True
+        assert mock_fs.exists.call_count == 3
+        assert mock_fs.invalidate_cache.call_count == 2  # once per retry
+
+    @patch("nmaipy.storage.time.sleep", lambda *_: None)
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_persistent_error_raises_not_false(self, mock_get_fs):
+        # A persistent outage must surface as the real error, never be silently
+        # reported as "file absent".
+        mock_fs = MagicMock()
+        mock_fs.exists.side_effect = OSError("s3 down")
+        mock_get_fs.return_value = mock_fs
+
+        with pytest.raises(OSError, match="s3 down"):
+            storage.file_exists("s3://bucket/key.parquet")
+
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_clean_negative_is_not_retried(self, mock_get_fs):
+        # A clean False from s3fs is a genuine "absent" — return immediately.
+        mock_fs = MagicMock()
+        mock_fs.exists.return_value = False
+        mock_get_fs.return_value = mock_fs
+
+        assert storage.file_exists("s3://bucket/missing.parquet") is False
+        assert mock_fs.exists.call_count == 1
+
+
+class TestValidateParquetResilience:
+    @patch("nmaipy.storage.time.sleep", lambda *_: None)
+    def test_transient_read_retries_then_true(self, tmp_path, monkeypatch):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        path = str(tmp_path / "valid.parquet")
+        df.to_parquet(path)
+
+        real_open = storage.open_file
+        calls = {"n": 0}
+
+        def flaky_open(p, mode="r", **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("transient read")
+            return real_open(p, mode, **kw)
+
+        monkeypatch.setattr(storage, "open_file", flaky_open)
+        assert storage.validate_parquet(path) is True
+        assert calls["n"] == 2  # failed once, succeeded on retry
+
+    @patch("nmaipy.storage.time.sleep", lambda *_: None)
+    def test_persistent_transient_returns_false_after_retrying(self, monkeypatch):
+        calls = {"n": 0}
+
+        def always_raise(p, mode="r", **kw):
+            calls["n"] += 1
+            raise OSError("s3 unreadable")
+
+        monkeypatch.setattr(storage, "open_file", always_raise)
+        # Persistent transient error → False, but only after exhausting retries
+        # (not silently on the first read).
+        assert storage.validate_parquet("s3://bucket/x.parquet") is False
+        assert calls["n"] == storage._S3_READ_RETRIES + 1
+
+    def test_corruption_is_not_retried(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "corrupt.parquet")
+        Path(path).write_text("not a parquet")
+        calls = {"n": 0}
+        real_open = storage.open_file
+
+        def counting_open(p, mode="r", **kw):
+            calls["n"] += 1
+            return real_open(p, mode, **kw)
+
+        monkeypatch.setattr(storage, "open_file", counting_open)
+        assert storage.validate_parquet(path) is False
+        assert calls["n"] == 1  # ArrowInvalid → no retry
+
+
+class TestInvalidateCache:
+    def test_local_is_noop(self):
+        with patch("nmaipy.storage._get_s3_filesystem") as mock_get_fs:
+            storage.invalidate_cache("/tmp/some/dir")
+            mock_get_fs.assert_not_called()
+
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_invalidates(self, mock_get_fs):
+        mock_fs = MagicMock()
+        mock_get_fs.return_value = mock_fs
+        storage.invalidate_cache("s3://bucket/dir")
+        mock_fs.invalidate_cache.assert_called_once_with("s3://bucket/dir")


### PR DESCRIPTION
## Problem

A resumed export (chunk files already on S3 from an earlier run) can abort during the rollup merge with:

```
Both error and data files for chunk N missing or corrupted, indicating files
failed to write, are corrupted, or have been deleted.
```

…and `sys.exit(1)` — failing the whole export — even when the chunk's `rollup_N.parquet` and `feature_api_errors_N.parquet` are **present and valid** on S3.

## Root cause

On a resume, the cache-check (`split_into_chunks`) already reprocesses genuinely-missing/corrupt chunks *before* the merge. So a cached chunk that reaches the merge looking missing is a **false negative** from a transient read, not real corruption. Two storage primitives turn that hiccup into a fatal merge:

- `validate_parquet()` wrapped the footer read in `except Exception: return False`, so **any** transient S3 read (throttle/timeout/connection reset) on a chunk footer was reported as corruption.
- `file_exists()` relied on s3fs's cached directory listing; a stale or partially-populated listing makes a present object look absent.

The merge's existence sweep then sees a chunk with neither a valid rollup nor an error file and hard-exits.

## Fix

- **`validate_parquet()`**: return `False` immediately only for genuine corruption (`pyarrow.ArrowInvalid`) or genuine absence (`FileNotFoundError`); retry other (transient) read errors with bounded backoff before giving up.
- **`file_exists()`**: retry transient S3 errors (a clean `False` from s3fs is still "absent"). On a *persistent* outage, raise the real error rather than silently returning `False` — a persistent failure should surface as itself, not be misread as "file missing".
- **`storage.invalidate_cache()`** (new): drop the cached s3fs listing for a path. The rollup merge calls it before its existence sweep so it reads S3 fresh instead of from a stale listing.

This is the minimal, targeted fix for the observed false-negative. (A genuinely failed write of a *just-processed* chunk — a separate, rarer gap, since `run_parallel` doesn't verify writes — still hard-exits and is recovered by a re-run's cache-check; deferred as a follow-up.)

## Tests

`tests/test_storage.py` adds coverage for: transient-retry-then-success, persistent failure (retries then gives up / re-raises), genuine corruption (no retry), clean negative (no retry), and `invalidate_cache`. Full storage suite: 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)