### PR TITLE
perf: per-class merge progress bars + tunable merge concurrency (5.0.23b1)

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -47,8 +47,9 @@ Execute these steps in order, stopping if any step fails:
    - This catches issues that may have bypassed proper PR review
 
 6. **Determine release path**
-   - If on a feature branch (not main/master): Create a PR to main
-   - If on main/master or PR already merged: Proceed to release
+   - If on a feature branch (not main/master): create the PR to main and wait for it to merge.
+   - Once the PR is merged (or if it already was): **`git checkout main && git pull`** so the tag in step 9 lands on the merge commit, not the branch tip.
+   - Always build, tag, and release from an up-to-date `main` — never from the feature branch.
 
 7. **Build and publish to PyPI**
    - Clean old builds: `rm -rf dist/ build/ *.egg-info`
@@ -56,11 +57,7 @@ Execute these steps in order, stopping if any step fails:
    - Verify: `twine check dist/*`
    - Upload: `twine upload dist/*`
 
-8. **Tag and push**
-   - Create annotated tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
-   - Push tag: `git push origin vX.Y.Z`
-
-9. **Write release notes**
+8. **Write release notes** (do this *before* pushing the tag, so they're ready to apply in step 10)
    - Review all changes since last release: `git log $(git describe --tags --abbrev=0)..HEAD --oneline`
    - Write comprehensive release notes covering:
      - **What's New**: One sentence summary of the release
@@ -71,12 +68,18 @@ Execute these steps in order, stopping if any step fails:
    - Present draft release notes to user for review before creating the release
    - Do NOT just use `--generate-notes` alone - that only shows commit titles
 
-10. **Create GitHub release**
-   - Use `gh release create` with:
-     - Tag name (vX.Y.Z)
-     - Title (vX.Y.Z)
-     - The release notes written in step 9 (use `--notes` with a heredoc)
-     - Mark as pre-release if version contains 'a', 'b', or 'rc' (`--prerelease` flag)
+9. **Tag and push**
+   - Create annotated tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
+   - Push tag: `git push origin vX.Y.Z`
+   - **Important:** pushing the tag triggers the Release Validation workflow (`.github/workflows/release.yml`), which **creates the GitHub release itself** (via `softprops/action-gh-release`) with **empty notes and `prerelease: false`**, then attaches the build artifacts. So by step 10 the release usually already exists — you finalize it, you don't create it fresh.
+
+10. **Finalize the GitHub release**
+   - The tag-triggered workflow has (or shortly will have) created the release. Set the notes and pre-release flag on it rather than assuming you're creating it:
+     - `gh release edit vX.Y.Z --notes-file <notes-file>` to apply the step-8 notes.
+     - **Pre-releases** (version contains 'a', 'b', or 'rc'): you MUST also pass `--prerelease` here — the workflow defaults the release to `prerelease: false`, so the flag has to be (re)applied via `edit`. Plain `gh release create --prerelease` fails once the workflow has run (`HTTP 422: Release.tag_name already exists`).
+     - If the release does not exist yet (workflow slow or failed), create it instead: `gh release create vX.Y.Z --title vX.Y.Z --notes-file <notes-file> [--prerelease]`.
+     - Robust either-way one-liner: `gh release edit vX.Y.Z --notes-file <f> [--prerelease] || gh release create vX.Y.Z --title vX.Y.Z --notes-file <f> [--prerelease]`.
+   - Verify the result: `gh release view vX.Y.Z --json isPrerelease,body --jq '{prerelease:.isPrerelease, body_len:(.body|length)}'` (body_len > 0; prerelease matches the version).
 
 11. **Update the conda-forge feedstock** (downstream of PyPI — asynchronous)
 
@@ -129,4 +132,4 @@ Report the final status with links to:
 - conda-forge feedstock PR (note whether dependency edits were needed). This is
   asynchronous and may still be open/pending when the rest of the release is done.
 
-**Note:** After the tag is pushed, a GitHub Actions workflow automatically runs to validate the release (runs tests, verifies version, attaches build artifacts to the release).
+**Note:** After the tag is pushed, the Release Validation workflow runs automatically: it runs tests, verifies the tag matches the version, **creates the GitHub release** (empty notes, `prerelease: false`) and attaches the build artifacts, then verifies the version is live on PyPI (with `--pre`, so pre-releases are found). Step 10 finalizes the notes and pre-release flag on the release this workflow creates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,19 +307,20 @@ When adding new columns derived from API descriptions, always use the programmat
 9. For S3 output, per-process local staging is used for formats requiring local I/O before uploading
 10. A customer-readable `README.md` is auto-generated in `final/` by `ReadmeGenerator`, plus a `<filename>_data_dictionary.csv` next to each tabular AI-data output by `data_dictionary_generator`
 
-### Resource tuning (`--processes` and `--chunk-size`)
+### Resource tuning (`--processes`, `--chunk-size`, `--merge-read-workers`)
 
-These are the two operator-facing dials for RAM. Both stages of the export scale with them:
+These are the operator-facing dials for RAM and consolidation speed. The export has two stages — parallel chunk processing (API fetch) and the single-process closeout (combined `features.parquet` stream + per-class merge):
 
-- **`--processes`** (default `4`; must be `>= 1`) sets the parallel worker count for chunk processing AND derives the closeout streaming prefetch buffer:
+- **`--processes`** (default `4`; must be `>= 1`) sets the parallel worker count for chunk processing AND derives the `features.parquet` streaming prefetch buffer:
   - Chunk-processing peak ≈ `processes × per-chunk feature tables` resident at once (one per worker).
-  - Closeout-streaming peak ≈ `(round(1.5 × processes) + 1) × dense-chunk-size` resident at once — the prefetch read-ahead window plus the one chunk currently being reconciled/written (see `_resolve_prefetch_workers` in `exporter.py`). This applies to both the combined `features.parquet` stream and the per-class chunk merge.
-  - Both stages scale linearly with this dial. If memory pressure shows in either phase, drop `--processes`.
-- **`--chunk-size`** (default `500`) sets how many AOIs each worker processes per chunk. Larger chunks → larger per-chunk feature tables → bigger per-process working set AND bigger per-table footprint at the streaming stage. Smaller chunks shrink both at the cost of more chunk-boundary overhead and more files to combine at the end.
+  - `features.parquet`-streaming peak ≈ `(round(1.5 × processes) + 1) × dense-chunk-size` resident at once — the prefetch read-ahead window plus the one chunk currently being reconciled/written (see `_resolve_prefetch_workers` in `exporter.py`). Those per-chunk tables hold **all** classes, so this stays tied to `--processes` for RAM safety.
+  - Both stages scale linearly with this dial. If memory pressure shows in either, drop `--processes`.
+- **`--chunk-size`** (default `500`) sets how many AOIs each worker processes per chunk. Larger chunks → larger per-chunk feature tables → bigger per-process working set AND bigger per-table footprint at the streaming/merge stages, but **fewer** chunk files (fewer footer reads, fewer output row groups, less per-file overhead in the merge). Smaller chunks shrink memory at the cost of more chunk-boundary overhead and more files to combine. For very large national exports, a bigger `--chunk-size` can noticeably cut merge overhead if RAM allows.
+- **`--merge-read-workers`** (default `0` = auto) sets the read-ahead concurrency for the **per-class merge** only (consolidation phase, `_resolve_merge_prefetch_workers`). Auto-sizes to `max(round(1.5 × processes), read-workers)` — i.e. the full S3/local read concurrency (24 on S3, 8 local) — because per-class chunks are a single class and small, so the merge can read at full concurrency without the lone parquet writer starving on I/O. Memory here ≈ `merge-read-workers × per-class-chunk-size` resident, far below the old read-all-then-concat peak. Raise it on a large-RAM box to read further ahead; lower it only if per-class chunks are unusually large (e.g. a big `--chunk-size` on the building layer).
 
-Memory monitoring reports the working set (`memory.current − inactive_file`), matching kubelet / OOM-killer semantics. The displayed figure ignores reclaimable page cache. See `nmaipy/cgroup_memory.py` and the "Container memory display" notes in the v5.0.16 release.
+Memory monitoring reports the working set (`memory.current − inactive_file`), matching kubelet / OOM-killer semantics. The displayed figure ignores reclaimable page cache. See `nmaipy/cgroup_memory.py` and the "Container memory display" notes in the v5.0.16 release. Each consolidation stage now shows a tqdm progress bar (`Streaming chunks` for `features.parquet`; `<Class> tabular`/`<Class> geo` for the per-class merge), so a long closeout no longer looks hung.
 
-Operationally: start with the defaults, watch the working-set figure in the tqdm postfix during a real export, and tune `--processes` first (linear effect on both stages, no surprises) before reaching for `--chunk-size`.
+Operationally: start with the defaults, watch the working-set figure in the tqdm postfix during a real export, and tune `--processes` first (linear effect on both stages, no surprises) before reaching for `--chunk-size`. If the per-class merge is the bottleneck on a roomy box, raise `--merge-read-workers`.
 
 For the retry / backoff / gridding strategy these dials sit on top of, see `RetryRequest` and `GriddedApiClient` in `nmaipy/api_common.py`. (A standalone engineering doc, `docs/retry-and-gridding.md`, is drafted but deliberately held back from the repo until reviewed — see commit 256f1b4.)
 

--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.23a1"
+__version__ = "5.0.23b1"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -679,6 +679,7 @@ def _stream_merge_chunks_to_parquet(
     prefetch_workers: int,
     geo_metadata: dict = None,
     logger=None,
+    progress_desc: str = None,
 ) -> int:
     """Stream-merge per-class chunk parquet files into one output file.
 
@@ -726,6 +727,9 @@ def _stream_merge_chunks_to_parquet(
         geo_metadata: GeoParquet metadata dict to attach to the schema (geo files);
             None for tabular files.
         logger: Optional logger; falls back to the module logger.
+        progress_desc: If set, render a tqdm progress bar over the data pass with
+            this label (e.g. "Building geo"). None (the default) renders no bar —
+            keeps the helper quiet when called from tests.
 
     Returns:
         Number of rows written. 0 (and no file at ``output_path``) when there were
@@ -775,6 +779,10 @@ def _stream_merge_chunks_to_parquet(
     data_reads_succeeded = 0
     completed = False
     writer = None
+    pbar = None
+    last_resource_update = 0.0
+    if progress_desc is not None:
+        pbar = tqdm(total=n, desc=progress_desc, file=sys.stdout, position=0, leave=True)
     executor = ThreadPoolExecutor(max_workers=prefetch_workers)
     prefetch_futures = {}
     initial_submit = min(prefetch_workers, n)
@@ -792,6 +800,12 @@ def _stream_merge_chunks_to_parquet(
             if next_submit_idx < n:
                 prefetch_futures[next_submit_idx] = executor.submit(pq.read_table, valid_paths[next_submit_idx])
                 next_submit_idx += 1
+            if pbar is not None:
+                pbar.update(1)
+                now = time.time()
+                if now - last_resource_update >= 5.0:
+                    pbar.set_postfix_str(resource_postfix())
+                    last_resource_update = now
             try:
                 table = future.result()
             except Exception as e:
@@ -809,6 +823,8 @@ def _stream_merge_chunks_to_parquet(
         executor.shutdown(wait=True, cancel_futures=True)
         if writer is not None:
             writer.close()
+        if pbar is not None:
+            pbar.close()
         if not completed:
             # Write failed or was interrupted: the closed writer left a valid but
             # truncated temp file. Drop it; output_path is never touched. The
@@ -897,6 +913,21 @@ def _resolve_prefetch_workers(processes: int) -> int:
     Precondition: ``processes >= 1`` (enforced by BaseExporter.__init__).
     """
     return max(FEATURE_PREFETCH_FLOOR, round(FEATURE_PREFETCH_MULTIPLIER * processes))
+
+
+def _resolve_merge_prefetch_workers(merge_read_workers: int, processes: int, scan_workers: int) -> int:
+    """Resolve the read-ahead concurrency for the per-class output merge.
+
+    A positive ``merge_read_workers`` is an explicit operator override (``--merge-read-workers``).
+    Otherwise auto-size to ``max(_resolve_prefetch_workers(processes), scan_workers)``: unlike the
+    combined ``features.parquet`` stream — whose per-chunk tables hold every class and so stay tied
+    to ``--processes`` for RAM safety — per-class chunks contain a single class and are small, so the
+    merge can read at the full scan concurrency (24 on S3) without the lone writer starving on I/O.
+    Memory stays bounded at ~this many chunks resident, far below the old read-all peak.
+    """
+    if merge_read_workers and merge_read_workers > 0:
+        return merge_read_workers
+    return max(_resolve_prefetch_workers(processes), scan_workers)
 
 
 def _resolve_rsi_batch(n_rows, resolve_fn):
@@ -2292,6 +2323,18 @@ def parse_arguments():
         default=CHUNK_SIZE,
     )
     parser.add_argument(
+        "--merge-read-workers",
+        help=(
+            "Read-ahead concurrency for the per-class output merge (consolidation phase). "
+            "0 (default) auto-sizes to the S3/local read-worker count so merge reads do not "
+            "bottleneck the writer. Raise on a large-RAM box to read more chunks ahead; lower "
+            "if per-class chunks are unusually large (memory ~= this many chunks resident)."
+        ),
+        type=int,
+        required=False,
+        default=0,
+    )
+    parser.add_argument(
         "--include-parcel-geometry",
         help="If set, parcel geometries will be in the output",
         action="store_true",
@@ -2505,6 +2548,7 @@ _CONFIG_KEYS_NOT_AFFECTING_OUTPUT = frozenset(
         "processes",
         "threads",
         "chunk_size",
+        "merge_read_workers",
         "log_level",
         "cache_dir",
         "compress_cache",
@@ -2539,6 +2583,7 @@ class NearmapAIExporter(BaseExporter):
         processes=PROCESSES,
         threads=THREADS,
         chunk_size=CHUNK_SIZE,
+        merge_read_workers=0,  # 0 = auto-size the per-class merge read-ahead
         include_parcel_geometry=False,
         save_features=False,
         tabular_file_format="csv",
@@ -2589,6 +2634,7 @@ class NearmapAIExporter(BaseExporter):
         self.aoi_grid_cell_size = aoi_grid_cell_size
         self.regrid_on_skip = regrid_on_skip
         # Note: processes, chunk_size, log_level handled by BaseExporter
+        self.merge_read_workers = merge_read_workers
         self.threads = threads
         self.include_parcel_geometry = include_parcel_geometry
         self.save_features = save_features
@@ -2662,6 +2708,7 @@ class NearmapAIExporter(BaseExporter):
             "processes": processes,
             "threads": threads,
             "chunk_size": chunk_size,
+            "merge_read_workers": merge_read_workers,
             "include_parcel_geometry": include_parcel_geometry,
             "save_features": save_features,
             "tabular_file_format": tabular_file_format,
@@ -3056,12 +3103,17 @@ class NearmapAIExporter(BaseExporter):
         if requested_class_ids is not None:
             whitelisted_classes = [cid for cid in whitelisted_classes if cid in requested_class_ids]
         # scan_workers: cheap footer-only schema reads (parallelised for S3).
-        # prefetch_workers: bounded read-ahead for the data pass — each prefetched
-        # table stays resident until the writer consumes it, so this is kept small
-        # (derived from --processes, the RAM dial) rather than reusing the high
-        # S3-read count, matching _stream_and_convert_features.
         scan_workers = S3_PARALLEL_READ_WORKERS if self.is_s3_output else PARALLEL_READ_WORKERS
-        prefetch_workers = _resolve_prefetch_workers(self.processes)
+        # prefetch_workers: bounded read-ahead for the data pass — each prefetched
+        # table stays resident until the writer consumes it. Unlike the combined
+        # features.parquet stream (whose per-chunk tables hold ALL classes, so it
+        # stays tied to --processes), per-class chunks are a single class and thus
+        # small, so the merge defaults to the full read concurrency (scan_workers,
+        # i.e. 24 on S3) to keep reads from bottlenecking the single writer.
+        # Still bounded (~scan_workers chunks resident, far below the old read-all
+        # peak); --merge-read-workers overrides for unusually large per-class chunks.
+        prefetch_workers = _resolve_merge_prefetch_workers(self.merge_read_workers, self.processes, scan_workers)
+        self.logger.info(f"Per-class merge read-ahead: {prefetch_workers} (scan workers: {scan_workers})")
 
         # Set up staging directory for atomic writes
         if self.is_s3_output:
@@ -3122,6 +3174,7 @@ class NearmapAIExporter(BaseExporter):
                     scan_workers=scan_workers,
                     prefetch_workers=prefetch_workers,
                     logger=self.logger,
+                    progress_desc=f"{desc} tabular",
                 )
                 if rows or os.path.exists(staging_path):
                     tabular_count += 1
@@ -3136,6 +3189,7 @@ class NearmapAIExporter(BaseExporter):
                     prefetch_workers=prefetch_workers,
                     geo_metadata=geo_metadata,
                     logger=self.logger,
+                    progress_desc=f"{desc} geo",
                 )
                 if rows or os.path.exists(staging_path):
                     geo_count += 1
