### PR TITLE
Skip re-uploading staged files already in S3 at the same size (5.0.20)

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.19"
+__version__ = "5.0.20"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -666,6 +666,12 @@ def _staged_file_needs_upload(local_size: int, remote_size: Optional[int]) -> bo
     ``features.parquet``, which is streamed and uploaded during consolidation;
     without the check, the per-class staging sweep re-pushes it in full
     (multi-hundred-GB) every run.
+
+    Size equality is the same staleness signal the downstream consumer's sync
+    uses. We don't checksum because S3's ETag isn't a portable hash for
+    multipart uploads, and a byte-identical accidental collision at this scale
+    is vanishingly unlikely; the rare case where it does happen is handled
+    manually rather than designed around.
     """
     return remote_size is None or remote_size != local_size
 
@@ -2967,12 +2973,18 @@ class NearmapAIExporter(BaseExporter):
                 # Skip files already in S3 at the same size. features.parquet is
                 # streamed + uploaded earlier but shares this staging dir, so an
                 # unconditional sweep would re-upload the whole file every run.
+                # Two S3 calls (file_exists then file_size) instead of one bare
+                # file_size + try/except is deliberate: file_exists carries the
+                # retry-on-transient-S3-read logic from storage.py, so a flaky
+                # HEAD doesn't get misread as "absent" and trigger a redundant
+                # multi-hundred-GB upload.
                 remote_size = storage.file_size(s3_path) if storage.file_exists(s3_path) else None
-                if not _staged_file_needs_upload(os.path.getsize(local_path), remote_size):
-                    self.logger.info(f"  Skipped {fname} (already in S3, same size)")
+                local_size = os.path.getsize(local_path)
+                if not _staged_file_needs_upload(local_size, remote_size):
+                    self.logger.info(f"  Skipped {fname} (already in S3, {local_size} bytes)")
                     continue
                 storage.upload_file(local_path, s3_path)
-                self.logger.info(f"  Uploaded {fname}")
+                self.logger.info(f"  Uploaded {fname} ({local_size} bytes)")
         else:
             for fname in staged_files:
                 src = os.path.join(staging_dir, fname)

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -657,6 +657,19 @@ def _reconcile_table_schema(table: pa.Table, ref_schema: pa.Schema) -> pa.Table:
     return pa.Table.from_arrays(arrays, schema=ref_schema)
 
 
+def _staged_file_needs_upload(local_size: int, remote_size: Optional[int]) -> bool:
+    """Whether a staged output file must be (re)uploaded to S3.
+
+    True unless an object of identical size already exists at the destination
+    (``remote_size`` is None when absent). This skips files that were uploaded
+    earlier but happen to share the per-class staging dir — notably
+    ``features.parquet``, which is streamed and uploaded during consolidation;
+    without the check, the per-class staging sweep re-pushes it in full
+    (multi-hundred-GB) every run.
+    """
+    return remote_size is None or remote_size != local_size
+
+
 # Raw RSI columns excluded from per-class output; the resolved
 # roof_spotlight_index/confidence/model_version columns are added separately.
 _EXCLUDE_RSI = {
@@ -2951,6 +2964,13 @@ class NearmapAIExporter(BaseExporter):
             for fname in staged_files:
                 local_path = os.path.join(staging_dir, fname)
                 s3_path = storage.join_path(self.final_path, fname)
+                # Skip files already in S3 at the same size. features.parquet is
+                # streamed + uploaded earlier but shares this staging dir, so an
+                # unconditional sweep would re-upload the whole file every run.
+                remote_size = storage.file_size(s3_path) if storage.file_exists(s3_path) else None
+                if not _staged_file_needs_upload(os.path.getsize(local_path), remote_size):
+                    self.logger.info(f"  Skipped {fname} (already in S3, same size)")
+                    continue
                 storage.upload_file(local_path, s3_path)
                 self.logger.info(f"  Uploaded {fname}")
         else:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -29,6 +29,7 @@ from nmaipy.exporter import (
     _per_class_chunk_regexes,
     _read_parquet_chunks_parallel,
     _resolve_prefetch_workers,
+    _staged_file_needs_upload,
     _unify_and_concat_tables,
     _write_errors_parquet,
 )
@@ -64,6 +65,28 @@ class TestResolvePrefetchWorkers:
     def test_scales_with_processes(self):
         # Dropping --processes shrinks the buffer; raising it reads further ahead.
         assert _resolve_prefetch_workers(4) < _resolve_prefetch_workers(8) < _resolve_prefetch_workers(16)
+
+
+class TestStagedFileNeedsUpload:
+    """``_staged_file_needs_upload`` skips staged files already in S3 at the same size.
+
+    Guards the per-class staging sweep against re-uploading features.parquet (streamed +
+    uploaded earlier, shares the staging dir) while still uploading new/changed files.
+    Pure function, no live API.
+    """
+
+    def test_absent_remote_uploads(self):
+        # No remote object yet -> must upload.
+        assert _staged_file_needs_upload(1000, None) is True
+
+    def test_same_size_skips(self):
+        # Identical size already in S3 -> skip (the features.parquet case).
+        assert _staged_file_needs_upload(636658449520, 636658449520) is False
+
+    def test_different_size_uploads(self):
+        # Size differs -> re-upload (changed / incomplete remote object).
+        assert _staged_file_needs_upload(1000, 999) is True
+        assert _staged_file_needs_upload(1000, 0) is True
 
 
 class TestAddMissingColumns:


### PR DESCRIPTION
## Summary

The per-class merge's final staging upload swept the staging dir with `os.listdir` and uploaded **every** `.parquet`/`.csv` unconditionally:

```python
staged_files = [f for f in os.listdir(staging_dir) if f.endswith((".parquet", ".csv"))]
for fname in staged_files:
    storage.upload_file(staging_dir/fname → S3)   # no skip check
```

`features.parquet` is streamed and uploaded earlier during consolidation, but it lives in that **same** staging dir — so the sweep re-uploaded the entire combined features file a second time. On large exports that's a redundant multi-hundred-GB push (observed ~80 min for a ~590 GB file) every run, on top of the original upload.

## Fix

Skip a staged file when an object of **identical size already exists** at the destination; upload everything else:

```python
remote_size = storage.file_size(s3_path) if storage.file_exists(s3_path) else None
if not _staged_file_needs_upload(os.path.getsize(local_path), remote_size):
    continue   # already in S3 at this size
storage.upload_file(...)
```

`_staged_file_needs_upload(local, remote)` returns `True` unless `remote == local`. This is the robust form of "don't re-push what's done": it never misses a new/changed file, and it auto-skips `features.parquet` (and any other already-uploaded file sharing the staging dir) with no hardcoded names — the same size-based criterion the downstream consumer's own sync uses.

## Tests
- `TestStagedFileNeedsUpload` (non-live): absent → upload, same-size → skip, different-size → upload.
- `pytest tests/test_exporter.py tests/test_constants.py -m "not live_api"` → 74 passed.

## Behaviour
No change for new/changed files. Eliminates the redundant re-upload of already-uploaded staged outputs (chiefly `features.parquet`). Bump 5.0.19 → 5.0.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)