### PR TITLE
Reactively grid AOIs when API marks an include as skipped

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.13"
+__version__ = "5.0.14"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1997,6 +1997,11 @@ def parse_arguments():
         default=GRID_SIZE_DEGREES,
     )
     parser.add_argument(
+        "--no-regrid-on-skip",
+        help="Disable reactive gridding when the Feature API marks any include as skipped due to its per-parcel CPU cutoff. Default is enabled — when a parcel exceeds ~100 buildings and the API returns {'skipped': true} for scores or defensible space, the AOI is automatically re-issued as a gridded query so the sub-AOIs appear as mini-parcels and return populated data. Pass this flag to keep the legacy behaviour where the skipped includes stay null with the *_skipped flag set.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--processes",
         help="Number of processes",
         type=int,
@@ -2261,6 +2266,7 @@ class NearmapAIExporter(BaseExporter):
         aoi_grid_min_pct=100,
         aoi_grid_inexact=False,
         aoi_grid_cell_size=GRID_SIZE_DEGREES,  # Grid cell size in degrees for subdividing large AOIs
+        regrid_on_skip=True,  # Reactive gridding when API marks any include as skipped
         processes=PROCESSES,
         threads=THREADS,
         chunk_size=CHUNK_SIZE,
@@ -2312,6 +2318,7 @@ class NearmapAIExporter(BaseExporter):
         self.aoi_grid_min_pct = aoi_grid_min_pct
         self.aoi_grid_inexact = aoi_grid_inexact
         self.aoi_grid_cell_size = aoi_grid_cell_size
+        self.regrid_on_skip = regrid_on_skip
         # Note: processes, chunk_size, log_level handled by BaseExporter
         self.threads = threads
         self.include_parcel_geometry = include_parcel_geometry
@@ -2382,6 +2389,7 @@ class NearmapAIExporter(BaseExporter):
             "aoi_grid_min_pct": aoi_grid_min_pct,
             "aoi_grid_inexact": aoi_grid_inexact,
             "aoi_grid_cell_size": aoi_grid_cell_size,
+            "regrid_on_skip": regrid_on_skip,
             "processes": processes,
             "threads": threads,
             "chunk_size": chunk_size,
@@ -2997,6 +3005,7 @@ class NearmapAIExporter(BaseExporter):
                 parcel_mode=self.parcel_mode,
                 progress_counters=progress_counters,
                 grid_size=self.aoi_grid_cell_size,
+                regrid_on_skip=self.regrid_on_skip,
                 maxretry=self.max_retries,
                 rapid=self.rapid,
                 order=self.order,
@@ -4351,6 +4360,7 @@ def main():
         roof_age_dataset=args.roof_age_dataset,
         class_level_files=not args.no_class_level_files,
         aoi_grid_cell_size=args.aoi_grid_cell_size,
+        regrid_on_skip=not args.no_regrid_on_skip,
         max_retries=args.max_retries,
         api_warmup_interval_seconds=args.api_warmup_interval,
     )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1998,7 +1998,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--no-regrid-on-skip",
