### PR TITLE
Report cgroup working set, not raw memory.current

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.15"
+__version__ = "5.0.16"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.14"
+__version__ = "5.0.15"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/cgroup_memory.py
+++ b/nmaipy/cgroup_memory.py
@@ -7,6 +7,12 @@ the actual container resource limits from cgroup files.
 
 Supports both cgroup v1 and v2 (unified hierarchy).
 Currently covers memory and CPU resources.
+
+Cross-platform: cgroup files live under /sys/fs/cgroup, which only exists on
+Linux. On Windows, macOS, and Linux outside a container, `is_running_in_container`
+returns False (the cgroup paths don't exist) and `get_*_cgroup_aware` functions
+fall back to psutil for the host's view. Each helper that touches a cgroup file
+guards on `os.path.exists` first.
 """
 
 import logging
@@ -121,6 +127,11 @@ def get_cgroup_memory_usage_bytes() -> Optional[int]:
 def _read_memory_stat_field(stat_path: str, field: str) -> Optional[int]:
     """
     Read a single ``key value`` field (in bytes) from a cgroup memory.stat file.
+
+    The Linux cgroup memory.stat format guarantees exactly two whitespace-
+    separated tokens per line (one key, one numeric value in bytes). Returns
+    None on any non-Linux platform (sysfs absent), missing field, or parse
+    error — callers are expected to fall back gracefully.
 
     Args:
         stat_path: Path to the memory.stat file.

--- a/nmaipy/cgroup_memory.py
+++ b/nmaipy/cgroup_memory.py
@@ -21,11 +21,13 @@ logger = logging.getLogger(__name__)
 # Cgroup v2 paths (unified hierarchy, newer K8s)
 CGROUP_V2_MEMORY_MAX = "/sys/fs/cgroup/memory.max"
 CGROUP_V2_MEMORY_CURRENT = "/sys/fs/cgroup/memory.current"
+CGROUP_V2_MEMORY_STAT = "/sys/fs/cgroup/memory.stat"
 CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
 
 # Cgroup v1 paths (legacy, older K8s)
 CGROUP_V1_MEMORY_LIMIT = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 CGROUP_V1_MEMORY_USAGE = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+CGROUP_V1_MEMORY_STAT = "/sys/fs/cgroup/memory/memory.stat"
 CGROUP_V1_CPU_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 CGROUP_V1_CPU_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 
@@ -116,6 +118,69 @@ def get_cgroup_memory_usage_bytes() -> Optional[int]:
     return None
 
 
+def _read_memory_stat_field(stat_path: str, field: str) -> Optional[int]:
+    """
+    Read a single ``key value`` field (in bytes) from a cgroup memory.stat file.
+
+    Args:
+        stat_path: Path to the memory.stat file.
+        field: The leading key to match (e.g. "inactive_file").
+
+    Returns:
+        The field value in bytes, or None if the file/field is unavailable.
+    """
+    if not os.path.exists(stat_path):
+        return None
+    try:
+        with open(stat_path, "r") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) == 2 and parts[0] == field:
+                    return int(parts[1])
+    except (IOError, ValueError) as e:
+        logger.debug(f"Could not read {field} from {stat_path}: {e}")
+    return None
+
+
+def get_cgroup_inactive_file_bytes() -> Optional[int]:
+    """
+    Get the reclaimable file-backed page cache (inactive_file) from cgroup files.
+
+    This is clean page cache the kernel can evict for free under memory pressure,
+    so it does NOT count toward an OOM kill. Tries cgroup v2 first, then v1.
+
+    Returns:
+        Inactive file cache in bytes, or None if not in a container / unavailable.
+    """
+    # cgroup v2 reports this as "inactive_file"; v1 as "total_inactive_file".
+    inactive = _read_memory_stat_field(CGROUP_V2_MEMORY_STAT, "inactive_file")
+    if inactive is not None:
+        return inactive
+    return _read_memory_stat_field(CGROUP_V1_MEMORY_STAT, "total_inactive_file")
+
+
+def get_cgroup_working_set_bytes() -> Optional[int]:
+    """
+    Get the container's working-set memory in bytes.
+
+    working_set = memory.current - inactive_file (the reclaimable page cache).
+    This is the figure kubelet and the kernel OOM killer key off: raw
+    memory.current includes reclaimable page cache and so overstates how close
+    the container is to being killed. If inactive_file can't be read we fall back
+    to raw usage (conservative: overcounts rather than understating OOM risk).
+
+    Returns:
+        Working-set memory in bytes, or None if not in a container.
+    """
+    usage = get_cgroup_memory_usage_bytes()
+    if usage is None:
+        return None
+    inactive = get_cgroup_inactive_file_bytes()
+    if inactive is None:
+        return usage
+    return max(0, usage - inactive)
+
+
 def get_cgroup_memory_limit_gb() -> Optional[float]:
     """
     Get the container's memory limit in GB.
@@ -133,6 +198,9 @@ def get_cgroup_memory_usage_gb() -> Optional[float]:
     """
     Get the container's current memory usage in GB.
 