@@ -4602,6 +4656,7 @@ def main():
         processes=args.processes,
         threads=args.threads,
         chunk_size=args.chunk_size,
+        merge_read_workers=args.merge_read_workers,
         include_parcel_geometry=args.include_parcel_geometry,
         save_features=args.save_features,
         tabular_file_format=args.tabular_file_format,

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2221,6 +2221,14 @@ THREADS = 10  # Reduced from 20 to prevent resource exhaustion
 logger = log.get_logger()
 
 
+def _nonnegative_int(value):
+    """argparse type for counts where 0 means 'auto' and negatives are invalid."""
+    ivalue = int(value)
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0 (0 = auto), got {value}")
+    return ivalue
+
+
 def parse_arguments():
     """
     Get command line arguments
@@ -2330,7 +2338,7 @@ def parse_arguments():
             "bottleneck the writer. Raise on a large-RAM box to read more chunks ahead; lower "
             "if per-class chunks are unusually large (memory ~= this many chunks resident)."
         ),
-        type=int,
+        type=_nonnegative_int,
         required=False,
         default=0,
     )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import os
@@ -33,6 +34,7 @@ from nmaipy.exporter import (
     _add_missing_columns,
     _dataframe_to_records_with_index,
     _description_to_cname,
+    _nonnegative_int,
     _parquet_to_csv_streaming,
     _per_class_chunk_regexes,
     _read_parquet_chunks_parallel,
@@ -103,6 +105,19 @@ class TestResolveMergePrefetchWorkers:
     def test_zero_and_negative_are_treated_as_auto(self):
         assert _resolve_merge_prefetch_workers(0, processes=4, scan_workers=8) == 8
         assert _resolve_merge_prefetch_workers(-1, processes=4, scan_workers=8) == 8
+
+
+class TestNonnegativeInt:
+    """``_nonnegative_int`` is the argparse type for --merge-read-workers: 0 = auto,
+    positives allowed, negatives rejected with a clear error."""
+
+    def test_zero_and_positive_pass(self):
+        assert _nonnegative_int("0") == 0
+        assert _nonnegative_int("24") == 24
+
+    def test_negative_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _nonnegative_int("-1")
 
 
 class TestStagedFileNeedsUpload:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -36,6 +36,7 @@ from nmaipy.exporter import (
     _parquet_to_csv_streaming,
     _per_class_chunk_regexes,
     _read_parquet_chunks_parallel,
+    _resolve_merge_prefetch_workers,
     _resolve_prefetch_workers,
     _staged_file_needs_upload,
     _stream_merge_chunks_to_parquet,
@@ -74,6 +75,34 @@ class TestResolvePrefetchWorkers:
     def test_scales_with_processes(self):
         # Dropping --processes shrinks the buffer; raising it reads further ahead.
         assert _resolve_prefetch_workers(4) < _resolve_prefetch_workers(8) < _resolve_prefetch_workers(16)
+
+
+class TestResolveMergePrefetchWorkers:
+    """``_resolve_merge_prefetch_workers`` sizes the per-class merge read-ahead.
+
+    Auto (merge_read_workers<=0) = max(features-stream prefetch, scan_workers), since per-class
+    chunks are small enough to read at full scan concurrency; a positive value is an operator
+    override. Pure function, no live API."""
+
+    def test_explicit_override_is_honored(self):
+        # A positive override wins regardless of processes/scan_workers.
+        assert _resolve_merge_prefetch_workers(3, processes=16, scan_workers=24) == 3
+        assert _resolve_merge_prefetch_workers(64, processes=4, scan_workers=8) == 64
+
+    def test_auto_uses_scan_workers_when_higher(self):
+        # Default processes=4 -> prefetch 6; S3 scan_workers=24 dominates, so the
+        # merge reads at 24-way (the regression this restores vs the old 24-way read-all).
+        assert _resolve_merge_prefetch_workers(0, processes=4, scan_workers=24) == 24
+        # Local: scan_workers=8 dominates the prefetch of 6.
+        assert _resolve_merge_prefetch_workers(0, processes=4, scan_workers=8) == 8
+
+    def test_auto_uses_processes_prefetch_when_higher(self):
+        # Many processes -> processes-derived prefetch can exceed scan_workers.
+        assert _resolve_merge_prefetch_workers(0, processes=32, scan_workers=24) == _resolve_prefetch_workers(32)
+
+    def test_zero_and_negative_are_treated_as_auto(self):
+        assert _resolve_merge_prefetch_workers(0, processes=4, scan_workers=8) == 8
+        assert _resolve_merge_prefetch_workers(-1, processes=4, scan_workers=8) == 8
 
 
 class TestStagedFileNeedsUpload:
@@ -1262,6 +1291,17 @@ class TestStreamMergeChunksToParquet:
         assert result.schema.field("val").type == pa.float64()
         assert result.schema.field("name").type == pa.large_string()
 
+    def test_progress_desc_renders_without_breaking_output(self, tmp_path):
+        """With progress_desc set, a tqdm bar is drawn but output is unchanged."""
+        chunks = self._mismatched_chunks()
+        paths = _write_chunks(tmp_path, chunks)
+        out = str(tmp_path / "merged.parquet")
+        rows = _stream_merge_chunks_to_parquet(
+            paths, out, scan_workers=2, prefetch_workers=2, progress_desc="Building geo"
+        )
+        assert rows == sum(len(c) for c in chunks)
+        assert pq.read_table(out).num_rows == rows
+
     def test_missing_column_null_filled(self, tmp_path):
         chunks = self._mismatched_chunks()
         paths = _write_chunks(tmp_path, chunks)
@@ -1584,6 +1624,16 @@ class TestMergePerClassChunks:
     """Integration test for the rewired caller: real per-class chunk files on
     local disk are merged, the tabular output is converted to CSV, the geo output
     keeps its GeoParquet metadata, and the staging dir is cleaned up."""
+
+    def test_merge_read_workers_plumbed_to_instance(self, tmp_path):
+        exporter = AOIExporter(
+            aoi_file="tests/data/test_parcels_2.csv",
+            output_dir=str(tmp_path),
+            country="us",
+            packs=["building"],
+            merge_read_workers=7,
+        )
+        assert exporter.merge_read_workers == 7
 
     def test_merges_real_chunks_to_final(self, tmp_path):
         exporter = AOIExporter(


### PR DESCRIPTION
Follow-up to #204 (the streaming per-class merge). Promotes that work to **beta** (`5.0.23b1`) and addresses the two performance/UX gaps surfaced while running it on a real national export.

## Motivation

The per-class merge was the one streaming phase with **no progress indication** — it logged `Merging N chunks for Building` then went silent for the duration of the largest layer, so a long closeout looked hung. And its read-ahead was tied to `--processes` (`round(1.5 × processes)` = **6** at the default), a ~4× drop from the old read-all-then-concat's 24-way reads on S3, which can leave the single parquet writer starved on I/O.

## Changes

- **Per-class progress bars** — `_stream_merge_chunks_to_parquet` takes an optional `progress_desc`; the caller renders `<Class> tabular` / `<Class> geo` bars with the live mem/CPU postfix, mirroring the existing `features.parquet` `Streaming chunks` bar. `None` (tests) renders no bar.
- **Dedicated merge read-ahead** — new `_resolve_merge_prefetch_workers` auto-sizes the merge to `max(round(1.5 × processes), read-workers)` = full scan concurrency (24 on S3, 8 local). Per-class chunks are a single class and small, so the merge can read at full concurrency without starving the writer, while staying bounded at ~that many chunks resident (far below the old read-all peak). New **`--merge-read-workers N`** flag overrides it (raise on a big box; lower for unusually large per-class chunks). It's a perf knob, so it does not invalidate the README resume sentinel.
- **Docs** — CLAUDE.md resource-tuning section covers the new knob, the `--chunk-size` trade-offs for the merge, and the new progress bars.

The combined `features.parquet` stream deliberately **stays tied to `--processes`** — its per-chunk tables hold every class and are large, so its RAM bound must track that dial, unlike the small single-class merge chunks.

## Tests

- `TestResolveMergePrefetchWorkers`: explicit override honored; auto = `max(processes-derived, scan_workers)`; 0/negative treated as auto.
- `progress_desc` renders a bar without changing merge output.
- `--merge-read-workers` is plumbed through to the exporter instance.
- Full non-live exporter suite: 92 passed. Verified live on a US `building` export — bars render per class, read-ahead log shows the resolved value, output byte-identical (148/143 rows, geo v1.0.0, EPSG:4326), no `.tmp`/staging leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)