-        help="Disable reactive gridding when the Feature API marks any include as skipped due to its per-parcel CPU cutoff. Default is enabled — when a parcel exceeds ~100 buildings and the API returns {'skipped': true} for scores or defensible space, the AOI is automatically re-issued as a gridded query so the sub-AOIs appear as mini-parcels and return populated data. Pass this flag to keep the legacy behaviour where the skipped includes stay null with the *_skipped flag set.",
+        help="Disable reactive gridding when the API marks any include as skipped. Default is to regrid so the AOI is re-queried as sub-AOIs and populated scores come back.",
         action="store_true",
     )
     parser.add_argument(
@@ -2266,7 +2266,7 @@ class NearmapAIExporter(BaseExporter):
         aoi_grid_min_pct=100,
         aoi_grid_inexact=False,
         aoi_grid_cell_size=GRID_SIZE_DEGREES,  # Grid cell size in degrees for subdividing large AOIs
-        regrid_on_skip=True,  # Reactive gridding when API marks any include as skipped
+        regrid_on_skip=True,
         processes=PROCESSES,
         threads=THREADS,
         chunk_size=CHUNK_SIZE,

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -104,6 +104,37 @@ def is_class_returnable_at_version(
     return False
 
 
+def _response_has_include_skips(features_gdf, metadata) -> Tuple[bool, List[str]]:
+    """Detect whether the API's per-parcel CPU cutoff fired on any include.
+
+    The Feature API returns ``{"skipped": true}`` for include sections (RSI,
+    hurricane / wind / hail / wildfire / wind-hail risk scores, defensible
+    space) when a parcel exceeds the backend per-parcel CPU budget — currently
+    triggered around ~100 buildings on the parcel. nmaipy surfaces these as
+    boolean ``*_skipped`` columns on the per-roof rows, plus the parcel-mode
+    aggregate-DS skip on ``metadata["aggregate"]["defensibleSpace"]["skipped"]``.
+
+    Returns (any_skipped, list_of_skipped_includes) so the caller can log which
+    includes triggered the reactive grid.
+    """
+    skipped: List[str] = []
+    if features_gdf is not None and len(features_gdf) > 0:
+        for col in features_gdf.columns:
+            if not col.endswith("_skipped"):
+                continue
+            series = features_gdf[col]
+            # Bool-coerce-then-OR: missing/None entries become False, then any() detects a True.
+            if (series == True).any():  # noqa: E712 - explicit equality avoids dtype coercion warning
+                skipped.append(col)
+    if isinstance(metadata, dict):
+        agg = metadata.get("aggregate")
+        if isinstance(agg, dict):
+            ds = agg.get("defensibleSpace")
+            if isinstance(ds, dict) and ds.get("skipped") is True:
+                skipped.append("aggregate_defensible_space")
+    return (len(skipped) > 0, skipped)
+
+
 class FeatureApi(GriddedApiClient):
     """
     Client for the Nearmap AI Feature API.
@@ -158,6 +189,7 @@ class FeatureApi(GriddedApiClient):
         exclude_tiles_with_occlusion: Optional[bool] = False,
         progress_counters: Optional[dict] = None,
         grid_size: Optional[float] = GRID_SIZE_DEGREES,
+        regrid_on_skip: Optional[bool] = True,
     ):
         """
         Initialize FeatureApi class
@@ -188,6 +220,13 @@ class FeatureApi(GriddedApiClient):
             exclude_tiles_with_occlusion: When True, ignores survey resources with occluded tiles
             progress_counters: Optional dict with 'total' and 'completed' counters for tracking progress across processes
             grid_size: Grid cell size in degrees for subdividing large AOIs (default ~200m)
+            regrid_on_skip: When True (default), if any include in the response is marked
+                ``{"skipped": true}`` by the API's per-parcel CPU cutoff (currently triggered
+                around ~100 buildings on a parcel), reactively re-issue the AOI as a gridded
+                query. Sub-AOIs appear to the API as mini-parcels that fall under the cutoff
+                and return populated scores / per-roof DS. Aggregate DS columns
+                (parcel-mode-only) stay null in the gridded path; we flag them as skipped to
+                preserve the existing contract.
         """
         # Call parent class initialization
         # GriddedApiClient handles: thread-safety (_sessions, _thread_local, _lock),
@@ -240,6 +279,9 @@ class FeatureApi(GriddedApiClient):
 
         # Keep grid_size for backward compatibility (GriddedApiClient uses grid_cell_size internally)
         self.grid_size = grid_size
+
+        # When True, reactive gridding fires on per-parcel include skips (RSI, peril scores, DS).
+        self.regrid_on_skip = regrid_on_skip
 
     @contextlib.contextmanager
     def _session_scope(self, in_gridding_mode=False):
@@ -1229,6 +1271,47 @@ class FeatureApi(GriddedApiClient):
                 disable_parcel_mode=disable_parcel_mode,
             )
             features_gdf, metadata = self.payload_gdf(payload, aoi_id, effective_parcel_mode)
+
+            # Reactive gridding on per-parcel include skips. The Feature API returns
+            # {"skipped": true} for includes (RSI, peril scores, defensible space) when
+            # the parcel exceeds the backend's per-parcel CPU budget. Gridding disables
+            # parcel mode in sub-queries, so the API sees mini-parcels under the cutoff
+            # and returns populated scores. See _response_has_include_skips for detection.
+            if (
+                self.regrid_on_skip
+                and not in_gridding_mode
+                and not fail_hard_regrid
+                and geometry is not None
+            ):
+                any_skipped, skipped_includes = _response_has_include_skips(features_gdf, metadata)
+                if any_skipped:
+                    logger.info(
+                        f"AOI (id {aoi_id}): include skip detected ({', '.join(skipped_includes)}), "
+                        f"triggering reactive gridding"
+                    )
+                    features_gdf, metadata, error, grid_errors_df = self._attempt_gridding(
+                        geometry=geometry,
+                        region=region,
+                        packs=packs,
+                        classes=classes,
+                        include=include,
+                        aoi_id=aoi_id,
+                        since=since,
+                        until=until,
+                        survey_resource_id=survey_resource_id,
+                        aoi_grid_inexact=self.aoi_grid_inexact,
+                        reason="reactive - include skip",
+                    )
+                    # Aggregate DS is parcel-mode-only — the gridded path disables parcel
+                    # mode, so the API doesn't return aggregate values. Synthesize the
+                    # skipped flag so parcels.parcel_rollup populates
+                    # aggregate_defensible_space_skipped=True via its existing code path.
+                    if (
+                        metadata is not None
+                        and include is not None
+                        and "defensibleSpace" in include
+                    ):
+                        metadata.setdefault("aggregate", {})["defensibleSpace"] = {"skipped": True}
         except AIFeatureAPIRequestSizeError as e:
             features_gdf, metadata, error = None, None, None
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1015,10 +1015,13 @@ class FeatureApi(GriddedApiClient):
         survey_resource_id: Optional[str] = None,
         aoi_grid_inexact: Optional[bool] = None,
         reason: Optional[str] = None,
-    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[dict], Optional[dict]]:
+    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[dict], Optional[dict], Optional[pd.DataFrame]]:
         """
         Helper method to attempt gridding large AOIs and handle the common pattern of gridding,
         combining results, and creating metadata.
+
+        Returns a 4-tuple of (features_gdf, metadata, error, grid_errors_df), where the last
+        is a DataFrame of per-grid-cell failures (may be None on a complete grid failure).
 
         This method is called when an AOI is too large for a single API request, either
         proactively (when area > MAX_AOI_AREA_SQM_BEFORE_GRIDDING) or reactively
@@ -1249,34 +1252,37 @@ class FeatureApi(GriddedApiClient):
             )
             features_gdf, metadata = self.payload_gdf(payload, aoi_id, effective_parcel_mode)
 