+    This is raw memory.current and includes reclaimable page cache. For an
+    OOM-risk figure prefer get_cgroup_working_set_gb().
+
     Returns:
         Current memory usage in GB, or None if not in a container.
     """
@@ -142,19 +210,40 @@ def get_cgroup_memory_usage_gb() -> Optional[float]:
     return usage_bytes / (1024**3)
 
 
+def get_cgroup_working_set_gb() -> Optional[float]:
+    """
+    Get the container's working-set memory in GB (the OOM-relevant figure).
+
+    See get_cgroup_working_set_bytes(): this is memory.current minus reclaimable
+    page cache, matching kubelet's working_set_bytes.
+
+    Returns:
+        Working-set memory in GB, or None if not in a container.
+    """
+    working_set_bytes = get_cgroup_working_set_bytes()
+    if working_set_bytes is None:
+        return None
+    return working_set_bytes / (1024**3)
+
+
 def get_memory_info_cgroup_aware() -> Tuple[float, float]:
     """
     Get memory usage and total, respecting cgroup limits when in a container.
+
+    The "used" figure is the working set (memory.current minus reclaimable page
+    cache), so it reflects the memory that actually drives an OOM kill rather
+    than raw usage inflated by evictable cache. This also matches the bare-metal
+    psutil fallback (total - available), which already excludes reclaimable cache.
 
     Returns:
         Tuple of (used_gb, total_gb) - uses cgroup values in containers,
         falls back to psutil for bare metal.
     """
     if is_running_in_container():
-        usage_gb = get_cgroup_memory_usage_gb()
+        used_gb = get_cgroup_working_set_gb()
         limit_gb = get_cgroup_memory_limit_gb()
-        if usage_gb is not None and limit_gb is not None:
-            return (usage_gb, limit_gb)
+        if used_gb is not None and limit_gb is not None:
+            return (used_gb, limit_gb)
 
     # Fall back to psutil
     mem = psutil.virtual_memory()

--- a/tests/test_cgroup_memory.py
+++ b/tests/test_cgroup_memory.py
@@ -1,0 +1,144 @@
+from unittest.mock import patch
+
+from nmaipy.cgroup_memory import (
+    get_cgroup_inactive_file_bytes,
+    get_cgroup_working_set_bytes,
+    get_cgroup_working_set_gb,
+    get_memory_info_cgroup_aware,
+)
+
+# memory.current / memory.usage_in_bytes only carries the usage counter; the
+# reclaimable cache figure lives in memory.stat (inactive_file on v2,
+# total_inactive_file on v1). Working set = usage - inactive_file.
+
+
+class TestGetCgroupInactiveFileBytes:
+    def test_reads_v2_inactive_file(self, tmp_path, monkeypatch):
+        stat = tmp_path / "memory.stat"
+        stat.write_text("anon 500\ninactive_file 200\nactive_file 10\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        assert get_cgroup_inactive_file_bytes() == 200
+
+    def test_reads_v1_total_inactive_file(self, tmp_path, monkeypatch):
+        stat = tmp_path / "memory.stat"
+        stat.write_text("cache 1000\ntotal_inactive_file 200\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(tmp_path / "nonexistent"))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_STAT", str(stat))
+        assert get_cgroup_inactive_file_bytes() == 200
+
+    def test_missing_stat_returns_none(self, monkeypatch):
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", "/nonexistent")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_STAT", "/nonexistent")
+        assert get_cgroup_inactive_file_bytes() is None
+
+    def test_field_absent_returns_none(self, tmp_path, monkeypatch):
+        stat = tmp_path / "memory.stat"
+        stat.write_text("anon 500\nactive_file 10\n")  # no inactive_file line
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_STAT", "/nonexistent")
+        assert get_cgroup_inactive_file_bytes() is None
+
+
+class TestGetCgroupWorkingSetBytes:
+    def test_v2_working_set(self, tmp_path, monkeypatch):
+        """current=1000, inactive_file=200 -> working set 800."""
+        current = tmp_path / "memory.current"
+        current.write_text("1000\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text("inactive_file 200\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        assert get_cgroup_working_set_bytes() == 800
+
+    def test_v1_working_set(self, tmp_path, monkeypatch):
+        """v1: usage_in_bytes=1000, total_inactive_file=200 -> 800."""
+        usage = tmp_path / "memory.usage_in_bytes"
+        usage.write_text("1000\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text("total_inactive_file 200\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(tmp_path / "nonexistent"))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(tmp_path / "nonexistent"))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_USAGE", str(usage))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_STAT", str(stat))
+        assert get_cgroup_working_set_bytes() == 800
+
+    def test_falls_back_to_raw_usage_when_stat_missing(self, tmp_path, monkeypatch):
+        """No memory.stat -> conservative: return raw usage unchanged."""
+        current = tmp_path / "memory.current"
+        current.write_text("1000\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", "/nonexistent")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_STAT", "/nonexistent")
+        assert get_cgroup_working_set_bytes() == 1000
+
+    def test_inactive_exceeds_usage_clamps_to_zero(self, tmp_path, monkeypatch):
+        """Pathological inactive_file > usage must not go negative."""
+        current = tmp_path / "memory.current"
+        current.write_text("100\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text("inactive_file 200\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        assert get_cgroup_working_set_bytes() == 0
+
+    def test_no_usage_returns_none(self, monkeypatch):
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", "/nonexistent")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_USAGE", "/nonexistent")
+        assert get_cgroup_working_set_bytes() is None
+
+    def test_working_set_gb_conversion(self, tmp_path, monkeypatch):
+        current = tmp_path / "memory.current"
+        current.write_text(f"{4 * 1024**3}\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text(f"inactive_file {1 * 1024**3}\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        assert get_cgroup_working_set_gb() == 3.0
+
+    def test_reproduces_measured_live_values(self, tmp_path, monkeypatch):
+        """Real block export sample riding the limit: 124.2GB current, 76.7GB cache -> 47.4GB."""
+        current = tmp_path / "memory.current"
+        current.write_text("133303267328\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text("anon 46611353600\ninactive_file 82357862400\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        assert get_cgroup_working_set_bytes() == 50945404928
+        assert round(get_cgroup_working_set_gb(), 1) == 47.4
+
+
+class TestGetMemoryInfoCgroupAware:
+    def test_container_returns_working_set_and_limit(self, tmp_path, monkeypatch):
+        """In-container used figure is the working set, not raw current."""
+        mem_max = tmp_path / "memory.max"
+        mem_max.write_text(f"{8 * 1024**3}\n")
+        current = tmp_path / "memory.current"
+        current.write_text(f"{6 * 1024**3}\n")
+        stat = tmp_path / "memory.stat"
+        stat.write_text(f"inactive_file {2 * 1024**3}\n")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_MAX", str(mem_max))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", str(current))
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_STAT", str(stat))
+        used_gb, total_gb = get_memory_info_cgroup_aware()
+        assert used_gb == 4.0  # 6 current - 2 cache, not 6
+        assert total_gb == 8.0
+
+    def test_bare_metal_uses_psutil(self, monkeypatch):
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_MAX", "/nonexistent")
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_LIMIT", "/nonexistent")
+        used_gb, total_gb = get_memory_info_cgroup_aware()
+        assert used_gb > 0.0
+        assert total_gb > 0.0
+        assert used_gb <= total_gb
+
+    def test_container_falls_back_to_psutil_when_limit_unreadable(self, tmp_path, monkeypatch):
+        """is_running_in_container True (limit file exists) but unparseable -> psutil."""
+        mem_max = tmp_path / "memory.max"
+        mem_max.write_text("max\n")  # exists -> container detected, but no numeric limit
+        monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_MAX", str(mem_max))
+        with patch("nmaipy.cgroup_memory.psutil.virtual_memory") as vm:
+            vm.return_value.total = 16 * 1024**3
+            vm.return_value.available = 4 * 1024**3
+            used_gb, total_gb = get_memory_info_cgroup_aware()
+        assert total_gb == 16.0
+        assert used_gb == 12.0

--- a/tests/test_cgroup_memory.py
+++ b/tests/test_cgroup_memory.py
@@ -82,6 +82,11 @@ class TestGetCgroupWorkingSetBytes:
         assert get_cgroup_working_set_bytes() == 0
 
     def test_no_usage_returns_none(self, monkeypatch):
+        """Windows / macOS / Linux outside a container: no sysfs cgroup files → None.
+
+        The caller (`get_memory_info_cgroup_aware`) handles None by falling back
+        to psutil, so the host's view is reported on those platforms.
+        """
         monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V2_MEMORY_CURRENT", "/nonexistent")
         monkeypatch.setattr("nmaipy.cgroup_memory.CGROUP_V1_MEMORY_USAGE", "/nonexistent")
         assert get_cgroup_working_set_bytes() is None


### PR DESCRIPTION
## Problem

Container memory monitoring reads raw `memory.current` (cgroup v2) / `memory.usage_in_bytes` (v1), which **includes reclaimable file-backed page cache**. On file-heavy workloads this overstates how close the container is to an OOM kill — a process can sit at 96% of its limit indefinitely while the kernel evicts clean cache on demand and never kills it. The displayed `X/limit GB` number panics about cache that the kernel reclaims for free.

## Change

Report the **working set** — `working_set = memory.current − inactive_file` — matching kubelet's `working_set_bytes` and the kernel OOM killer's actual view:

- `get_cgroup_inactive_file_bytes()` — parse `inactive_file` (v2) / `total_inactive_file` (v1) from `memory.stat`.
- `get_cgroup_working_set_bytes()` / `_gb()` — usage minus reclaimable cache, clamped at 0; falls back to raw usage if `memory.stat` is unreadable (conservative: overcounts rather than understating OOM risk).
- `get_memory_info_cgroup_aware()` now returns the working set as the "used" figure, so every progress bar / log reflects OOM-relevant memory. This also makes the container path **consistent** with the bare-metal psutil fallback (`total − available`), which already excludes reclaimable cache — previously the container path was the only one counting cache.

Raw `get_cgroup_memory_usage_*()` is left unchanged for callers that want the literal counter.

## Tests

Adds `tests/test_cgroup_memory.py` (following the `tmp_path` + `monkeypatch` pattern from `test_cgroup_cpu.py`): v1/v2 working set, missing-`memory.stat` fallback to raw usage, `inactive_file > usage` clamp-to-zero, GB conversion, and `get_memory_info_cgroup_aware()` in-container vs psutil-fallback. `pytest tests/test_cgroup_memory.py tests/test_cgroup_cpu.py` → 32 passed.

Version bumped to 5.0.16.

## Note for maintainers

This branch also carries the `Bump version to 5.0.15` commit (`aa6c588`). The `5.0.15` tag was pushed but the commit itself never landed on `origin/main` (origin sits one commit behind the tag). Merging this PR brings `main` back in line with the released `5.0.15` tag. If you'd rather, push `aa6c588` to `main` first and I'll rebase so this PR shows only the working-set change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)