### PR TITLE
Backfill missing metadata columns in one concat, not per-column

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -238,6 +238,31 @@ def _write_errors_parquet(errors_df: pd.DataFrame, outfile: str) -> None:
         storage.write_parquet(errors_df, outfile)
 
 
+def _add_missing_columns(df: pd.DataFrame, columns: list, fill=None) -> pd.DataFrame:
+    """
+    Return ``df`` with every name in ``columns`` present, adding missing ones in a single concat.
+
+    The per-chunk ``final_df`` is frequently very wide (hundreds of rollup columns). Adding
+    absent columns one at a time with ``df[col] = fill`` trips pandas' "DataFrame is highly
+    fragmented" PerformanceWarning once per column, which floods the logs with thousands of
+    identical lines on a no-coverage export (one burst per chunk that returned no survey
+    resources). Building all missing columns at once and concatenating avoids that.
+
+    Args:
+        df: Frame to extend.
+        columns: Column names that must exist on the returned frame.
+        fill: Value used to populate any newly-added columns.
+
+    Returns:
+        ``df`` unchanged when all columns already exist, otherwise a new frame with the
+        missing columns appended.
+    """
+    missing = [col for col in columns if col not in df.columns]
+    if not missing:
+        return df
+    return pd.concat([df, pd.DataFrame({col: fill for col in missing}, index=df.index)], axis=1)
+
+
 def _add_is_primary_column(
     features_gdf: gpd.GeoDataFrame,
     rollup_df: pd.DataFrame,
@@ -3334,10 +3359,8 @@ class NearmapAIExporter(BaseExporter):
                 aoi_gdf, on=AOI_ID_COLUMN_NAME
             )
             # Ensure metadata columns exist even when metadata_df was empty
-            # (e.g. all Feature API requests failed) for consistent schema
-            for col in meta_data_columns:
-                if col not in final_df.columns:
-                    final_df[col] = None
+            # (e.g. no survey resources found for the chunk) for consistent schema.
+            final_df = _add_missing_columns(final_df, meta_data_columns)
             parcel_columns = [c for c in aoi_gdf.columns if c != "geometry"]
             columns = (
                 parcel_columns

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +22,7 @@ from nmaipy.constants import (
 )
 from nmaipy.exporter import (
     AOIExporter,
+    _add_missing_columns,
     _dataframe_to_records_with_index,
     _description_to_cname,
     _per_class_chunk_regexes,
@@ -29,6 +31,74 @@ from nmaipy.exporter import (
     _write_errors_parquet,
 )
 from nmaipy.feature_api import FeatureApi
+
+
+class TestAddMissingColumns:
+    """``_add_missing_columns`` backfills absent columns without the per-column fragmentation warning.
+
+    Regression guard for the no-coverage chunk path: a chunk that returns no survey resources has an
+    empty ``metadata_df``, so all metadata columns are absent from the (very wide) ``final_df`` and must
+    be added. Doing that one column at a time floods the logs with pandas PerformanceWarnings.
+    """
+
+    META_COLUMNS = [
+        "system_version",
+        "link",
+        "survey_date",
+        "survey_id",
+        "survey_resource_id",
+        "perspective",
+        "postcat",
+        "mesh_date",
+    ]
+
+    @staticmethod
+    def _fragmented_frame(n_cols: int = 300, n_rows: int = 5) -> pd.DataFrame:
+        """Build a deliberately block-fragmented frame, mirroring the wide per-chunk rollup."""
+        df = pd.DataFrame({AOI_ID_COLUMN_NAME: range(n_rows)})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # the fragmenting inserts warn too; not what we're testing
+            for i in range(n_cols):
+                df[f"col_{i}"] = i
+        return df
+
+    def test_adds_all_missing_columns_as_null(self):
+        df = self._fragmented_frame()
+        result = _add_missing_columns(df, self.META_COLUMNS)
+        for col in self.META_COLUMNS:
+            assert col in result.columns, f"{col} should have been added"
+            assert result[col].isna().all(), f"{col} should be all-null"
+        assert len(result) == len(df)
+
+    def test_no_fragmentation_warning_on_wide_frame(self):
+        # Sanity: the naive per-column approach DOES warn on a wide frame, so the regression
+        # assertion below is meaningful (it fails if anyone reverts to that loop).
+        naive = self._fragmented_frame()
+        with pytest.warns(pd.errors.PerformanceWarning):
+            for col in self.META_COLUMNS:
+                naive[col] = None
+
+        # The helper must add the same columns to an equally-wide frame without warning.
+        df = self._fragmented_frame()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", pd.errors.PerformanceWarning)
+            result = _add_missing_columns(df, self.META_COLUMNS)
+        assert all(col in result.columns for col in self.META_COLUMNS)
+
+    def test_returns_input_unchanged_when_nothing_missing(self):
+        df = pd.DataFrame({AOI_ID_COLUMN_NAME: [1], "system_version": ["gen6-"]})
+        result = _add_missing_columns(df, ["system_version"])
+        assert result is df  # no-op, no needless copy
+
+    def test_partial_backfill_preserves_present_values(self):
+        df = self._fragmented_frame()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # setup-only insert on the fragmented frame
+            df["system_version"] = "gen6-"
+        result = _add_missing_columns(df, self.META_COLUMNS)
+        assert (result["system_version"] == "gen6-").all()
+        for col in (c for c in self.META_COLUMNS if c != "system_version"):
+            assert result[col].isna().all()
 
 
 class TestExporter:


### PR DESCRIPTION
## Problem

When a chunk's Feature API response contains no survey resources, `metadata_df` is empty and none of the metadata columns survive the merge into `final_df`. The old code back-filled them with a per-column `final_df[col] = None` loop.

`final_df` is already very wide (hundreds of rollup columns), so each per-column assignment trips pandas' `PerformanceWarning: DataFrame is highly fragmented` — once per missing column, per no-coverage chunk. On an export with widespread no-coverage chunks this floods the run log with thousands of identical warnings (bursts of ~8 per chunk), drowning out real signal in the uploaded log.

## Fix

Extract the back-fill into `_add_missing_columns(df, columns, fill=None)`, which adds all absent columns in a single `pd.concat(axis=1)` — pandas' own recommended remedy. **Output schema is unchanged**; only the warning flood and the transient fragmentation/memory cost are removed.

## Test

Adds `TestAddMissingColumns` (self-validating regression): it first asserts the naive per-column loop *does* warn on a wide frame (so the guard fails if anyone reverts), then asserts the helper does not, plus coverage for all-missing / partial / nothing-missing cases.

Full `tests/test_exporter.py` passes, including the live `test_process_chunk_au` that exercises the real chunk path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)