-            # Discard the just-parsed response and grid when any include hit the
-            # per-parcel CPU cutoff — gridded sub-queries disable parcel mode and
-            # come back populated.
-            if (
-                self.regrid_on_skip
-                and not in_gridding_mode
-                and not fail_hard_regrid
-                and geometry is not None
-            ):
+            # Detect per-parcel CPU-cutoff skips. If reactive gridding is enabled,
+            # discard the just-parsed response and re-issue as a gridded query so
+            # sub-AOIs come back as mini-parcels with populated scores. Otherwise,
+            # surface the skip at INFO so the operator who opted out of regridding
+            # still sees what the API dropped.
+            if not in_gridding_mode and geometry is not None:
                 any_skipped, skipped_includes = _response_has_include_skips(features_gdf)
                 if any_skipped:
-                    logger.info(
-                        f"AOI (id {aoi_id}): include skip detected ({', '.join(skipped_includes)}), "
-                        f"triggering reactive gridding"
-                    )
-                    features_gdf, metadata, error, grid_errors_df = self._attempt_gridding(
-                        geometry=geometry,
-                        region=region,
-                        packs=packs,
-                        classes=classes,
-                        include=include,
-                        aoi_id=aoi_id,
-                        since=since,
-                        until=until,
-                        survey_resource_id=survey_resource_id,
-                        aoi_grid_inexact=self.aoi_grid_inexact,
-                        reason="reactive - include skip",
-                    )
+                    if self.regrid_on_skip and not fail_hard_regrid:
+                        logger.debug(
+                            f"AOI (id {aoi_id}): include skip detected ({', '.join(skipped_includes)}), "
+                            f"triggering reactive gridding"
+                        )
+                        features_gdf, metadata, error, grid_errors_df = self._attempt_gridding(
+                            geometry=geometry,
+                            region=region,
+                            packs=packs,
+                            classes=classes,
+                            include=include,
+                            aoi_id=aoi_id,
+                            since=since,
+                            until=until,
+                            survey_resource_id=survey_resource_id,
+                            aoi_grid_inexact=self.aoi_grid_inexact,
+                            reason="reactive - include skip",
+                        )
+                    else:
+                        logger.info(
+                            f"AOI (id {aoi_id}): include skip detected ({', '.join(skipped_includes)}), "
+                            f"reactive gridding disabled — scores will remain null"
+                        )
         except AIFeatureAPIRequestSizeError as e:
             features_gdf, metadata, error = None, None, None
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -104,34 +104,15 @@ def is_class_returnable_at_version(
     return False
 
 
-def _response_has_include_skips(features_gdf, metadata) -> Tuple[bool, List[str]]:
-    """Detect whether the API's per-parcel CPU cutoff fired on any include.
-
-    The Feature API returns ``{"skipped": true}`` for include sections (RSI,
-    hurricane / wind / hail / wildfire / wind-hail risk scores, defensible
-    space) when a parcel exceeds the backend per-parcel CPU budget — currently
-    triggered around ~100 buildings on the parcel. nmaipy surfaces these as
-    boolean ``*_skipped`` columns on the per-roof rows, plus the parcel-mode
-    aggregate-DS skip on ``metadata["aggregate"]["defensibleSpace"]["skipped"]``.
-
-    Returns (any_skipped, list_of_skipped_includes) so the caller can log which
-    includes triggered the reactive grid.
-    """
+def _response_has_include_skips(features_gdf) -> Tuple[bool, List[str]]:
+    """Return (any_skipped, names) for any per-roof ``*_skipped`` columns set True."""
     skipped: List[str] = []
     if features_gdf is not None and len(features_gdf) > 0:
         for col in features_gdf.columns:
             if not col.endswith("_skipped"):
                 continue
-            series = features_gdf[col]
-            # Bool-coerce-then-OR: missing/None entries become False, then any() detects a True.
-            if (series == True).any():  # noqa: E712 - explicit equality avoids dtype coercion warning
+            if (features_gdf[col] == True).any():  # noqa: E712 - avoid pandas dtype coercion warning
                 skipped.append(col)
-    if isinstance(metadata, dict):
-        agg = metadata.get("aggregate")
-        if isinstance(agg, dict):
-            ds = agg.get("defensibleSpace")
-            if isinstance(ds, dict) and ds.get("skipped") is True:
-                skipped.append("aggregate_defensible_space")
     return (len(skipped) > 0, skipped)
 
 
@@ -220,13 +201,10 @@ class FeatureApi(GriddedApiClient):
             exclude_tiles_with_occlusion: When True, ignores survey resources with occluded tiles
             progress_counters: Optional dict with 'total' and 'completed' counters for tracking progress across processes
             grid_size: Grid cell size in degrees for subdividing large AOIs (default ~200m)
-            regrid_on_skip: When True (default), if any include in the response is marked
-                ``{"skipped": true}`` by the API's per-parcel CPU cutoff (currently triggered
-                around ~100 buildings on a parcel), reactively re-issue the AOI as a gridded
-                query. Sub-AOIs appear to the API as mini-parcels that fall under the cutoff
-                and return populated scores / per-roof DS. Aggregate DS columns
-                (parcel-mode-only) stay null in the gridded path; we flag them as skipped to
-                preserve the existing contract.
+            regrid_on_skip: When True (default), reactively grid the AOI if any include
+                comes back ``{"skipped": true}`` from the API's per-parcel CPU cutoff.
+                Gridded sub-queries disable parcel mode, so the API sees mini-parcels and
+                returns populated scores. Aggregate DS is parcel-mode-only and stays null.
         """
         # Call parent class initialization
         # GriddedApiClient handles: thread-safety (_sessions, _thread_local, _lock),
@@ -280,7 +258,6 @@ class FeatureApi(GriddedApiClient):
         # Keep grid_size for backward compatibility (GriddedApiClient uses grid_cell_size internally)
         self.grid_size = grid_size
 
-        # When True, reactive gridding fires on per-parcel include skips (RSI, peril scores, DS).
         self.regrid_on_skip = regrid_on_skip
 
     @contextlib.contextmanager
@@ -1272,18 +1249,16 @@ class FeatureApi(GriddedApiClient):
             )
             features_gdf, metadata = self.payload_gdf(payload, aoi_id, effective_parcel_mode)
 
-            # Reactive gridding on per-parcel include skips. The Feature API returns
-            # {"skipped": true} for includes (RSI, peril scores, defensible space) when
-            # the parcel exceeds the backend's per-parcel CPU budget. Gridding disables
-            # parcel mode in sub-queries, so the API sees mini-parcels under the cutoff
-            # and returns populated scores. See _response_has_include_skips for detection.
+            # Discard the just-parsed response and grid when any include hit the
+            # per-parcel CPU cutoff — gridded sub-queries disable parcel mode and
+            # come back populated.
             if (
                 self.regrid_on_skip
                 and not in_gridding_mode
                 and not fail_hard_regrid
                 and geometry is not None
             ):
-                any_skipped, skipped_includes = _response_has_include_skips(features_gdf, metadata)
+                any_skipped, skipped_includes = _response_has_include_skips(features_gdf)
                 if any_skipped:
                     logger.info(
                         f"AOI (id {aoi_id}): include skip detected ({', '.join(skipped_includes)}), "
@@ -1302,16 +1277,6 @@ class FeatureApi(GriddedApiClient):
                         aoi_grid_inexact=self.aoi_grid_inexact,
                         reason="reactive - include skip",
                     )
-                    # Aggregate DS is parcel-mode-only — the gridded path disables parcel
-                    # mode, so the API doesn't return aggregate values. Synthesize the
-                    # skipped flag so parcels.parcel_rollup populates
-                    # aggregate_defensible_space_skipped=True via its existing code path.
-                    if (
-                        metadata is not None
-                        and include is not None
-                        and "defensibleSpace" in include
-                    ):
-                        metadata.setdefault("aggregate", {})["defensibleSpace"] = {"skipped": True}
         except AIFeatureAPIRequestSizeError as e:
             features_gdf, metadata, error = None, None, None
 

--- a/tests/test_regrid_on_skip.py
+++ b/tests/test_regrid_on_skip.py
@@ -71,6 +71,40 @@ class TestResponseHasIncludeSkips:
         assert any_skipped is False
 
 
+def _install_stubs(api, monkeypatch, *, skipped: bool):
+    """Stub `get_features`, `payload_gdf` and `_attempt_gridding` on `api`.
+
+    The stubbed payload reports `roof_spotlight_index_skipped = skipped`.
+    Returns a dict that the test can inspect; `dict["count"]` is the number
+    of times `_attempt_gridding` was invoked.
+    """
+    gridding_called = {"count": 0}
+
+    def stub_get_features(*args, **kwargs):
+        return {}
+
+    def stub_payload_gdf(payload, aoi_id, parcel_mode):
+        features_gdf = gpd.GeoDataFrame(
+            {"roof_spotlight_index_skipped": [skipped], "geometry": [SMALL_AOI]},
+            geometry="geometry",
+        )
+        return features_gdf, {"aoi_id": aoi_id}
+
+    def stub_attempt_gridding(*args, **kwargs):
+        gridding_called["count"] += 1
+        return (
+            gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
+            {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"},
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(api, "get_features", stub_get_features)
+    monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(stub_payload_gdf))
+    monkeypatch.setattr(api, "_attempt_gridding", stub_attempt_gridding)
+    return gridding_called
+
+
 class TestRegridOnSkip:
     """End-to-end behaviour of FeatureApi.get_features_gdf when skips arrive."""
 
@@ -83,109 +117,28 @@ class TestRegridOnSkip:
 
     def test_skip_triggers_gridding(self, tmp_path, monkeypatch):
         api = self._build_api(tmp_path, regrid_on_skip=True)
-
-        gridding_called = {"count": 0}
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            gridding_called["count"] += 1
-            return (
-                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
-                {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"},
-                None,
-                None,
-            )
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+        gridding_called = _install_stubs(api, monkeypatch, skipped=True)
 
         api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="skip-aoi")
         assert gridding_called["count"] == 1
 
     def test_skip_does_not_trigger_when_flag_off(self, tmp_path, monkeypatch):
         api = self._build_api(tmp_path, regrid_on_skip=False)
-
-        gridding_called = {"count": 0}
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            gridding_called["count"] += 1
-            return (None, None, None, None)
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+        gridding_called = _install_stubs(api, monkeypatch, skipped=True)
 
         api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="skip-aoi")
         assert gridding_called["count"] == 0
 
     def test_no_skips_does_not_trigger_gridding(self, tmp_path, monkeypatch):
         api = self._build_api(tmp_path, regrid_on_skip=True)
-
-        gridding_called = {"count": 0}
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"roof_spotlight_index_skipped": [False], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            gridding_called["count"] += 1
-            return (None, None, None, None)
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+        gridding_called = _install_stubs(api, monkeypatch, skipped=False)
 
         api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="ok-aoi")
         assert gridding_called["count"] == 0
 
     def test_gridding_mode_suppresses_skip_trigger(self, tmp_path, monkeypatch):
         api = self._build_api(tmp_path, regrid_on_skip=True)
-
-        gridding_called = {"count": 0}
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            gridding_called["count"] += 1
-            return (None, None, None, None)
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+        gridding_called = _install_stubs(api, monkeypatch, skipped=True)
 
         api.get_features_gdf(
             geometry=SMALL_AOI,

--- a/tests/test_regrid_on_skip.py
+++ b/tests/test_regrid_on_skip.py
@@ -1,0 +1,296 @@
+"""Tests for reactive gridding when the Feature API marks any include as skipped.
+
+The Feature API returns ``{"skipped": true}`` for include sections (RSI, peril
+scores, defensible space) when a parcel exceeds the per-parcel CPU budget —
+currently ~100 buildings. ``FeatureApi.regrid_on_skip`` (default True) detects
+this and reactively re-issues the AOI as a gridded query.
+"""
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Polygon
+
+from nmaipy.feature_api import FeatureApi, _response_has_include_skips
+
+
+SMALL_AOI = Polygon(
+    [
+        [144.9, -37.8],
+        [144.9 + 0.0045, -37.8],
+        [144.9 + 0.0045, -37.8 + 0.0045],
+        [144.9, -37.8 + 0.0045],
+        [144.9, -37.8],
+    ]
+)
+
+
+def _empty_features_gdf():
+    return gpd.GeoDataFrame({"geometry": []}, geometry="geometry")
+
+
+def _features_gdf_with_skip(col):
+    return gpd.GeoDataFrame({col: [True], "geometry": [SMALL_AOI]}, geometry="geometry")
+
+
+class TestResponseHasIncludeSkips:
+    def test_no_skips_returns_false(self):
+        features_gdf = gpd.GeoDataFrame(
+            {"roof_spotlight_index_skipped": [False, False], "geometry": [SMALL_AOI, SMALL_AOI]},
+            geometry="geometry",
+        )
+        metadata = {"aggregate": None}
+        any_skipped, skipped = _response_has_include_skips(features_gdf, metadata)
+        assert any_skipped is False
+        assert skipped == []
+
+    def test_per_roof_skip_detected(self):
+        features_gdf = _features_gdf_with_skip("hurricane_score_skipped")
+        any_skipped, skipped = _response_has_include_skips(features_gdf, None)
+        assert any_skipped is True
+        assert skipped == ["hurricane_score_skipped"]
+
+    def test_aggregate_ds_skip_detected(self):
+        metadata = {"aggregate": {"defensibleSpace": {"skipped": True}}}
+        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), metadata)
+        assert any_skipped is True
+        assert skipped == ["aggregate_defensible_space"]
+
+    def test_aggregate_ds_not_skipped(self):
+        metadata = {"aggregate": {"defensibleSpace": {"skipped": False, "zones": []}}}
+        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), metadata)
+        assert any_skipped is False
+
+    def test_missing_aggregate_returns_false(self):
+        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), {})
+        assert any_skipped is False
+
+    def test_none_inputs_return_false(self):
+        any_skipped, skipped = _response_has_include_skips(None, None)
+        assert any_skipped is False
+
+    def test_multiple_skip_columns_all_reported(self):
+        features_gdf = gpd.GeoDataFrame(
+            {
+                "roof_spotlight_index_skipped": [True],
+                "defensible_space_skipped": [True],
+                "wind_score_skipped": [False],
+                "geometry": [SMALL_AOI],
+            },
+            geometry="geometry",
+        )
+        any_skipped, skipped = _response_has_include_skips(features_gdf, None)
+        assert any_skipped is True
+        assert set(skipped) == {"roof_spotlight_index_skipped", "defensible_space_skipped"}
+
+    def test_nan_skip_treated_as_false(self):
+        features_gdf = gpd.GeoDataFrame(
+            {"roof_spotlight_index_skipped": [None, None], "geometry": [SMALL_AOI, SMALL_AOI]},
+            geometry="geometry",
+        )
+        any_skipped, _ = _response_has_include_skips(features_gdf, None)
+        assert any_skipped is False
+
+
+class TestRegridOnSkip:
+    """End-to-end behaviour of FeatureApi.get_features_gdf when skips arrive."""
+
+    def _build_api(self, tmp_path, regrid_on_skip=True):
+        return FeatureApi(api_key="test-key", cache_dir=tmp_path, regrid_on_skip=regrid_on_skip)
+
+    def test_default_regrid_on_skip_is_true(self, tmp_path):
+        api = FeatureApi(api_key="test-key", cache_dir=tmp_path)
+        assert api.regrid_on_skip is True
+
+    def test_skip_triggers_gridding(self, tmp_path, monkeypatch):
+        api = self._build_api(tmp_path, regrid_on_skip=True)
+
+        gridding_called = {"count": 0}
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            metadata = {"aoi_id": aoi_id, "aggregate": None}
+            return features_gdf, metadata
+
+        def mock_attempt_gridding(*args, **kwargs):
+            gridding_called["count"] += 1
+            return (
+                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
+                {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"},
+                None,
+                None,
+            )
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="skip-aoi")
+        assert gridding_called["count"] == 1
+
+    def test_skip_does_not_trigger_when_flag_off(self, tmp_path, monkeypatch):
+        api = self._build_api(tmp_path, regrid_on_skip=False)
+
+        gridding_called = {"count": 0}
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+
+        def mock_attempt_gridding(*args, **kwargs):
+            gridding_called["count"] += 1
+            return (None, None, None, None)
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="skip-aoi")
+        assert gridding_called["count"] == 0
+
+    def test_no_skips_does_not_trigger_gridding(self, tmp_path, monkeypatch):
+        api = self._build_api(tmp_path, regrid_on_skip=True)
+
+        gridding_called = {"count": 0}
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"roof_spotlight_index_skipped": [False], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+
+        def mock_attempt_gridding(*args, **kwargs):
+            gridding_called["count"] += 1
+            return (None, None, None, None)
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        api.get_features_gdf(geometry=SMALL_AOI, region="au", aoi_id="ok-aoi")
+        assert gridding_called["count"] == 0
+
+    def test_gridding_mode_suppresses_skip_trigger(self, tmp_path, monkeypatch):
+        api = self._build_api(tmp_path, regrid_on_skip=True)
+
+        gridding_called = {"count": 0}
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+
+        def mock_attempt_gridding(*args, **kwargs):
+            gridding_called["count"] += 1
+            return (None, None, None, None)
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        api.get_features_gdf(
+            geometry=SMALL_AOI,
+            region="au",
+            aoi_id="sub-aoi",
+            in_gridding_mode=True,
+        )
+        assert gridding_called["count"] == 0
+
+    def test_aggregate_ds_skip_synthesized_after_grid(self, tmp_path, monkeypatch):
+        """When DS was requested and skip triggered gridding, synthesize aggregate skip flag.
+
+        Aggregate DS is parcel-mode-only and the gridded path disables parcel mode, so
+        the API never returns aggregate values for gridded sub-queries. We synthesize
+        ``metadata["aggregate"]["defensibleSpace"]["skipped"] = True`` so
+        parcels.parcel_rollup populates aggregate_defensible_space_skipped=True.
+        """
+        api = self._build_api(tmp_path, regrid_on_skip=True)
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"defensible_space_skipped": [True], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            return features_gdf, {"aoi_id": aoi_id, "aggregate": {"defensibleSpace": {"skipped": True}}}
+
+        def mock_attempt_gridding(*args, **kwargs):
+            metadata = {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"}
+            return (
+                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
+                metadata,
+                None,
+                None,
+            )
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        _, metadata, _, _ = api.get_features_gdf(
+            geometry=SMALL_AOI,
+            region="au",
+            include=["defensibleSpace"],
+            aoi_id="ds-aoi",
+        )
+        assert metadata is not None
+        assert metadata["aggregate"]["defensibleSpace"]["skipped"] is True
+
+    def test_aggregate_ds_skip_not_synthesized_when_ds_not_requested(self, tmp_path, monkeypatch):
+        """If the caller never asked for defensibleSpace, don't fabricate an aggregate dict."""
+        api = self._build_api(tmp_path, regrid_on_skip=True)
+
+        def mock_get_features(*args, **kwargs):
+            return {}
+
+        def mock_payload_gdf(payload, aoi_id, parcel_mode):
+            features_gdf = gpd.GeoDataFrame(
+                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
+                geometry="geometry",
+            )
+            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+
+        def mock_attempt_gridding(*args, **kwargs):
+            metadata = {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"}
+            return (
+                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
+                metadata,
+                None,
+                None,
+            )
+
+        monkeypatch.setattr(api, "get_features", mock_get_features)
+        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
+        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
+
+        _, metadata, _, _ = api.get_features_gdf(
+            geometry=SMALL_AOI,
+            region="au",
+            include=["roofSpotlightIndex"],
+            aoi_id="rsi-aoi",
+        )
+        assert metadata is not None
+        assert "aggregate" not in metadata or metadata["aggregate"] is None or "defensibleSpace" not in metadata.get("aggregate", {})

--- a/tests/test_regrid_on_skip.py
+++ b/tests/test_regrid_on_skip.py
@@ -1,14 +1,12 @@
 """Tests for reactive gridding when the Feature API marks any include as skipped.
 
-The Feature API returns ``{"skipped": true}`` for include sections (RSI, peril
-scores, defensible space) when a parcel exceeds the per-parcel CPU budget —
-currently ~100 buildings. ``FeatureApi.regrid_on_skip`` (default True) detects
-this and reactively re-issues the AOI as a gridded query.
+The Feature API returns ``{"skipped": true}`` for include sections when a
+parcel exceeds the per-parcel CPU budget. ``FeatureApi.regrid_on_skip``
+(default True) detects this and reactively re-issues the AOI as a gridded
+query so the sub-AOIs come back as mini-parcels with populated scores.
 """
 
 import geopandas as gpd
-import pandas as pd
-import pytest
 from shapely.geometry import Polygon
 
 from nmaipy.feature_api import FeatureApi, _response_has_include_skips
@@ -25,10 +23,6 @@ SMALL_AOI = Polygon(
 )
 
 
-def _empty_features_gdf():
-    return gpd.GeoDataFrame({"geometry": []}, geometry="geometry")
-
-
 def _features_gdf_with_skip(col):
     return gpd.GeoDataFrame({col: [True], "geometry": [SMALL_AOI]}, geometry="geometry")
 
@@ -39,35 +33,20 @@ class TestResponseHasIncludeSkips:
             {"roof_spotlight_index_skipped": [False, False], "geometry": [SMALL_AOI, SMALL_AOI]},
             geometry="geometry",
         )
