### PR TITLE
chore: release version 5.0.23

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.0.23b1"
+__version__ = "5.0.23"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )


### PR DESCRIPTION
Promotes the streaming per-class merge line to the **stable `5.0.23`** release.

**Single-line, single-file change** — `__version__` `5.0.23b1` → `5.0.23`, cut from clean `main`. No code changes; byte-identical to `5.0.23b1` (which passed the full live suite (768) and code review this session).

> Replaces the closed #207, which was accidentally cut from `feature/damage-conflation-api` and bundled that feature in. Damage conflation will ship separately as **`5.1.0`** via its own PR.

### What `5.0.23` ships (cumulative since `5.0.22`)
- **Streaming per-class chunk merge** — bounds consolidation memory, fixing the national-scale OOM (exit 137); atomic temp-file write + no-empty-file-on-total-failure guarantees (`5.0.23a1`).
- **Per-class merge progress bars** and a tunable **`--merge-read-workers`** read-ahead (`5.0.23b1`).

### Validation
- `5.0.23b1` full live suite: 768 passed, 12 skipped this session; clean code review.
- This bump: non-live suite re-run green (746 passed); full live suite not re-run — only delta is the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)