### PR TITLE
Invalidate s3fs dircache in glob_files so the merge can't miss present chunks

### DIFF
--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -225,6 +225,13 @@ def glob_files(directory: str, pattern: str) -> List[str]:
     """
     Glob for files in a directory. Works for both local and S3.
 
+    For S3, the s3fs directory-listing cache is invalidated before globbing.
+    A stale or partially-populated dircache (e.g. cached early in a run, before
+    the chunk files were written) makes ``fs.glob`` silently miss files that are
+    present — which previously dropped feature / per-class chunks from the merge
+    phase, yielding an empty ``features.parquet`` (0 chunks discovered) and
+    breaking the CV Apps geodatabase export. Transient read errors are retried.
+
     Args:
         directory: Directory to search in
         pattern: Glob pattern (e.g. "rollup_*.parquet")
@@ -232,14 +239,24 @@ def glob_files(directory: str, pattern: str) -> List[str]:
     Returns:
         List of matching file paths as strings
     """
-    if is_s3_path(directory):
-        fs = _get_s3_filesystem()
-        full_pattern = join_path(directory, pattern)
-        # fsspec glob returns paths without the s3:// prefix
-        results = fs.glob(full_pattern)
-        return ["s3://" + r for r in results]
-    else:
+    if not is_s3_path(directory):
         return [str(p) for p in Path(directory).glob(pattern)]
+
+    fs = _get_s3_filesystem()
+    full_pattern = join_path(directory, pattern)
+    last_exc: Optional[Exception] = None
+    for attempt in range(_S3_READ_RETRIES + 1):
+        try:
+            # Force a fresh listing — never trust a possibly-stale dircache here.
+            fs.invalidate_cache(directory)
+            # fsspec glob returns paths without the s3:// prefix
+            results = fs.glob(full_pattern)
+            return ["s3://" + r for r in results]
+        except Exception as e:  # transient S3/network error — retry
+            last_exc = e
+            if attempt < _S3_READ_RETRIES:
+                time.sleep(_S3_READ_BACKOFF_SECONDS * (2**attempt))
+    raise last_exc
 
 
 def open_file(path: str, mode: str = "r", **kwargs):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -158,6 +158,34 @@ class TestGlobFiles:
         ]
         mock_fs.glob.assert_called_with("s3://bucket/prefix/chunks/rollup_*.parquet")
 
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_glob_invalidates_cache_before_listing(self, mock_get_fs):
+        # A stale s3fs dircache can make glob miss present files (it dropped all
+        # feature/per-class chunks from the merge, producing an empty
+        # features.parquet). glob_files must drop the cache before listing.
+        manager = MagicMock()
+        mock_get_fs.return_value = manager.fs
+        manager.fs.glob.return_value = ["bucket/prefix/chunks/features_0001.parquet"]
+
+        results = storage.glob_files("s3://bucket/prefix/chunks", "features_*.parquet")
+
+        manager.fs.invalidate_cache.assert_called_once_with("s3://bucket/prefix/chunks")
+        # invalidate_cache must happen *before* glob.
+        call_names = [c[0] for c in manager.fs.mock_calls if c[0] in ("invalidate_cache", "glob")]
+        assert call_names == ["invalidate_cache", "glob"], call_names
+        assert results == ["s3://bucket/prefix/chunks/features_0001.parquet"]
+
+    @patch("nmaipy.storage.time.sleep", lambda *_: None)
+    @patch("nmaipy.storage._get_s3_filesystem")
+    def test_s3_glob_retries_transient_then_succeeds(self, mock_get_fs):
+        mock_fs = MagicMock()
+        mock_fs.glob.side_effect = [OSError("timeout"), ["bucket/p/chunks/features_0001.parquet"]]
+        mock_get_fs.return_value = mock_fs
+
+        results = storage.glob_files("s3://bucket/p/chunks", "features_*.parquet")
+        assert results == ["s3://bucket/p/chunks/features_0001.parquet"]
+        assert mock_fs.glob.call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # open_file


### PR DESCRIPTION
## Problem

The chunk-merge discovers feature, per-class, and error chunks via `storage.glob_files` → `fs.glob`, which consults s3fs's **cached** directory listing. A stale or partially-populated dircache — e.g. the `chunks/` dir listed early in a run, before the chunk files were written — makes `glob` silently return **0** even though the files are present on S3.

Observed: an AOI export wrote 37 `features_*.parquet` (100 MB+) to `chunks/`, but the merge logged:

```
Saving feature data from 0 geoparquet chunks to .../final/features.parquet
No feature data found to write
Per-class merge complete: 0 tabular + 0 geo files
```

→ no `features.parquet` → the downstream geodatabase export fails with "No matching files". The rollup merge in the **same run** found all 37 chunks, because it discovers by index (`range(num_chunks)` + `file_exists`), not by the cached glob.

## Root cause / scope

Same stale-listing class as the rollup-merge fix (#191), which hardened the index-based rollup sweep (`invalidate_cache` + retrying `file_exists`/`validate_parquet`) but left the **glob-based** discovery paths exposed. There are four such callers: features, per-class (`{cname}_*.parquet`), `feature_api_errors_*`, `roof_age_errors_*`.

## Fix

Harden `glob_files` itself (covers all callers): invalidate the s3fs dircache before listing so a stale cache can't drop present files, and retry transient read errors with bounded backoff (consistent with `file_exists`/`validate_parquet`). All `glob_files` callers are merge-phase (low frequency), so always-invalidating is safe.

## Tests

`tests/test_storage.py`: assert `invalidate_cache` is called **before** `glob`, and retry-transient-then-succeed. 118 storage+exporter tests pass.

Needs a 5.0.15 publish to consume downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)