-        metadata = {"aggregate": None}
-        any_skipped, skipped = _response_has_include_skips(features_gdf, metadata)
+        any_skipped, skipped = _response_has_include_skips(features_gdf)
         assert any_skipped is False
         assert skipped == []
 
     def test_per_roof_skip_detected(self):
         features_gdf = _features_gdf_with_skip("hurricane_score_skipped")
-        any_skipped, skipped = _response_has_include_skips(features_gdf, None)
+        any_skipped, skipped = _response_has_include_skips(features_gdf)
         assert any_skipped is True
         assert skipped == ["hurricane_score_skipped"]
 
-    def test_aggregate_ds_skip_detected(self):
-        metadata = {"aggregate": {"defensibleSpace": {"skipped": True}}}
-        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), metadata)
-        assert any_skipped is True
-        assert skipped == ["aggregate_defensible_space"]
-
-    def test_aggregate_ds_not_skipped(self):
-        metadata = {"aggregate": {"defensibleSpace": {"skipped": False, "zones": []}}}
-        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), metadata)
+    def test_none_input_returns_false(self):
+        any_skipped, skipped = _response_has_include_skips(None)
         assert any_skipped is False
-
-    def test_missing_aggregate_returns_false(self):
-        any_skipped, skipped = _response_has_include_skips(_empty_features_gdf(), {})
-        assert any_skipped is False
-
-    def test_none_inputs_return_false(self):
-        any_skipped, skipped = _response_has_include_skips(None, None)
-        assert any_skipped is False
+        assert skipped == []
 
     def test_multiple_skip_columns_all_reported(self):
         features_gdf = gpd.GeoDataFrame(
@@ -79,7 +58,7 @@ class TestResponseHasIncludeSkips:
             },
             geometry="geometry",
         )
