### PR TITLE
Release v5.0.18

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.17"
+__version__ = "5.0.18"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -248,18 +248,20 @@ def _add_missing_columns(df: pd.DataFrame, columns: list[str], fill=None) -> pd.
     identical lines on a no-coverage export (one burst per chunk that returned no survey
     resources). Building all missing columns at once and concatenating avoids that.
 
-    The concat runs on a positional index, so it is safe regardless of ``df``'s index:
-    ``final_df`` is indexed by AOI id, and a left-merge against metadata carrying duplicate
-    AOI ids would make that index non-unique — aligning the additions on it would
-    cartesian-explode the rows. The original index (duplicate labels and name included) is
-    restored on the result. Missing columns are filled with ``fill`` (default ``None``),
-    preserving the object dtype the downstream cross-chunk parquet schema unification relies
-    on (a float ``NaN`` column would clash with string metadata from populated chunks).
+    The concat runs on a positional index, so the result is correct for any input index —
+    unique or not, named or not — and the caller's original index (labels and name) is
+    restored unchanged. This matters because the caller may pass a frame whose index is
+    non-unique (``final_df`` is keyed by AOI id, which can repeat after a left-merge against
+    metadata carrying duplicate AOI ids); aligning the additions on a non-unique index
+    directly would cartesian-explode the rows. Missing columns are filled with ``fill``
+    (default ``None``), preserving the object dtype the downstream cross-chunk parquet schema
+    unification relies on (a float ``NaN`` column would clash with string metadata from
+    populated chunks).
 
     Args:
         df: Frame to extend.
         columns: Column names that must exist on the returned frame.
-        fill: Value used to populate any newly-added columns.
+        fill: Scalar value broadcast into any newly-added columns (default ``None``).
 
     Returns:
         ``df`` unchanged when all columns already exist, otherwise a new frame with the

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -113,6 +113,15 @@ class TestAddMissingColumns:
         assert result["survey_id"].dtype == object
         assert result["survey_id"].iloc[0] is None
 
+    def test_empty_frame_gets_columns_with_zero_rows(self):
+        # A fully-failed chunk (all Feature API requests errored) can reach the backfill with
+        # zero rows; the metadata columns must still be added so the chunk's schema is consistent.
+        df = pd.DataFrame({"area": pd.Series([], dtype="float64")})
+        result = _add_missing_columns(df, ["survey_id", "link"])
+        assert len(result) == 0
+        assert "survey_id" in result.columns
+        assert "link" in result.columns
+
     def test_partial_backfill_preserves_present_values(self):
         df = self._fragmented_frame()
         with warnings.catch_warnings():


### PR DESCRIPTION
Version bump for the **5.0.18** release.

Bundles the two commits already merged to `main` since 5.0.17:
- #196 — replace the per-column metadata backfill loop that flooded logs with pandas `PerformanceWarning` on no-coverage chunks.
- #197 — make that backfill index-agnostic (no row explosion on a non-unique aoi_id index) and object-`None` preserving.

No API or output-schema changes. Full test suite (incl. live API) + code review run as part of the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)