### PR TITLE
Fix row-explosion risk in metadata-column backfill (follow-up to #196)

### DIFF
--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -238,7 +238,7 @@ def _write_errors_parquet(errors_df: pd.DataFrame, outfile: str) -> None:
         storage.write_parquet(errors_df, outfile)
 
 
-def _add_missing_columns(df: pd.DataFrame, columns: list, fill=None) -> pd.DataFrame:
+def _add_missing_columns(df: pd.DataFrame, columns: list[str], fill=None) -> pd.DataFrame:
     """
     Return ``df`` with every name in ``columns`` present, adding missing ones in a single concat.
 
@@ -247,6 +247,14 @@ def _add_missing_columns(df: pd.DataFrame, columns: list, fill=None) -> pd.DataF
     fragmented" PerformanceWarning once per column, which floods the logs with thousands of
     identical lines on a no-coverage export (one burst per chunk that returned no survey
     resources). Building all missing columns at once and concatenating avoids that.
+
+    The concat runs on a positional index, so it is safe regardless of ``df``'s index:
+    ``final_df`` is indexed by AOI id, and a left-merge against metadata carrying duplicate
+    AOI ids would make that index non-unique — aligning the additions on it would
+    cartesian-explode the rows. The original index (duplicate labels and name included) is
+    restored on the result. Missing columns are filled with ``fill`` (default ``None``),
+    preserving the object dtype the downstream cross-chunk parquet schema unification relies
+    on (a float ``NaN`` column would clash with string metadata from populated chunks).
 
     Args:
         df: Frame to extend.
@@ -260,7 +268,10 @@ def _add_missing_columns(df: pd.DataFrame, columns: list, fill=None) -> pd.DataF
     missing = [col for col in columns if col not in df.columns]
     if not missing:
         return df
-    return pd.concat([df, pd.DataFrame({col: fill for col in missing}, index=df.index)], axis=1)
+    additions = pd.DataFrame({col: fill for col in missing}, index=range(len(df)))
+    result = pd.concat([df.reset_index(drop=True), additions], axis=1)
+    result.index = df.index
+    return result
 
 
 def _add_is_primary_column(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -90,6 +90,29 @@ class TestAddMissingColumns:
         result = _add_missing_columns(df, ["system_version"])
         assert result is df  # no-op, no needless copy
 
+    def test_non_unique_index_does_not_explode(self):
+        # final_df is indexed by aoi_id; a left-merge against metadata carrying duplicate
+        # aoi_ids makes that index non-unique. Backfill must not cartesian-explode the rows,
+        # and must preserve the original index (duplicate labels and name included).
+        df = pd.DataFrame(
+            {"area": [1, 2, 3, 4]},
+            index=pd.Index(["a", "a", "b", "c"], name=AOI_ID_COLUMN_NAME),
+        )
+        result = _add_missing_columns(df, self.META_COLUMNS)
+        assert len(result) == 4
+        assert list(result.index) == ["a", "a", "b", "c"]
+        assert result.index.name == AOI_ID_COLUMN_NAME
+        assert result["area"].tolist() == [1, 2, 3, 4]
+        for col in self.META_COLUMNS:
+            assert result[col].isna().all()
+
+    def test_added_columns_are_object_none_not_nan(self):
+        # Object None (not float NaN) keeps a no-coverage chunk schema-compatible with chunks
+        # that carry string metadata, so cross-chunk parquet unification doesn't clash.
+        result = _add_missing_columns(pd.DataFrame({"area": [1, 2]}), ["survey_id"])
+        assert result["survey_id"].dtype == object
+        assert result["survey_id"].iloc[0] is None
+
     def test_partial_backfill_preserves_present_values(self):
         df = self._fragmented_frame()
         with warnings.catch_warnings():


### PR DESCRIPTION
Follow-up to #196, which merged before this correctness fix was pushed. `main` currently has the buggy first cut.

## The bug in #196

`#196` replaced a per-column `final_df[col] = None` loop with `pd.concat([final_df, additions], axis=1)` where `additions` was indexed by `final_df.index`. But `final_df` is indexed by **aoi_id**, not a unique `RangeIndex` — `parcel_rollup` returns a frame keyed by aoi_id and the merge chain preserves it.

If `metadata_df` carries duplicate aoi_ids, the upstream left-merge makes that index **non-unique**, and `concat(axis=1)` then **cartesian-explodes the rows**. The per-column loop it replaced was index-agnostic and had no such failure mode, so #196 introduced a regression — on gridded exports in particular, the exact workload it was meant to help.

## Fix

- Concat the additions on a **positional** index, then restore the original index (duplicate labels and name included) — safe regardless of `final_df`'s index.
- Keep the fill as object `None` (not float `NaN`). `reindex(columns=...)` was rejected for this reason: a `NaN` column would clash with string metadata from populated chunks during cross-chunk parquet schema unification.

## Tests

Adds regression tests for the non-unique-index (no row explosion, index preserved) and object-`None`-not-`NaN` guarantees. `tests/test_exporter.py` passes (55 non-live + the live `test_process_chunk_au` exercising the real call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)