-        any_skipped, skipped = _response_has_include_skips(features_gdf, None)
+        any_skipped, skipped = _response_has_include_skips(features_gdf)
         assert any_skipped is True
         assert set(skipped) == {"roof_spotlight_index_skipped", "defensible_space_skipped"}
 
@@ -88,7 +67,7 @@ class TestResponseHasIncludeSkips:
             {"roof_spotlight_index_skipped": [None, None], "geometry": [SMALL_AOI, SMALL_AOI]},
             geometry="geometry",
         )
-        any_skipped, _ = _response_has_include_skips(features_gdf, None)
+        any_skipped, _ = _response_has_include_skips(features_gdf)
         assert any_skipped is False
 
 
@@ -115,8 +94,7 @@ class TestRegridOnSkip:
                 {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
                 geometry="geometry",
             )
-            metadata = {"aoi_id": aoi_id, "aggregate": None}
-            return features_gdf, metadata
+            return features_gdf, {"aoi_id": aoi_id}
 
         def mock_attempt_gridding(*args, **kwargs):
             gridding_called["count"] += 1
@@ -147,7 +125,7 @@ class TestRegridOnSkip:
                 {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
                 geometry="geometry",
             )
-            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+            return features_gdf, {"aoi_id": aoi_id}
 
         def mock_attempt_gridding(*args, **kwargs):
             gridding_called["count"] += 1
