### PR TITLE
Release version 5.1.0

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.1.0a3"
+__version__ = "5.1.0"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )


### PR DESCRIPTION
Release **v5.1.0** — bumps `5.1.0a3 → 5.1.0` and cuts the first stable release of the 5.1.0 line.

Pre-flight (on `release/v5.1.0`): `black -l 120` + `isort` clean; full test suite **incl. live API** 821 passed / 12 skipped; code review of the delta since `v5.1.0a3` found no blocking issues.

---

## What's New
nmaipy 5.1.0 adds the **Damage Conflation API exporter** for event-scoped catastrophe damage assessment, plus lightweight **Coverage event discovery** to resolve a catastrophe event id + boundary from a location. Supersedes pre-releases 5.1.0a1–a3.

## Features
- **Damage Conflation API exporter** (`ai/damage/v2`) — `python -m nmaipy.damage_conflation_exporter`. Given `--event-id` + an AOI file, returns building-level conflated damage ratings (`damage.event` + `damage.preEvent`) for every building intersecting each AOI. Always writes `damage_buildings.{parquet,csv}`; opt-in `--rollup` adds per-AOI `damage_rollup.{parquet,csv}` (`--primary-decision largest|optimal`) plus `damage_metadata.csv` / `damage_errors.csv`. `nextCursor` pagination (no gridding). Adds `DamageConflationApi`, `conflation_rollup()`, `flatten_conflated_damage_attributes()`. US-only.
- **Coverage event discovery** — `nmaipy.coverage_utils.discover_event(lat, lon)` / `latest_event_id_at_point` / `event_boundary`: resolve the latest catastrophe event id + footprint (shapely (Multi)Polygon) from a lat/lon via the Coverage API `postCatEventId` tag filter (paginated). Lightweight in-memory helpers, no CLI/file output.

## Bug Fixes
- **S3 chunk consolidation**: fix a silent stale-`s3fs`-listing bug that could consolidate 0 records despite valid chunks; fixed for Damage Conflation and Roof Age via shared `BaseExporter.combine_chunk_files()`.
- **Damage Conflation**: cap an unbounded pagination loop; fix rollup dtype drift on always-null columns; sync CSV columns with the GeoParquet; derive rollup at combine and drop wrong-unit `area_sqm` for US.

## Security
- `coverage_utils` sends the API key via `requests` `params=` instead of the URL string, keeping it out of URLs/logs (clears CodeQL `py/clear-text-logging-sensitive-data`).

## Notes
- Damage Conflation (and Roof Age) remain **US-only**.
- Event-id auto-discovery is a separate helper; the damage exporter still takes an explicit `--event-id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
