### PR TITLE
publish skill: add conda-forge feedstock step

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -78,10 +78,55 @@ Execute these steps in order, stopping if any step fails:
      - The release notes written in step 8 (use `--notes` with a heredoc)
      - Mark as pre-release if version contains 'a', 'b', or 'rc' (`--prerelease` flag)
 
+11. **Update the conda-forge feedstock** (downstream of PyPI — asynchronous)
+
+   nmaipy is also distributed on conda-forge via the feedstock at
+   `https://github.com/conda-forge/nmaipy-feedstock` (recipe: `recipe/recipe.yaml`,
+   `schema_version: 1` / rattler-build format). This step depends on the PyPI sdist already
+   being live and does **not** complete in the same session as the PyPI publish — treat it
+   as a follow-up to poll for, not a blocking step. Skip it entirely for pre-releases
+   (versions containing 'a', 'b', or 'rc'): conda-forge tracks stable releases only.
+
+   - **Wait for the autotick bot.** Within a few hours of the PyPI release the
+     `regro-cf-autotick-bot` opens a version-bump PR on the feedstock that updates only
+     `context.version` and `source.sha256` (a 2-line change). Find it with:
+     `gh pr list --repo conda-forge/nmaipy-feedstock`.
+     Do **not** upload to anaconda.org yourself — merging the feedstock PR is what makes
+     conda-forge CI build the `noarch: python` package and publish it to the channel.
+
+   - **Reconcile run dependencies — the bot does NOT do this.** This is the whole reason the
+     step exists: the bot bumps version + hash only, so a dependency added, removed, or
+     re-floored in nmaipy since the last conda release silently leaves the recipe wrong and
+     the conda package ships with the wrong deps. Compare the two sources of truth:
+       - nmaipy: `[project].dependencies` in `pyproject.toml`
+       - recipe: `requirements.run` in `recipe/recipe.yaml`
+
+     `grayskull pypi nmaipy==X.Y.Z` regenerates the run list from the published sdist
+     metadata if you'd rather diff against a fresh generation than eyeball it. If they
+     differ, push the fix to the bot's PR branch (the bot PR explicitly invites
+     "Feel free to push to the bot's branch"):
+     ```
+     gh repo clone conda-forge/nmaipy-feedstock
+     cd nmaipy-feedstock && git checkout <bot-branch>   # e.g. 5.0.17_h00a991, from the PR
+     # edit recipe/recipe.yaml requirements.run to match pyproject deps (conda spacing: "name >=x.y")
+     git commit -am "Sync run requirements with nmaipy X.Y.Z" && git push
+     ```
+     The recipe's `pip_check: true` test fails CI when a declared dep is missing, so a red CI
+     on the bot PR usually means a `run:` dep needs adding.
+
+   - **Merge on green CI.** You must be a listed maintainer
+     (`extra.recipe-maintainers` — currently `mbewley`, `bretttully`).
+
+   - **Manual fallback** if you can't wait for the bot: branch the feedstock, bump
+     `context.version` + `source.sha256` (sha256 of the PyPI sdist tarball) and the run-deps
+     in `recipe.yaml`, open a PR, merge once CI passes.
+
 ### Output
 
 Report the final status with links to:
 - PyPI package page
 - GitHub release page
+- conda-forge feedstock PR (note whether dependency edits were needed). This is
+  asynchronous and may still be open/pending when the rest of the release is done.
 
 **Note:** After the tag is pushed, a GitHub Actions workflow automatically runs to validate the release (runs tests, verifies version, attaches build artifacts to the release).


### PR DESCRIPTION
The `/publish` skill ended at PyPI + GitHub release and never mentioned conda-forge, so the conda package silently drifts from PyPI on every release.

## What this adds

A new **step 11 — Update the conda-forge feedstock** (`conda-forge/nmaipy-feedstock`, `recipe/recipe.yaml`, rattler-build schema v1), framed as the asynchronous, downstream follow-up it is:

- Wait for the `regro-cf-autotick-bot` version-bump PR (it changes only `version` + `sha256`); merging that PR — not a manual anaconda.org upload — is what builds + publishes to the channel.
- **Reconcile `requirements.run` against `pyproject.toml` `[project].dependencies`** — the bot never touches deps, so this is where the conda package goes wrong. Push edits to the bot's branch; `grayskull` can regenerate the list. `pip_check: true` in the recipe turns CI red on a missing dep.
- Merge on green CI (maintainers: `mbewley`, `bretttully`); manual fallback if the bot is slow.
- Skip for pre-releases.

## Why now

Concrete proof the step is needed: the live feedstock PR (#3 there) bumps 4.4.5 → 5.0.17 but the recipe `run:` list has no `boto3`, while nmaipy added `boto3>=1.40.0` (imported in `storage.py`). Merging the bot PR as-is would ship a broken conda package. This step would have flagged that.

Docs-only change to the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)