@@ -173,7 +151,7 @@ class TestRegridOnSkip:
                 {"roof_spotlight_index_skipped": [False], "geometry": [SMALL_AOI]},
                 geometry="geometry",
             )
-            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+            return features_gdf, {"aoi_id": aoi_id}
 
         def mock_attempt_gridding(*args, **kwargs):
             gridding_called["count"] += 1
@@ -199,7 +177,7 @@ class TestRegridOnSkip:
                 {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
                 geometry="geometry",
             )
-            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
+            return features_gdf, {"aoi_id": aoi_id}
 
         def mock_attempt_gridding(*args, **kwargs):
             gridding_called["count"] += 1
@@ -216,81 +194,3 @@ class TestRegridOnSkip:
             in_gridding_mode=True,
         )
         assert gridding_called["count"] == 0
-
-    def test_aggregate_ds_skip_synthesized_after_grid(self, tmp_path, monkeypatch):
-        """When DS was requested and skip triggered gridding, synthesize aggregate skip flag.
-
-        Aggregate DS is parcel-mode-only and the gridded path disables parcel mode, so
-        the API never returns aggregate values for gridded sub-queries. We synthesize
-        ``metadata["aggregate"]["defensibleSpace"]["skipped"] = True`` so
-        parcels.parcel_rollup populates aggregate_defensible_space_skipped=True.
-        """
-        api = self._build_api(tmp_path, regrid_on_skip=True)
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"defensible_space_skipped": [True], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id, "aggregate": {"defensibleSpace": {"skipped": True}}}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            metadata = {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"}
-            return (
-                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
-                metadata,
-                None,
-                None,
-            )
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
-
-        _, metadata, _, _ = api.get_features_gdf(
-            geometry=SMALL_AOI,
-            region="au",
-            include=["defensibleSpace"],
-            aoi_id="ds-aoi",
-        )
-        assert metadata is not None
-        assert metadata["aggregate"]["defensibleSpace"]["skipped"] is True
-
-    def test_aggregate_ds_skip_not_synthesized_when_ds_not_requested(self, tmp_path, monkeypatch):
-        """If the caller never asked for defensibleSpace, don't fabricate an aggregate dict."""
-        api = self._build_api(tmp_path, regrid_on_skip=True)
-
-        def mock_get_features(*args, **kwargs):
-            return {}
-
-        def mock_payload_gdf(payload, aoi_id, parcel_mode):
-            features_gdf = gpd.GeoDataFrame(
-                {"roof_spotlight_index_skipped": [True], "geometry": [SMALL_AOI]},
-                geometry="geometry",
-            )
-            return features_gdf, {"aoi_id": aoi_id, "aggregate": None}
-
-        def mock_attempt_gridding(*args, **kwargs):
-            metadata = {"aoi_id": kwargs.get("aoi_id", "x"), "system_version": "v"}
-            return (
-                gpd.GeoDataFrame({"geometry": [SMALL_AOI]}, geometry="geometry"),
-                metadata,
-                None,
-                None,
-            )
-
-        monkeypatch.setattr(api, "get_features", mock_get_features)
-        monkeypatch.setattr(FeatureApi, "payload_gdf", staticmethod(mock_payload_gdf))
-        monkeypatch.setattr(api, "_attempt_gridding", mock_attempt_gridding)
-
-        _, metadata, _, _ = api.get_features_gdf(
-            geometry=SMALL_AOI,
-            region="au",
-            include=["roofSpotlightIndex"],
-            aoi_id="rsi-aoi",
-        )
-        assert metadata is not None
-        assert "aggregate" not in metadata or metadata["aggregate"] is None or "defensibleSpace" not in metadata.get("aggregate", {})


### PR DESCRIPTION
## Summary

- Add `regrid_on_skip` (default True) to `FeatureApi`. When the Feature API returns `{"skipped": true}` for any include (RSI, peril scores, defensible space) on a parcel exceeding its per-parcel CPU budget, the AOI is automatically re-issued as a gridded query — gridded sub-queries disable parcel mode so the API sees mini-parcels under the cutoff and returns populated scores / per-roof DS.
- Exposed as `--no-regrid-on-skip` on the exporter CLI; persisted in the saved export config so resumed exports honour the original choice.
- Aggregate defensible space is parcel-mode-only and stays null in the gridded path. No client-side synthesis or recompute.
- Bump to 5.0.14.

## Test plan

- [x] `pytest tests/test_regrid_on_skip.py` — 10 tests covering detection, trigger gating (flag off, in-gridding-mode loop guard, no-skips no-op), and helper edge cases.
- [x] Regression check on related areas — `tests/test_parcels.py`, `tests/test_defensible_space.py`, `tests/test_gridded_aggregate_dict_dedup.py`, `test_feature_api.py` proactive-gridding tests: 97 pass / 5 skipped (live_api).
- [ ] Integration test on a known skip-heavy export: confirm `CHUNK_SKIPS` log counts drop, per-roof score columns populate on previously-skipped AOIs, request count rises moderately on those AOIs only.