### PR TITLE
Code-quality review sweep: error-budget fix, fast-path integrity, dead-code removal

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -75,7 +75,7 @@ Execute these steps in order, stopping if any step fails:
    - Use `gh release create` with:
      - Tag name (vX.Y.Z)
      - Title (vX.Y.Z)
-     - The release notes written in step 8 (use `--notes` with a heredoc)
+     - The release notes written in step 9 (use `--notes` with a heredoc)
      - Mark as pre-release if version contains 'a', 'b', or 'rc' (`--prerelease` flag)
 
 11. **Update the conda-forge feedstock** (downstream of PyPI — asynchronous)

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ tests/data/cache/*
 
 # Test artifacts
 test_pip_install.py
-tests/data/integration_test_output/chunks/
-tests/data/integration_test_output/final/
+tests/data/integration_test_output/
 
 # Local run scripts (developer convenience, not tracked)
 run.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,23 +262,35 @@ When adding new columns derived from API descriptions, always use the programmat
 ### Output Layer
 
 16. **readme_generator.py**: `ReadmeGenerator` class
-    - Auto-generates a data dictionary `README.md` in export output directories
-    - Discovers files present, generates tables of file descriptions and column patterns
+    - Auto-generates a customer-readable `README.md` in export output directories
+    - Lists files via the `output_files` registry; column descriptions come from `column_metadata.lookup_column()`
     - Reads `export_config.json` to detect country (for area units) and selection method
     - Works with both local and S3 output directories
 
+17. **column_metadata.py**: Column metadata loader and lookup
+    - Single source of truth for column descriptions, used by both the README generator and the data dictionary generator
+    - `lookup_column()`: Resolves a column name (including scope prefixes like `primary_roof_`) to its metadata
+    - Reads from `nmaipy/data/column_metadata.json` (+ `column_metadata_overrides.json`), which the PM edits when descriptions need refining
+
+18. **output_files.py**: Registry of files the exporter produces
+    - `FileSpec` entries describe each output file; `kind` (`ai_data`/`geometry`/`operational`/`config`) drives whether a file gets a data dictionary and/or a README listing
+    - Consumed by `readme_generator` and `data_dictionary_generator` so output file metadata lives in one place
+
+19. **data_dictionary_generator.py**: Per-file data dictionaries
+    - Generates `<filename>_data_dictionary.csv` next to every tabular `ai_data` output in `final/`
+    - Columns looked up via `column_metadata.lookup_column()`; user input columns are recognised by header-matching against the input AOI file
+
 ### Legacy/Internal
 
-17. **coverage_utils.py**: Legacy coverage API utilities
+20. **coverage_utils.py**: Legacy coverage API utilities
     - Survey coverage point queries and threading
     - Not integrated with current `BaseApiClient` architecture (uses its own `requests.Session`)
 
-18. **reference_code.py**: Minimal utility
+21. **reference_code.py**: Minimal utility
     - `is_building_small()`: Checks building area < 30 sqm
 
 ### Configuration Files
 
-- **config.json** (repo root): Per-feature-class filtering thresholds, keyed by class UUID. Fields: `min_size` (m²), `min_confidence`, `min_fidelity`, `min_area_in_parcel` (m²), `min_ratio_in_parcel`. Applied during parcel rollup processing in `parcels.py`.
 - **pyproject.toml**: Package metadata, dependencies, build config. Python >=3.12 required.
 - **environment.yaml** / **environment-minimal.yaml**: Conda environment specifications.
 
@@ -288,12 +300,12 @@ When adding new columns derived from API descriptions, always use the programmat
 2. The exporter loads the AOI file via `aoi_io.read_from_file()` and divides work into chunks
 3. Chunks are processed in parallel via `ProcessPoolExecutor` with API warmup ramp-up
 4. For each AOI, the Feature API (and optionally Roof Age API) fetches relevant AI features
-5. Features are filtered based on intersection with AOI boundaries and `config.json` thresholds
+5. Features are filtered based on intersection with AOI boundaries
 6. For large AOIs (>1 sq km), the system automatically grids them and merges/deduplicates results
 7. Results are summarized into rollup statistics and/or saved as feature data per chunk
 8. Chunks are merged into final output files (rollup CSV/Parquet, per-class files, GeoParquet)
 9. For S3 output, per-process local staging is used for formats requiring local I/O before uploading
-10. A `README.md` data dictionary is auto-generated in `final/` by `ReadmeGenerator`
+10. A customer-readable `README.md` is auto-generated in `final/` by `ReadmeGenerator`, plus a `<filename>_data_dictionary.csv` next to each tabular AI-data output by `data_dictionary_generator`
 
 ### Resource tuning (`--processes` and `--chunk-size`)
 
@@ -309,7 +321,7 @@ Memory monitoring reports the working set (`memory.current − inactive_file`), 
 
 Operationally: start with the defaults, watch the working-set figure in the tqdm postfix during a real export, and tune `--processes` first (linear effect on both stages, no surprises) before reaching for `--chunk-size`.
 
-For the retry / backoff / gridding strategy these dials sit on top of, see `docs/retry-and-gridding.md`.
+For the retry / backoff / gridding strategy these dials sit on top of, see `RetryRequest` and `GriddedApiClient` in `nmaipy/api_common.py`. (A standalone engineering doc, `docs/retry-and-gridding.md`, is drafted but deliberately held back from the repo until reviewed — see commit 256f1b4.)
 
 ### API Authentication
 

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -17,11 +17,9 @@ import logging
 import os
 import random
 import re
-import ssl
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
-from http.client import RemoteDisconnected
 from itertools import takewhile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -30,7 +28,6 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import requests
-import urllib3
 from dotenv import load_dotenv
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -174,40 +171,28 @@ def format_error_summary_table(status_counts, message_counts, max_message_len=16
 
 class RetryRequest(Retry):
     """
-    Extended retry strategy with full-jitter backoff, first-retry logging, and broader exception coverage.
+    Extended retry strategy with full-jitter backoff and first-retry logging.
 
     Implements full jitter: sleep = uniform(0, min(backoff_max, backoff_factor * 2^n)).
     Jitter scales with retry count — fast recovery on early retries, strong desynchronisation
     on late retries (thundering herd prevention for parallel exports).
+
+    Which statuses/exceptions are retried is controlled by the ``status_forcelist``
+    passed at construction (see ``BaseApiClient._session_scope``) plus urllib3's
+    built-in handling of connection/read errors.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Add all connection-related errors to retry on
+        # Statuses whose Retry-After header is honoured (urllib3 consults this in
+        # is_retry/sleep). Deliberately excludes 413 (urllib3's default includes it):
+        # 413 means the AOI is too large and triggers gridding, not a retry.
         self.RETRY_AFTER_STATUS_CODES = frozenset(
             {
                 HTTPStatus.TOO_MANY_REQUESTS,  # 429
                 HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
                 HTTPStatus.BAD_GATEWAY,  # 502
                 HTTPStatus.SERVICE_UNAVAILABLE,  # 503
-            }
-        )
-
-        # Add connection errors that should trigger retries
-        self.RETRY_ON_EXCEPTIONS = frozenset(
-            {
-                requests.exceptions.ChunkedEncodingError,
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ReadTimeout,
-                RemoteDisconnected,  # From http.client
-                requests.exceptions.ProxyError,
-                requests.exceptions.SSLError,
-                urllib3.exceptions.SSLError,  # Added to catch SSL errors from urllib3
-                requests.exceptions.Timeout,
-                urllib3.exceptions.ProtocolError,
-                EOFError,  # Sometimes occurs with RemoteDisconnected
-                ConnectionResetError,  # Python built-in exception
-                ssl.SSLEOFError,  # Explicit SSL EOF error
             }
         )
 
@@ -425,8 +410,10 @@ class BaseApiClient:
             threads: Number of threads for concurrent execution
             maxretry: Number of retries for failed requests
         """
-        # Initialize thread-safety attributes
-        self._sessions = []
+        # Initialize thread-safety attributes. _adapters tracks every pooled
+        # HTTPAdapter handed out by _session_scope (sessions themselves are
+        # created fresh per request and closed in _session_scope's finally).
+        self._adapters = []
         self._thread_local = threading.local()
         self._lock = threading.Lock()
 
@@ -482,7 +469,7 @@ class BaseApiClient:
         self.cleanup()
 
     def cleanup(self):
-        """Clean up all sessions and cached adapters"""
+        """Close all pooled HTTP adapters and clear the thread-local adapter cache"""
         # Drain any pending per-thread progress buffers first so the displayed
         # counter catches up before the worker process exits. Diagnostic only —
         # never let it fail cleanup if the shared Manager.Lock is already gone.
@@ -491,24 +478,24 @@ class BaseApiClient:
         except Exception:
             pass
 
-        if hasattr(self, "_lock") and hasattr(self, "_sessions"):
+        if hasattr(self, "_lock") and hasattr(self, "_adapters"):
             with self._lock:
-                for session in self._sessions:
+                for adapter in self._adapters:
                     try:
-                        session.close()
+                        adapter.close()
                     except Exception:
                         pass
-                self._sessions.clear()
+                self._adapters.clear()
         else:  # Fallback if attributes don't exist
-            if hasattr(self, "_sessions"):
-                for session in self._sessions:
+            if hasattr(self, "_adapters"):
+                for adapter in self._adapters:
                     try:
-                        session.close()
+                        adapter.close()
                     except Exception:
                         pass
-                self._sessions.clear()
+                self._adapters.clear()
         # Clear thread-local adapter cache (only affects calling thread,
-        # but other threads' adapters are already closed via self._sessions above)
+        # but other threads' adapters are already closed via self._adapters above)
         if hasattr(self, "_thread_local") and hasattr(self._thread_local, "adapters"):
             self._thread_local.adapters.clear()
 
@@ -636,7 +623,7 @@ class BaseApiClient:
             )
             self._thread_local.adapters[cache_key] = adapter
             with self._lock:
-                self._sessions.append(adapter)  # Track for cleanup
+                self._adapters.append(adapter)  # Track for cleanup
 
         # Fresh session per request — prevents state accumulation (cookies, auth, etc.)
         session = requests.Session()

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -447,8 +447,11 @@ def lookup_column(
         if templated != name and templated in exact:
             return _instantiate(exact[templated], area_unit=area_unit, class_label=class_label, extra_groups=extras)
 
-    # 2. Scope-stripped exact match.
-    for scope_prefix in _SCOPE_PHRASES:
+    # 2. Scope-stripped exact match. Longest prefix first, so e.g.
+    # "primary_roof_instance_" wins over "primary_roof_" for
+    # primary_roof_instance_* columns rather than relying on the wrong
+    # remainder failing to resolve.
+    for scope_prefix in sorted(_SCOPE_PHRASES, key=len, reverse=True):
         if not name.startswith(scope_prefix):
             continue
         remainder = name[len(scope_prefix) :]

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -826,8 +826,9 @@ def _compute_all_per_class_data(
     then calls _compute_feature_class_data() for each class. Returns a dict of
     {class_id: {"tabular": pa.Table, "geo": pa.Table}}.
 
-    This is the shared core used by both process_chunk() (in-memory path) and
-    _merge_per_class_chunks() (fallback recomputation path).
+    This is the per-class computation core called from process_chunk() while the
+    chunk's feature data is still in memory; _merge_per_class_chunks() later
+    concatenates the resulting chunk files without recomputing.
 
     Args:
         threads: number of worker threads for the per-class loop. Defaults to 1
@@ -1034,6 +1035,12 @@ def _compute_feature_class_data(
         non_roof_features: Pre-filtered non-roof features
         roof_instance_features: Pre-filtered roof instance features
         roof_attrs_cache: Pre-computed dict mapping roof feature_id to flattened attribute dicts
+        parent_lookup: Pre-built dict mapping feature_id to feature record, for parent-chain
+            traversal (rebuilt from features_gdf if not provided)
+        roof_to_building_lookup: Pre-built dict mapping roof feature_id to parent building
+            feature_id (rebuilt via link_roofs_to_buildings if not provided)
+        roofs_linked: Pre-linked roof features (output of link_roofs_to_buildings)
+        buildings_linked: Pre-linked building features (output of link_roofs_to_buildings)
 
     Returns:
         Tuple of (flat_df, geo_gdf) where flat_df is the tabular DataFrame and
@@ -1352,9 +1359,6 @@ def _compute_feature_class_data(
 
         # Resolve best scores (peril scores, defensible space) per roof via BL fallback.
         try:
-            bl_in_features = (
-                BUILDING_LIFECYCLE_ID in features_gdf["class_id"].values if features_gdf is not None else False
-            )
             if bl_in_features:
                 roof_records_for_scores = _dataframe_to_records_with_index(class_features)
 
@@ -2843,8 +2847,6 @@ class NearmapAIExporter(BaseExporter):
 
     def _merge_per_class_chunks(
         self,
-        primary_ids_df: pd.DataFrame,
-        aoi_input_columns: list,
         tabular_file_format: str = "parquet",
         requested_class_ids: set = None,
     ):
@@ -2854,9 +2856,9 @@ class NearmapAIExporter(BaseExporter):
         reads them as Arrow tables, concatenates via _unify_and_concat_tables(),
         and writes the final files to final/.
 
-        If per-class chunk files are missing for some chunks (e.g. old exports,
-        or per-class computation failed), falls back to recomputing from the
-        corresponding feature chunk file.
+        Classes with no per-class chunk files (e.g. old exports, or per-class
+        computation failed) are skipped with a warning; regenerating requires
+        deleting the rollup chunk files and re-running the export.
         """
         whitelisted_classes = sorted(PER_CLASS_FILE_CLASS_IDS)
         if requested_class_ids is not None:
@@ -4196,10 +4198,7 @@ class NearmapAIExporter(BaseExporter):
                         data["geometry"] = data.geometry.to_wkt()
                 data.to_csv(outpath, index=True)
 
-        # Extract only the primary feature ID columns needed for is_primary marking,
-        # then free the full rollup DataFrame to reduce peak memory during per-class export.
-        primary_cols = [c for c in PRIMARY_FEATURE_COLUMN_TO_CLASS if c in data.columns]
-        primary_ids_df = data[primary_cols].copy() if primary_cols else pd.DataFrame()
+        # Free the full rollup DataFrame to reduce peak memory during per-class export.
         del data
         gc.collect()
 
@@ -4347,20 +4346,7 @@ class NearmapAIExporter(BaseExporter):
         # Per-class data was computed in process_chunk() while feature data was still
         # in memory, avoiding the expensive re-read of features.parquet.
         if self.class_level_files:
-            # Compute aoi_input_columns from the AOI GeoDataFrame.
-            system_columns = {
-                AOI_ID_COLUMN_NAME,
-                "geometry",
-                SINCE_COL_NAME,
-                UNTIL_COL_NAME,
-                SURVEY_RESOURCE_ID_COL_NAME,
-                "query_aoi_lat",
-                "query_aoi_lon",
-            }
-            aoi_input_columns = [c for c in aoi_gdf.columns if c not in system_columns and c not in ADDRESS_FIELDS]
             self._merge_per_class_chunks(
-                primary_ids_df=primary_ids_df,
-                aoi_input_columns=aoi_input_columns,
                 tabular_file_format=self.tabular_file_format,
                 requested_class_ids=set(classes_df.index),
             )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -3878,6 +3878,12 @@ class NearmapAIExporter(BaseExporter):
                     f"README.md present at {readme_path} but export config has changed "
                     f"since the prior run ({changed}). Rebuilding."
                 )
+                # Remove the stale sentinel now: __init__ has already overwritten
+                # export_config.json with the current params, so if this rebuild
+                # dies before re-writing README.md, a re-invocation would see an
+                # empty config diff plus the old README and incorrectly fast-path
+                # back to the previous config's output.
+                storage.remove_file(readme_path)
 
         # Process a single AOI file
         aoi_path = self.aoi_file

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1930,14 +1930,13 @@ class FeatureApi(GriddedApiClient):
                     if len(aoi_metadata) > 0:
                         metadata.append(aoi_metadata)
                 if aoi_error is not None:
+                    errors.append(aoi_error)
                     if len(errors) > max_allowed_error_count:
                         executor.shutdown(wait=True)
                         logger.debug(
                             f"Exceeded maximum error count of {max_allowed_error_count} out of {len(gdf)} AOIs."
                         )
                         raise AIFeatureAPIError(aoi_error, aoi_error["request"])
-                    else:
-                        errors.append(aoi_error)
                 # Collect grid cell errors (partial failures with geometry)
                 if aoi_grid_errors is not None and len(aoi_grid_errors) > 0:
                     grid_errors.append(aoi_grid_errors)

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1045,6 +1045,8 @@ class FeatureApi(GriddedApiClient):
             - features_gdf: GeoDataFrame with combined features from all grid cells, or None if error
             - metadata: Dictionary with survey metadata, or None if error
             - error: Dictionary with error details if gridding failed, None if successful
+            - grid_errors_df: DataFrame of per-grid-cell errors (with cell geometry) when the AOI
+              succeeded partially, or None
         """
         try:
             # Use the provided aoi_grid_inexact parameter, or fall back to the instance default
@@ -1166,7 +1168,7 @@ class FeatureApi(GriddedApiClient):
         in_gridding_mode: bool = False,
         param_dic: Optional[Dict[str, str]] = None,
         disable_parcel_mode: bool = False,
-    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[dict], Optional[dict]]:
+    ) -> Tuple[Optional[gpd.GeoDataFrame], Optional[dict], Optional[dict], Optional[pd.DataFrame]]:
         """
         Get feature data for an AOI. If a cache is configured, the cache will be checked before using the API.
         Data is returned as a GeoDataframe with response metadata and error information (if any occurred).
@@ -1188,7 +1190,8 @@ class FeatureApi(GriddedApiClient):
                               AIFeatureAPIRequestSizeError
             param_dic: Optional dictionary of custom parameters to add to the API request
         Returns:
-            API response features GeoDataFrame, metadata dictionary, and an error dictionary
+            API response features GeoDataFrame, metadata dictionary, an error dictionary, and a
+            DataFrame of per-grid-cell errors (None unless the AOI was gridded and partially failed)
         """
         if geometry is None and address_fields is None:
             raise ValueError(
@@ -1432,7 +1435,8 @@ class FeatureApi(GriddedApiClient):
             grid_size: The AOI is gridded in the native projection (constants.API_CRS) to save compute.
 
         Returns:
-            API response features GeoDataFrame, metadata dictionary, and an error dictionary
+            API response features GeoDataFrame, metadata DataFrame, and an errors DataFrame
+            (per-grid-cell errors with cell geometry, marked failure_type="grid")
         """
         # Acquire semaphore to limit concurrent gridding operations
         # This prevents too many file handles being opened simultaneously

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -207,7 +207,7 @@ class FeatureApi(GriddedApiClient):
                 returns populated scores. Aggregate DS is parcel-mode-only and stays null.
         """
         # Call parent class initialization
-        # GriddedApiClient handles: thread-safety (_sessions, _thread_local, _lock),
+        # GriddedApiClient handles: thread-safety (_adapters, _thread_local, _lock),
         # API key validation, cache setup, latency tracking, and gridding semaphore
         super().__init__(
             api_key=api_key,
@@ -1947,7 +1947,7 @@ class FeatureApi(GriddedApiClient):
                 self._thread_local.executor = None
                 # Skip cleanup in gridding mode — gridding runs inside a parent
                 # executor thread, and cleanup() would close all threads' cached
-                # adapters (shared via self._sessions), breaking connection reuse.
+                # adapters (shared via self._adapters), breaking connection reuse.
                 if not in_gridding_mode:
                     self.cleanup()
 

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -1155,6 +1155,15 @@ def feature_attributes(
                         geometry_projected_col=geometry_projected_col,
                         projected_crs=projected_crs,
                     )
+                if primary_feature is None:
+                    # select_primary with method="nearest" may find no suitable
+                    # feature (all small, or none within tolerance). Fill the
+                    # same defaults as the no-features case above.
+                    parcel[f"primary_{name}_area_{area_units}"] = 0.0
+                    parcel[f"primary_{name}_clipped_area_{area_units}"] = 0.0
+                    parcel[f"primary_{name}_unclipped_area_{area_units}"] = 0.0
+                    parcel[f"primary_{name}_confidence"] = None
+                    continue
                 if country in IMPERIAL_COUNTRIES:
                     parcel[f"primary_{name}_area_sqft"] = round(primary_feature.area_sqft, 1)
                     parcel[f"primary_{name}_clipped_area_sqft"] = round(primary_feature.clipped_area_sqft, 1)

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -24,6 +24,7 @@ Note: The Roof Age API is currently available for US properties only.
 import argparse
 import sys
 import time
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -429,8 +430,6 @@ class RoofAgeExporter(BaseExporter):
 
         except Exception as e:
             logger.error(f"Chunk {chunk_id} failed: {e}")
-            import traceback
-
             traceback.print_exc()
             raise
 
@@ -479,7 +478,9 @@ class RoofAgeExporter(BaseExporter):
         self.logger.info(f"Loaded {len(aoi_gdf)} AOIs")
 
         # Split into chunks and process in parallel (using BaseExporter methods)
-        chunks_to_process, skipped_chunks, skipped_aois, _ = self.split_into_chunks(aoi_gdf, check_cache=True)
+        chunks_to_process, skipped_chunks, skipped_aois, num_chunks = self.split_into_chunks(
+            aoi_gdf, check_cache=True
+        )
 
         initial_aoi_count = len(aoi_gdf) - skipped_aois
         latency_csv_path = storage.join_path(self.final_path, "latency_stats.csv")
@@ -510,9 +511,8 @@ class RoofAgeExporter(BaseExporter):
         metadata_list = []
         errors_list = []
 
-        # Calculate total number of chunks (including cached ones)
-        num_chunks = max(len(aoi_gdf) // self.chunk_size, 1)
-
+        # num_chunks (including cached chunks) comes from split_into_chunks so the
+        # combine loop iterates exactly the chunk count the files were written with.
         for i in range(num_chunks):
             chunk_id = str(i).zfill(4)
 
@@ -675,7 +675,9 @@ class RoofAgeExporter(BaseExporter):
                 columns_to_save = [col for col in public_fields if col in roofs_df.columns]
                 roofs_df = roofs_df[columns_to_save]
 
-                roofs_df.to_csv(roofs_path, index=True)
+                # aoi_id is already a column (matching the geoparquet output above);
+                # the RangeIndex would be a vestigial unnamed column in the CSV.
+                roofs_df.to_csv(roofs_path, index=False)
         else:
             self.logger.warning("No roof data to save")
 
@@ -720,8 +722,6 @@ def main():
         exporter.run()
     except Exception as e:
         logger.error(f"Export failed: {e}")
-        import traceback
-
         traceback.print_exc()
         sys.exit(1)
 

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -478,9 +478,7 @@ class RoofAgeExporter(BaseExporter):
         self.logger.info(f"Loaded {len(aoi_gdf)} AOIs")
 
         # Split into chunks and process in parallel (using BaseExporter methods)
-        chunks_to_process, skipped_chunks, skipped_aois, num_chunks = self.split_into_chunks(
-            aoi_gdf, check_cache=True
-        )
+        chunks_to_process, skipped_chunks, skipped_aois, num_chunks = self.split_into_chunks(aoi_gdf, check_cache=True)
 
         initial_aoi_count = len(aoi_gdf) - skipped_aois
         latency_csv_path = storage.join_path(self.final_path, "latency_stats.csv")

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -376,7 +376,7 @@ def move_file(src: str, dst: str) -> None:
         os.replace(src, dst)
 
 
-def read_json(path: str, compressed: bool = False) -> Optional[Dict]:
+def read_json(path: str, compressed: bool = False) -> Dict:
     """
     Read a JSON file, optionally gzip-compressed. Works for both local and S3.
 
@@ -385,7 +385,11 @@ def read_json(path: str, compressed: bool = False) -> Optional[Dict]:
         compressed: If True, read as gzip-compressed JSON
 
     Returns:
-        Parsed JSON data, or None on failure
+        Parsed JSON data.
+
+    Raises:
+        OSError / json.JSONDecodeError on missing or unparseable files —
+        callers that tolerate failure wrap this in their own try/except.
     """
     if compressed:
         with open_file(path, "rb") as raw_f:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1289,6 +1289,38 @@ class TestSkipRebuildWhenReadmeExists:
             with pytest.raises(RuntimeError, match="got past fast-path"):
                 exporter2.run()
 
+    def test_stale_readme_removed_when_config_changed_rebuild_crashes(self, tmp_path):
+        """A config-change rebuild must remove the old README sentinel up front.
+
+        __init__ overwrites export_config.json with the current params before
+        _run_inner runs, so if the rebuild dies mid-way and the old README were
+        left in place, the next invocation would see an empty config diff plus
+        the README and incorrectly fast-path back to the previous config's output.
+        """
+        AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="au",
+            packs=["building"],
+        )
+        (tmp_path / "final" / "README.md").write_text("# done")
+
+        exporter2 = AOIExporter(
+            aoi_file="data/examples/sydney_parcels.geojson",
+            output_dir=str(tmp_path),
+            country="us",
+            packs=["building"],
+        )
+
+        with patch("nmaipy.exporter.FeatureApi", side_effect=RuntimeError("simulated mid-rebuild crash")):
+            with pytest.raises(RuntimeError, match="simulated mid-rebuild crash"):
+                exporter2.run()
+
+        assert not (tmp_path / "final" / "README.md").exists(), (
+            "Stale README sentinel must be removed when a config-change rebuild starts, "
+            "otherwise a crashed rebuild leaves a false 'complete' marker"
+        )
+
     def test_fast_path_skipped_when_packs_changed(self, tmp_path):
         """Packs change → rebuild even though README is present."""
         AOIExporter(

--- a/tests/test_feature_api.py
+++ b/tests/test_feature_api.py
@@ -1256,6 +1256,75 @@ class TestBulkUnexpectedErrorHandling:
         assert "simulated unexpected failure" in failed["message"]
 
 
+class TestMaxAllowedErrorBudget:
+    """Pin the exact error-budget boundary in _get_features_gdf_bulk_inner.
+
+    Regression guard: the budget check used to run before appending the current
+    error, so the effective tolerance was max_allowed_error_count + 1 — with
+    50% allowed errors on 2 AOIs, 100% failure was tolerated, defeating the
+    floor() logic that exists to guarantee at least one success.
+    """
+
+    @staticmethod
+    def _aoi_gdf():
+        aoi_a = Polygon([(0, 0), (0.001, 0), (0.001, 0.001), (0, 0.001), (0, 0)])
+        aoi_b = Polygon([(1, 1), (1.001, 1), (1.001, 1.001), (1, 1.001), (1, 1)])
+        return gpd.GeoDataFrame(
+            [
+                {AOI_ID_COLUMN_NAME: "a", "geometry": aoi_a},
+                {AOI_ID_COLUMN_NAME: "b", "geometry": aoi_b},
+            ],
+            crs=API_CRS,
+        ).set_index(AOI_ID_COLUMN_NAME)
+
+    @staticmethod
+    def _error_dict(aoi_id):
+        return {
+            AOI_ID_COLUMN_NAME: aoi_id,
+            "status_code": 404,
+            "message": "No coverage",
+            "text": "No coverage",
+            "request": "http://test/request",
+            "failure_type": "api",
+        }
+
+    def test_errors_within_budget_are_returned(self, monkeypatch):
+        """One failure out of 2 AOIs with 50% allowed (budget = 1) must not raise."""
+        feature_api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+        good_features = gpd.GeoDataFrame(
+            [{AOI_ID_COLUMN_NAME: "a", "geometry": Polygon([(0, 0), (1, 0), (1, 1), (0, 0)]), "class_id": "x"}],
+            crs=API_CRS,
+        ).set_index(AOI_ID_COLUMN_NAME)
+        good_metadata = {AOI_ID_COLUMN_NAME: "a", "survey_date": "2025-01-01"}
+
+        def fake_get_features_gdf(self, *args, **kwargs):
+            if kwargs.get("aoi_id") == "b":
+                return None, None, TestMaxAllowedErrorBudget._error_dict("b"), None
+            return good_features, good_metadata, None, None
+
+        monkeypatch.setattr(FeatureApi, "get_features_gdf", fake_get_features_gdf)
+
+        features_gdf, metadata_df, errors_df = feature_api.get_features_gdf_bulk(
+            self._aoi_gdf(), region="au", packs=["building"], max_allowed_error_pct=50
+        )
+        assert "a" in features_gdf.index
+        assert len(errors_df) == 1
+
+    def test_exceeding_budget_raises(self, monkeypatch):
+        """Two failures out of 2 AOIs with 50% allowed (budget = 1) must raise."""
+        feature_api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+
+        def fake_get_features_gdf(self, *args, **kwargs):
+            return None, None, TestMaxAllowedErrorBudget._error_dict(kwargs.get("aoi_id")), None
+
+        monkeypatch.setattr(FeatureApi, "get_features_gdf", fake_get_features_gdf)
+
+        with pytest.raises(AIFeatureAPIError):
+            feature_api.get_features_gdf_bulk(
+                self._aoi_gdf(), region="au", packs=["building"], max_allowed_error_pct=50
+            )
+
+
 if __name__ == "__main__":
     current_file = os.path.abspath(__file__)
     sys.exit(pytest.main([current_file]))


### PR DESCRIPTION
## Summary

Fresh-eyes review sweep across the whole package (exporter, API clients, data-processing, infra/output layers, docs/skills). Three behavioral bug fixes, the rest is dead-code removal, doc drift, and consistency cleanups. Patch-level: no API or output-schema changes beyond the fixes below.

## Bug fixes

- **`max_allowed_error_pct` enforced exactly** (`feature_api.py`): the bulk error-budget check ran *before* appending the current error, so the effective tolerance was `max_allowed_error_count + 1`. With `aoi_grid_min_pct=100` (budget 0) a failing grid cell was still tolerated, and 50 AOIs at 99% allowed errors could fail 100% — exactly the case the `floor()` comment above the calculation exists to prevent. New regression test pins both sides of the boundary.
- **Stale fast-path sentinel on config-change rebuild** (`exporter.py`): `__init__` overwrites `export_config.json` before `_run_inner` runs, so a config-change rebuild that crashed mid-way left the *old* `README.md` in place; the next invocation saw an empty config diff + README and fast-pathed back to output produced under the old config. The sentinel is now deleted as soon as a rebuild is triggered. New test simulates the mid-rebuild crash.
- **`--primary-decision nearest` crash guard** (`parcels.py`): `select_primary(method="nearest")` documents that it may return `None` (all features small, or none within tolerance), and `nearest` is a selectable CLI value — but the generic per-class rollup path dereferenced the result unconditionally (`AttributeError` kills the chunk). Now fills the same defaults as the zero-features branch.

## Cleanups

- **`api_common.py`**: removed `RETRY_ON_EXCEPTIONS` — urllib3 has no such hook, so the frozenset (and its `ssl`/`RemoteDisconnected`/`urllib3` imports) was dead; retry coverage genuinely comes from `status_forcelist`. Documented what `RETRY_AFTER_STATUS_CODES` actually controls (Retry-After honouring; deliberately excludes 413, which must trigger gridding). Renamed `_sessions` → `_adapters` — it holds pooled `HTTPAdapter`s, not Sessions.
- **`exporter.py`**: dropped dead `primary_ids_df`/`aoi_input_columns` params from `_merge_per_class_chunks` (they fed a recompute fallback that no longer exists), including the rollup-column `.copy()` spent purely on the dead param; deduped a twice-computed `bl_in_features`; corrected stale docstrings.
- **`feature_api.py`**: corrected 3-tuple → 4-tuple return docstrings/type hints (`get_features_gdf`, `_attempt_gridding`, `get_features_gdf_gridded`).
- **`column_metadata.py`**: scope-prefix lookup now matches longest-first (`primary_roof_instance_` before `primary_roof_`), matching what `readme_generator` already does, instead of relying on the wrong remainder failing to resolve.
- **`roof_age_exporter.py`**: `roofs.csv` no longer writes a vestigial RangeIndex column (geoparquet sibling already writes `index=False`; `metadata.csv`/`errors.csv` keep their meaningful `aoi_id` index); chunk-combine loop reuses the chunk count from `split_into_chunks` instead of recomputing it from a different frame; in-function `import traceback` moved to top.
- **`storage.py`**: `read_json` docstring claimed "None on failure" but it raises (callers already rely on that) — contract documented correctly.
- **CLAUDE.md / publish skill**: removed the stale `config.json` thresholds section (that system no longer exists in code), documented the three missing modules (`column_metadata`, `output_files`, `data_dictionary_generator`), fixed the dangling `docs/retry-and-gridding.md` reference (doc deliberately held back in 256f1b4), fixed step-numbering drift in the publish skill.

## Reviewed but deliberately not changed

- `flatten_building_attributes`/`flatten_roof_attributes` hard-key access (`attribute["height"]`, `component["areaSqm"]`) — would be defensive fallbacks against API responses we currently treat as guaranteed; flagging rather than softening preconditions.
- Latency histogram p99 returns the 60s bucket lower bound when the tail lands in the `inf` bucket — known representation limit, not fixable without changing the histogram.
- `coverage_utils.py` module-level shared `requests.Session` across threads — legacy module, no current callers.
- Roof Age per-page latency vs per-call cache-miss accounting divergence from Feature API conventions — doc-note territory.
- `environment.yaml` / `pyproject.toml` explicit-dependency asymmetry (`rtree`, `pyogrio`) — installs fine either way.

## Testing

- Full non-live suite: **685 passed, 11 skipped**
- New regression tests: error-budget boundary (2), crashed config-change rebuild (1)
- `black -l 120` + `isort` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)