### PR TITLE
Fix: multiparcel features get wrong parcel's clipped attributes (per-class export + rollup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,20 @@ This consistency matters because:
 
 When adding new columns derived from API descriptions, always use the programmatic pattern rather than inventing abbreviated or "cleaned" names.
 
+## Feature ID Semantics (multiparcel row identity)
+
+`feature_id` values originate in the raw vector tiles, and features can be large — a single roof, building, or building lifecycle polygon can span parcel boundaries or grid cells. Their stability rules:
+
+- **Stable within a survey**: the same physical feature from the same survey ID has the same `feature_id` no matter which AOI or query returned it. This is what makes gridding deduplication (`combine_features_from_grid`) and cross-AOI matching work.
+- **Not stable across surveys/dates**: the same physical feature captured on different survey dates gets different IDs. Never match or deduplicate by `feature_id` across dates.
+- **Multiparcel consequence (parcelMode)**: two AOIs that intersect the same feature from the same survey each get a row with the *same* `feature_id`, but attributes (RSI, component areas, defensible space, …) are computed by the API on **that parcel's clipped geometry**, and nmaipy's flattening recomputes child-intersection attributes per clip as well. The row identity in any multi-AOI frame is therefore `(aoi_id, feature_id)`, never `feature_id` alone.
+
+Code implications (see PR #210 for the bug class this prevents):
+- Any chunk-level (multi-AOI) cross-row structure must be keyed by `(aoi_id, feature_id)` (e.g. `roof_attrs_cache`) or scoped per AOI as `{aoi_id: {feature_id: …}}` (`build_parent_lookup_by_aoi`, `roof_to_building_lookup`), with each consumer taking its row's own parcel sub-dict.
+- `build_parent_lookup` (flat, fid-keyed) is only valid for a single AOI's features.
+- Parent-chain traversal and IoU linkage never cross parcels — per-AOI scoping preserves that invariant by construction, and a chain that is broken within a parcel must yield null rather than borrow another parcel's clip value.
+- Deduplication by bare `feature_id` is only correct within one AOI and one survey (the gridded-query merge case).
+
 ## Code Architecture
 
 ### Exporter Layer (user-facing entry points)

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1015,6 +1015,22 @@ def _dataframe_to_records_with_index(df):
     return records
 
 
+def _aoi_id_values(df):
+    """Return the per-row aoi_id values whether aoi_id is a column or the index.
+
+    The chunk frame is indexed by aoi_id in the standalone export path but carries
+    aoi_id as a column with a RangeIndex in the streaming path (the on=aoi_id merges
+    in process_chunk reset the index). Roof attribute lookups key on (aoi_id,
+    feature_id), so both layouts must resolve to the same aoi_id series that the
+    cache producer (via _dataframe_to_records_with_index) sees.
+    """
+    if AOI_ID_COLUMN_NAME in df.columns:
+        return df[AOI_ID_COLUMN_NAME].values
+    if df.index.name == AOI_ID_COLUMN_NAME:
+        return df.index.values
+    return [None] * len(df)
+
+
 def _description_to_cname(description: str) -> str:
     """Convert a class description like 'Roof Instance' to a filename-safe slug like 'roof_instance'."""
     return re.sub(r"[^a-z0-9]+", "_", description.lower()).strip("_")
@@ -1151,7 +1167,14 @@ def _compute_all_per_class_data(
                         parent_projected=roof_geoms_proj.iloc[ridx],
                         children_projected=child_proj_by_aoi.get(roof_aoi),
                     )
-                    roof_attrs_cache_chunk[row["feature_id"]] = attrs
+                    # Key by (aoi_id, feature_id): in parcelMode a multiparcel
+                    # roof appears once per parcel it overlaps, each row carrying
+                    # attributes recomputed on that parcel's clipped geometry
+                    # (RSI, materials, defensible space, ...). Keying by feature_id
+                    # alone lets one parcel's clip overwrite another's, so every
+                    # duplicate row would inherit whichever parcel was flattened
+                    # last. See consumers in _compute_feature_class_data.
+                    roof_attrs_cache_chunk[(roof_aoi, row["feature_id"])] = attrs
                 except Exception as e:
                     _log.debug(f"Could not flatten roof attrs: {e}")
             del child_by_aoi, child_proj_by_aoi, roof_geoms_proj
@@ -1499,8 +1522,13 @@ def _compute_feature_class_data(
         # These are from include parameters and the roof's own attributes array
         try:
             if roof_attrs_cache is not None:
-                # Use pre-computed cache (avoids duplicate flatten loop)
-                attr_records = [roof_attrs_cache.get(fid, {}) for fid in class_features["feature_id"].values]
+                # Use pre-computed cache (avoids duplicate flatten loop).
+                # Cache is keyed by (aoi_id, feature_id) so multiparcel roofs
+                # resolve to this parcel's clipped attributes, not another's.
+                attr_records = [
+                    roof_attrs_cache.get((aoi, fid), {})
+                    for aoi, fid in zip(_aoi_id_values(class_features), class_features["feature_id"].values)
+                ]
                 logger.debug(f"Roof attribute flattening: used cache for {len(class_features)} roofs")
             else:
                 # Fallback: compute per-row (for standalone calls without cache)
@@ -1687,8 +1715,14 @@ def _compute_feature_class_data(
 
                 # Build a mapping from roof feature_id to flattened attributes.
                 if roof_attrs_cache is not None:
-                    # Use pre-computed cache (avoids duplicate flatten loop)
-                    roof_attrs = {fid: roof_attrs_cache.get(fid, {}) for fid in roofs_linked["feature_id"].values}
+                    # Use pre-computed cache (avoids duplicate flatten loop).
+                    # Keyed by (aoi_id, feature_id) so a multiparcel roof keeps a
+                    # distinct entry per parcel; the reindex below looks each
+                    # building up by its own (aoi_id, primary_child_roof_id).
+                    roof_attrs = {
+                        (aoi, fid): roof_attrs_cache.get((aoi, fid), {})
+                        for aoi, fid in zip(_aoi_id_values(roofs_linked), roofs_linked["feature_id"].values)
+                    }
                     logger.debug(f"Building roof attribute flattening: used cache for {len(roofs_linked)} roofs")
                 else:
                     # Fallback: compute per-row (for standalone calls without cache)
@@ -1712,7 +1746,7 @@ def _compute_feature_class_data(
                                 parent_projected=bldg_roof_geoms_projected.iloc[idx],
                                 children_projected=bldg_child_proj_by_aoi.get(roof_aoi),
                             )
-                            roof_attrs[row["feature_id"]] = attrs
+                            roof_attrs[(roof_aoi, row["feature_id"])] = attrs
                         except Exception as e:
                             logger.debug(f"Could not flatten building-linked roof attributes: {e}")
                     logger.debug(
@@ -1722,10 +1756,20 @@ def _compute_feature_class_data(
                 if roof_attrs:
                     # Map primary child roof attributes to buildings via DataFrame reindex
                     # (replaces per-attribute .apply(lambda) with a single vectorized lookup)
-                    roof_attrs_df = pd.DataFrame.from_dict(roof_attrs, orient="index")
+                    # roof_attrs is keyed by (aoi_id, feature_id); build the frame
+                    # with a matching MultiIndex and look each building up by its
+                    # own (aoi_id, primary_child_roof_id) so a multiparcel roof
+                    # resolves to this building's parcel clip.
+                    attr_keys = list(roof_attrs.keys())
+                    roof_attrs_df = pd.DataFrame([roof_attrs[k] for k in attr_keys])
                     roof_attrs_df.columns = [f"primary_child_roof_{c}" for c in roof_attrs_df.columns]
-                    primary_ids = buildings_linked["primary_child_roof_id"].values
-                    mapped = roof_attrs_df.reindex(primary_ids).reset_index(drop=True)
+                    roof_attrs_df.index = pd.MultiIndex.from_tuples(
+                        attr_keys, names=[AOI_ID_COLUMN_NAME, "feature_id"]
+                    )
+                    lookup_keys = list(
+                        zip(_aoi_id_values(buildings_linked), buildings_linked["primary_child_roof_id"].values)
+                    )
+                    mapped = roof_attrs_df.reindex(lookup_keys).reset_index(drop=True)
 
                     roof_attr_batch = {}
                     _DOM = (
@@ -1747,31 +1791,39 @@ def _compute_feature_class_data(
                     # For each child roof, resolve best RSI (roof's own first,
                     # then BL fallback) so min/max reflect the same logic as
                     # the per-row roof_spotlight_index column.
+                    # Keyed by (aoi_id, feature_id): child_roofs are matched within
+                    # the building's own parcel, so min/max must look up the roof's
+                    # clip for that parcel, not another's.
                     rsi_lookup = {}
-                    for fid, attrs in roof_attrs.items():
+                    for (r_aoi, fid), attrs in roof_attrs.items():
                         if "roof_spotlight_index" in attrs:
-                            rsi_lookup[fid] = attrs["roof_spotlight_index"]
+                            rsi_lookup[(r_aoi, fid)] = attrs["roof_spotlight_index"]
                         else:
-                            # Try BL fallback via IoU-linked Building(New) → BL
+                            # BL fallback goes through the feature_id-keyed parent
+                            # lookup (see layer-2 note in the PR); best-effort here.
                             bn_id = _roof_to_building.get(fid)
                             if bn_id:
                                 bn_row = p_lookup.get(bn_id)
                                 if bn_row is not None:
                                     resolved_rsi = resolve_footprint_rsi(bn_row, parent_lookup=p_lookup)
                                     if resolved_rsi and "roof_spotlight_index" in resolved_rsi:
-                                        rsi_lookup[fid] = resolved_rsi["roof_spotlight_index"]
+                                        rsi_lookup[(r_aoi, fid)] = resolved_rsi["roof_spotlight_index"]
 
                     if rsi_lookup:
                         n_buildings = len(buildings_linked)
                         min_vals = np.full(n_buildings, np.nan)
                         max_vals = np.full(n_buildings, np.nan)
+                        building_aois = _aoi_id_values(buildings_linked)
                         for i, child_json in enumerate(buildings_linked["child_roofs"].values):
                             if not child_json or child_json == "[]":
                                 continue
+                            b_aoi = building_aois[i]
                             try:
                                 child_list = json.loads(child_json) if isinstance(child_json, str) else child_json
                                 rsi_vals = [
-                                    rsi_lookup[c["feature_id"]] for c in child_list if c.get("feature_id") in rsi_lookup
+                                    rsi_lookup[(b_aoi, c["feature_id"])]
+                                    for c in child_list
+                                    if (b_aoi, c.get("feature_id")) in rsi_lookup
                                 ]
                                 if rsi_vals:
                                     min_vals[i] = min(rsi_vals)
@@ -1977,9 +2029,15 @@ def _compute_feature_class_data(
                 if bl_linkage_batch:
                     df_parts.append(pd.DataFrame(bl_linkage_batch, index=range(n_rows)))
 
-                # Map primary child roof attributes to BL features
+                # Map primary child roof attributes to BL features.
+                # Cache is keyed by (aoi_id, feature_id); pull each roof's own
+                # parcel while keeping this dict keyed by feature_id for the
+                # primary_child_roof reindex below.
                 roof_attrs = (
-                    {fid: roof_attrs_cache.get(fid, {}) for fid in roofs["feature_id"].values}
+                    {
+                        fid: roof_attrs_cache.get((aoi, fid), {})
+                        for aoi, fid in zip(_aoi_id_values(roofs), roofs["feature_id"].values)
+                    }
                     if roof_attrs_cache is not None
                     else {}
                 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -126,7 +126,7 @@ from nmaipy.feature_attributes import (
 )
 from nmaipy.parcels import (
     _traverse_to_bl,
-    build_parent_lookup,
+    build_parent_lookup_by_aoi,
     class_column_names,
     extract_rsi_from_feature,
     link_roofs_to_buildings,
@@ -1096,9 +1096,12 @@ def _compute_all_per_class_data(
     if "class_id" in chunk_gdf.columns and len(chunk_gdf) > 0:
         class_groups = dict(iter(chunk_gdf.groupby("class_id", sort=False)))
 
-    # Build parent lookup once for all classes in this chunk
+    # Build parent lookup once for all classes in this chunk, scoped per AOI:
+    # in parcelMode a multiparcel feature appears once per parcel (same
+    # feature_id, per-clip attributes), so parent-chain traversal must stay
+    # inside each row's own parcel.
     shared_parent_lookup = (
-        build_parent_lookup(cross_class_gdf) if cross_class_gdf is not None and len(cross_class_gdf) > 0 else {}
+        build_parent_lookup_by_aoi(cross_class_gdf) if cross_class_gdf is not None and len(cross_class_gdf) > 0 else {}
     )
 
     # Build class_descriptions from chunk data
@@ -1139,14 +1142,18 @@ def _compute_all_per_class_data(
                 roofs_linked_chunk, buildings_linked_chunk = link_roofs_to_buildings(
                     roof_features_chunk, building_new_chunk
                 )
-                roof_to_building_lookup = {
-                    fid: bid
-                    for fid, bid in zip(
-                        roofs_linked_chunk["feature_id"].values,
-                        roofs_linked_chunk["parent_building_id"].values,
-                    )
-                    if pd.notna(bid)
-                }
+                # Scoped per AOI like the parent lookup: a multiparcel roof links
+                # within each parcel independently (the building may be absent
+                # from one parcel's rows), so roof→building resolution must not
+                # leak across parcels.
+                roof_to_building_lookup = {}
+                for aoi, fid, bid in zip(
+                    _aoi_id_values(roofs_linked_chunk),
+                    roofs_linked_chunk["feature_id"].values,
+                    roofs_linked_chunk["parent_building_id"].values,
+                ):
+                    if pd.notna(bid):
+                        roof_to_building_lookup.setdefault(aoi, {})[fid] = bid
 
         # Compute roof attrs cache
         if ROOF_ID in whitelisted_classes and roof_features_chunk is not None and len(roof_features_chunk) > 0:
@@ -1283,10 +1290,12 @@ def _compute_feature_class_data(
         roof_attrs_cache: Pre-computed dict mapping (aoi_id, feature_id) to flattened attribute
             dicts. Keyed per parcel because in parcelMode a multiparcel roof appears once per
             parcel with attributes recomputed on that parcel's clipped geometry.
-        parent_lookup: Pre-built dict mapping feature_id to feature record, for parent-chain
-            traversal (rebuilt from features_gdf if not provided)
-        roof_to_building_lookup: Pre-built dict mapping roof feature_id to parent building
-            feature_id (rebuilt via link_roofs_to_buildings if not provided)
+        parent_lookup: Pre-built nested dict {aoi_id: {feature_id: record}} for parent-chain
+            traversal (rebuilt from features_gdf if not provided). Scoped per AOI because in
+            parcelMode a multiparcel feature appears once per parcel with per-clip attributes;
+            every consumer takes its row's own parcel sub-dict.
+        roof_to_building_lookup: Pre-built nested dict {aoi_id: {roof feature_id: parent
+            building feature_id}} (empty if not provided). Scoped per AOI for the same reason.
         roofs_linked: Pre-linked roof features (output of link_roofs_to_buildings)
         buildings_linked: Pre-linked building features (output of link_roofs_to_buildings)
 
@@ -1302,13 +1311,14 @@ def _compute_feature_class_data(
     if len(class_features) == 0:
         return (None, None)
 
-    # Use pre-built parent lookup if provided (avoids rebuilding per class)
-    p_lookup = (
+    # Use pre-built parent lookup if provided (avoids rebuilding per class).
+    # Nested {aoi_id: {feature_id: record}}; consumers scope to their row's parcel.
+    p_lookup_by_aoi = (
         parent_lookup
         if parent_lookup is not None
-        else (build_parent_lookup(features_gdf) if features_gdf is not None and len(features_gdf) > 0 else {})
+        else (build_parent_lookup_by_aoi(features_gdf) if features_gdf is not None and len(features_gdf) > 0 else {})
     )
-    _roof_to_building = roof_to_building_lookup or {}
+    _roof_to_bn_by_aoi = roof_to_building_lookup or {}
 
     # Build output DataFrame using vectorized operations (much faster than iterrows)
     # Accumulate DataFrames in a list and concat once at the end to avoid fragmentation
@@ -1510,14 +1520,23 @@ def _compute_feature_class_data(
                         col_rename[col] = prefixed_dst
 
                 if len(ri_cols) > 1:  # More than just feature_id
-                    ri_lookup = roof_instances[ri_cols].drop_duplicates(subset=["feature_id"])
-                    ri_lookup = ri_lookup.rename(columns=col_rename).set_index("feature_id")
+                    # Keyed by (aoi_id, feature_id): roof instances are linked
+                    # per parcel, so a multiparcel instance resolves to its own
+                    # parcel's row (universal row identity in parcelMode, even
+                    # though the whitelisted columns are clip-independent today).
+                    ri_lookup = roof_instances[ri_cols].copy()
+                    ri_lookup[AOI_ID_COLUMN_NAME] = _aoi_id_values(roof_instances)
+                    ri_lookup = ri_lookup.drop_duplicates(subset=[AOI_ID_COLUMN_NAME, "feature_id"])
+                    ri_lookup = ri_lookup.rename(columns=col_rename).set_index([AOI_ID_COLUMN_NAME, "feature_id"])
 
-                    # Map attributes using vectorized lookup
-                    primary_child_ids = class_features["primary_child_roof_age_feature_id"]
+                    # Map attributes using vectorized lookup by (aoi_id, instance id)
+                    ri_keys = list(
+                        zip(_aoi_id_values(class_features), class_features["primary_child_roof_age_feature_id"].values)
+                    )
+                    ri_mapped = ri_lookup.reindex(ri_keys).reset_index(drop=True)
                     ri_mapped_batch = {}
-                    for col in ri_lookup.columns:
-                        ri_mapped_batch[col] = primary_child_ids.map(ri_lookup[col]).values
+                    for col in ri_mapped.columns:
+                        ri_mapped_batch[col] = ri_mapped[col].values
                         added_cols.add(col)
                     convert_bool_columns_to_yn(ri_mapped_batch)
                     if ri_mapped_batch:
@@ -1587,16 +1606,22 @@ def _compute_feature_class_data(
             )
             if bl_in_features and "roof_spotlight_index" in class_features.columns:
                 roof_records_for_fp = _dataframe_to_records_with_index(class_features)
+                roof_aois_for_fp = _aoi_id_values(class_features)
 
                 def _resolve_roof_rsi(i):
                     row = roof_records_for_fp[i]
                     rsi = extract_rsi_from_feature(row)
                     if not rsi:
-                        bn_id = _roof_to_building.get(row.get("feature_id"))
+                        # BL fallback stays inside this roof row's own parcel:
+                        # both lookups are scoped by aoi_id so a multiparcel
+                        # roof/building resolves its own clip, not another's.
+                        row_aoi = roof_aois_for_fp[i]
+                        aoi_lookup = p_lookup_by_aoi.get(row_aoi, {})
+                        bn_id = _roof_to_bn_by_aoi.get(row_aoi, {}).get(row.get("feature_id"))
                         if bn_id:
-                            bn_row = p_lookup.get(bn_id)
+                            bn_row = aoi_lookup.get(bn_id)
                             if bn_row is not None:
-                                rsi = resolve_footprint_rsi(bn_row, parent_lookup=p_lookup)
+                                rsi = resolve_footprint_rsi(bn_row, parent_lookup=aoi_lookup)
                     return rsi
 
                 rsi_result = _resolve_rsi_batch(n_rows, _resolve_roof_rsi)
@@ -1614,12 +1639,15 @@ def _compute_feature_class_data(
         try:
             if bl_in_features:
                 roof_records_for_scores = _dataframe_to_records_with_index(class_features)
+                roof_aois_for_scores = _aoi_id_values(class_features)
 
                 def _resolve_roof_scores(i):
                     row = roof_records_for_scores[i]
-                    bn_id = _roof_to_building.get(row.get("feature_id"))
-                    bn_row = p_lookup.get(bn_id) if bn_id else None
-                    bl_row = _traverse_to_bl(bn_row, p_lookup) if bn_row is not None else None
+                    row_aoi = roof_aois_for_scores[i]
+                    aoi_lookup = p_lookup_by_aoi.get(row_aoi, {})
+                    bn_id = _roof_to_bn_by_aoi.get(row_aoi, {}).get(row.get("feature_id"))
+                    bn_row = aoi_lookup.get(bn_id) if bn_id else None
+                    bl_row = _traverse_to_bl(bn_row, aoi_lookup) if bn_row is not None else None
                     return resolve_scores_with_bl_fallback(row, bl_row, country=country)
 
                 score_batch = _resolve_scores_batch(n_rows, _resolve_roof_scores, added_cols)
@@ -1803,13 +1831,13 @@ def _compute_feature_class_data(
                         if "roof_spotlight_index" in attrs:
                             rsi_lookup[(r_aoi, fid)] = attrs["roof_spotlight_index"]
                         else:
-                            # BL fallback goes through the feature_id-keyed parent
-                            # lookup (see layer-2 note in the PR); best-effort here.
-                            bn_id = _roof_to_building.get(fid)
+                            # BL fallback scoped to the roof row's own parcel.
+                            aoi_lookup = p_lookup_by_aoi.get(r_aoi, {})
+                            bn_id = _roof_to_bn_by_aoi.get(r_aoi, {}).get(fid)
                             if bn_id:
-                                bn_row = p_lookup.get(bn_id)
+                                bn_row = aoi_lookup.get(bn_id)
                                 if bn_row is not None:
-                                    resolved_rsi = resolve_footprint_rsi(bn_row, parent_lookup=p_lookup)
+                                    resolved_rsi = resolve_footprint_rsi(bn_row, parent_lookup=aoi_lookup)
                                     if resolved_rsi and "roof_spotlight_index" in resolved_rsi:
                                         rsi_lookup[(r_aoi, fid)] = resolved_rsi["roof_spotlight_index"]
 
@@ -1851,17 +1879,21 @@ def _compute_feature_class_data(
                 # then BL fallback via Building(New) → BL parent_id), same logic as per-roof.
                 if roof_attrs:
                     pcr_ids = buildings_linked["primary_child_roof_id"].values
+                    bn_aois = _aoi_id_values(buildings_linked)
                     bl_records = _dataframe_to_records_with_index(buildings_linked)
 
                     def _resolve_bn_rsi(i):
+                        # All lookups scoped to this building row's own parcel so a
+                        # multiparcel primary roof resolves its own clip's RSI.
+                        aoi_lookup = p_lookup_by_aoi.get(bn_aois[i], {})
                         pcr_id = pcr_ids[i]
-                        roof_row = p_lookup.get(pcr_id) if pd.notna(pcr_id) else None
+                        roof_row = aoi_lookup.get(pcr_id) if pd.notna(pcr_id) else None
                         if roof_row is not None:
                             rsi = extract_rsi_from_feature(roof_row)
                             if rsi:
                                 return rsi
                         # Roof lacks RSI or no child roof — traverse BN → BL
-                        return resolve_footprint_rsi(bl_records[i], parent_lookup=p_lookup)
+                        return resolve_footprint_rsi(bl_records[i], parent_lookup=aoi_lookup)
 
                     rsi_result = _resolve_rsi_batch(n_rows, _resolve_bn_rsi)
                     if rsi_result is not None:
@@ -1877,12 +1909,14 @@ def _compute_feature_class_data(
                 # Resolve best scores per building (same pattern as RSI).
                 if roof_attrs:
                     pcr_ids_for_scores = buildings_linked["primary_child_roof_id"].values
+                    bn_aois_for_scores = _aoi_id_values(buildings_linked)
                     bn_records_for_scores = _dataframe_to_records_with_index(buildings_linked)
 
                     def _resolve_bn_scores(i):
+                        aoi_lookup = p_lookup_by_aoi.get(bn_aois_for_scores[i], {})
                         pcr_id = pcr_ids_for_scores[i]
-                        roof_row = p_lookup.get(pcr_id) if pd.notna(pcr_id) else None
-                        bl_row = _traverse_to_bl(bn_records_for_scores[i], p_lookup)
+                        roof_row = aoi_lookup.get(pcr_id) if pd.notna(pcr_id) else None
+                        bl_row = _traverse_to_bl(bn_records_for_scores[i], aoi_lookup)
                         return resolve_scores_with_bl_fallback(roof_row, bl_row, country=country)
 
                     score_batch = _resolve_scores_batch(n_rows, _resolve_bn_scores, added_cols)
@@ -1898,8 +1932,18 @@ def _compute_feature_class_data(
                         else features_gdf[features_gdf["class_id"] == ROOF_INSTANCE_CLASS_ID].copy()
                     )
                     if len(roof_instances) > 0:
-                        # Create lookup from roof feature_id → roof's primary_child_roof_age_feature_id
-                        roof_to_ri = roofs_linked.set_index("feature_id")["primary_child_roof_age_feature_id"].to_dict()
+                        # Lookup from (aoi_id, roof feature_id) → roof's
+                        # primary_child_roof_age_feature_id. Scoped per parcel: a
+                        # multiparcel roof is IoU-linked to instances within each
+                        # parcel independently.
+                        roof_to_ri = {
+                            (aoi, fid): ri
+                            for aoi, fid, ri in zip(
+                                _aoi_id_values(roofs_linked),
+                                roofs_linked["feature_id"].values,
+                                roofs_linked["primary_child_roof_age_feature_id"].values,
+                            )
+                        }
 
                         # Roof age columns to link through (same as what roofs
                         # get). Iterate canonical order so building.csv lands
@@ -1932,17 +1976,30 @@ def _compute_feature_class_data(
                             col_rename[col] = prefixed_dst
 
                         if len(ri_cols) > 1:  # More than just feature_id
-                            ri_lookup = roof_instances[ri_cols].drop_duplicates(subset=["feature_id"])
-                            ri_lookup = ri_lookup.rename(columns=col_rename).set_index("feature_id")
+                            # Keyed by (aoi_id, feature_id) — same per-parcel row
+                            # identity as the roof-class mapping above.
+                            ri_lookup = roof_instances[ri_cols].copy()
+                            ri_lookup[AOI_ID_COLUMN_NAME] = _aoi_id_values(roof_instances)
+                            ri_lookup = ri_lookup.drop_duplicates(subset=[AOI_ID_COLUMN_NAME, "feature_id"])
+                            ri_lookup = ri_lookup.rename(columns=col_rename).set_index(
+                                [AOI_ID_COLUMN_NAME, "feature_id"]
+                            )
 
-                            # Map: building.primary_child_roof_id → roof.primary_child_roof_age_feature_id → ri attributes
-                            primary_roof_ids = buildings_linked["primary_child_roof_id"]
-                            primary_ri_ids = primary_roof_ids.map(roof_to_ri)
+                            # Map: building.(aoi, primary_child_roof_id) → roof's
+                            # primary_child_roof_age_feature_id → ri attributes
+                            bldg_aois_for_ri = _aoi_id_values(buildings_linked)
+                            ri_keys = [
+                                (aoi, roof_to_ri.get((aoi, pcr_id)))
+                                for aoi, pcr_id in zip(
+                                    bldg_aois_for_ri, buildings_linked["primary_child_roof_id"].values
+                                )
+                            ]
+                            ri_mapped = ri_lookup.reindex(ri_keys).reset_index(drop=True)
 
                             bldg_ri_batch = {}
-                            for col in ri_lookup.columns:
+                            for col in ri_mapped.columns:
                                 if col not in added_cols:
-                                    bldg_ri_batch[col] = primary_ri_ids.map(ri_lookup[col]).values
+                                    bldg_ri_batch[col] = ri_mapped[col].values
                                     added_cols.add(col)
                             convert_bool_columns_to_yn(bldg_ri_batch)
                             if bldg_ri_batch:
@@ -1977,24 +2034,29 @@ def _compute_feature_class_data(
                 else features_gdf[features_gdf["class_id"] == ROOF_ID].copy()
             )
             if len(roofs) > 0:
-                # Map each roof to its ancestor BL via IoU-linked Building(New)
+                # Map each roof to its ancestor BL via IoU-linked Building(New).
+                # The whole chain is keyed by (aoi_id, feature_id): in parcelMode
+                # a multiparcel roof/building/BL appears once per parcel with
+                # per-clip attributes, so linkage must stay within each parcel.
                 roof_to_bl = {}
-                for roof_fid, bn_id in _roof_to_building.items():
-                    if bn_id:
-                        bn_row = p_lookup.get(bn_id)
-                        if bn_row is not None:
-                            bl_fid = (
-                                bn_row.get("parent_id")
-                                if hasattr(bn_row, "get")
-                                else getattr(bn_row, "parent_id", None)
-                            )
-                            if bl_fid:
-                                roof_to_bl[roof_fid] = bl_fid
+                for r_aoi, aoi_roof_to_bn in _roof_to_bn_by_aoi.items():
+                    aoi_lookup = p_lookup_by_aoi.get(r_aoi, {})
+                    for roof_fid, bn_id in aoi_roof_to_bn.items():
+                        if bn_id:
+                            bn_row = aoi_lookup.get(bn_id)
+                            if bn_row is not None:
+                                bl_fid = (
+                                    bn_row.get("parent_id")
+                                    if hasattr(bn_row, "get")
+                                    else getattr(bn_row, "parent_id", None)
+                                )
+                                if bl_fid:
+                                    roof_to_bl[(r_aoi, roof_fid)] = bl_fid
 
-                # Group roofs by their BL and pick the largest as primary
+                # Group roofs by their (aoi, BL) and pick the largest as primary
                 bl_to_roofs = {}
-                for roof_fid, bl_fid in roof_to_bl.items():
-                    bl_to_roofs.setdefault(bl_fid, []).append(roof_fid)
+                for (r_aoi, roof_fid), bl_fid in roof_to_bl.items():
+                    bl_to_roofs.setdefault((r_aoi, bl_fid), []).append(roof_fid)
 
                 bl_primary_roof = {}
                 # Use the country-correct unit suffix (rather than always-metric) so this works
@@ -2005,25 +2067,32 @@ def _compute_feature_class_data(
                     if f"clipped_area_{roof_suffix}" in roofs.columns
                     else f"unclipped_area_{roof_suffix}" if f"unclipped_area_{roof_suffix}" in roofs.columns else None
                 )
-                roof_fid_to_idx = {fid: idx for idx, fid in enumerate(roofs["feature_id"].values)}
-                for bl_fid, roof_fids in bl_to_roofs.items():
+                # Row identity is (aoi_id, feature_id); largest-roof selection
+                # uses that parcel's own clipped area.
+                roof_key_to_idx = {
+                    (aoi, fid): idx
+                    for idx, (aoi, fid) in enumerate(zip(_aoi_id_values(roofs), roofs["feature_id"].values))
+                }
+                for (r_aoi, bl_fid), roof_fids in bl_to_roofs.items():
                     if roof_area_col and len(roof_fids) > 1:
                         best = max(
                             roof_fids,
-                            key=lambda f: (
-                                roofs.iloc[roof_fid_to_idx[f]][roof_area_col]
-                                if pd.notna(roofs.iloc[roof_fid_to_idx[f]][roof_area_col])
+                            key=lambda f, _a=r_aoi: (
+                                roofs.iloc[roof_key_to_idx[(_a, f)]][roof_area_col]
+                                if pd.notna(roofs.iloc[roof_key_to_idx[(_a, f)]][roof_area_col])
                                 else 0
                             ),
                         )
                     else:
                         best = roof_fids[0]
-                    bl_primary_roof[bl_fid] = best
+                    bl_primary_roof[(r_aoi, bl_fid)] = best
 
-                # Build linkage columns
+                # Build linkage columns; each BL row looks up its own parcel's chain
+                bl_aois = _aoi_id_values(class_features)
+                bl_fids = class_features["feature_id"].values
                 bl_linkage_batch = {}
-                primary_ids = [bl_primary_roof.get(fid) for fid in class_features["feature_id"].values]
-                child_counts = [len(bl_to_roofs.get(fid, [])) for fid in class_features["feature_id"].values]
+                primary_ids = [bl_primary_roof.get((aoi, fid)) for aoi, fid in zip(bl_aois, bl_fids)]
+                child_counts = [len(bl_to_roofs.get((aoi, fid), [])) for aoi, fid in zip(bl_aois, bl_fids)]
                 if "primary_child_roof_id" not in added_cols:
                     bl_linkage_batch["primary_child_roof_id"] = primary_ids
                     added_cols.add("primary_child_roof_id")
@@ -2034,16 +2103,11 @@ def _compute_feature_class_data(
                     df_parts.append(pd.DataFrame(bl_linkage_batch, index=range(n_rows)))
 
                 # Map primary child roof attributes to BL features.
-                # Cache is keyed by (aoi_id, feature_id); each roof row pulls its
-                # own parcel's clip, but this dict is keyed by feature_id because
-                # the whole BL linkage chain (roof_to_bl, bl_primary_roof,
-                # primary_ids) is fid-keyed — for a multiparcel roof the last row
-                # wins, so BL primary_child_roof_* attrs can still carry another
-                # parcel's clip. Pre-existing behaviour, part of the fid-keyed
-                # parent-chain limitation (see PR #210 follow-up note).
+                # Keyed by (aoi_id, feature_id) end-to-end so a multiparcel roof
+                # resolves to this BL row's own parcel clip, not another's.
                 roof_attrs = (
                     {
-                        fid: roof_attrs_cache.get((aoi, fid), {})
+                        (aoi, fid): roof_attrs_cache.get((aoi, fid), {})
                         for aoi, fid in zip(_aoi_id_values(roofs), roofs["feature_id"].values)
                     }
                     if roof_attrs_cache is not None
@@ -2051,9 +2115,11 @@ def _compute_feature_class_data(
                 )
 
                 if roof_attrs:
-                    roof_attrs_df = pd.DataFrame.from_dict(roof_attrs, orient="index")
+                    attr_keys = list(roof_attrs.keys())
+                    roof_attrs_df = pd.DataFrame([roof_attrs[k] for k in attr_keys])
                     roof_attrs_df.columns = [f"primary_child_roof_{c}" for c in roof_attrs_df.columns]
-                    mapped = roof_attrs_df.reindex(primary_ids).reset_index(drop=True)
+                    roof_attrs_df.index = pd.MultiIndex.from_tuples(attr_keys, names=[AOI_ID_COLUMN_NAME, "feature_id"])
+                    mapped = roof_attrs_df.reindex(list(zip(bl_aois, primary_ids))).reset_index(drop=True)
 
                     roof_attr_batch = {}
                     for col in sorted(mapped.columns):
@@ -2068,16 +2134,19 @@ def _compute_feature_class_data(
                     bl_records = _dataframe_to_records_with_index(class_features)
 
                     def _resolve_bl_rsi(i):
+                        # All lookups scoped to this BL row's own parcel.
+                        row_aoi = bl_aois[i]
+                        aoi_lookup = p_lookup_by_aoi.get(row_aoi, {})
                         pcr_id = primary_ids[i]
-                        roof_row = p_lookup.get(pcr_id) if pcr_id is not None else None
+                        roof_row = aoi_lookup.get(pcr_id) if pcr_id is not None else None
                         if roof_row is not None:
                             rsi = extract_rsi_from_feature(roof_row)
                             if not rsi:
-                                bn_id = _roof_to_building.get(pcr_id)
+                                bn_id = _roof_to_bn_by_aoi.get(row_aoi, {}).get(pcr_id)
                                 if bn_id:
-                                    bn_row = p_lookup.get(bn_id)
+                                    bn_row = aoi_lookup.get(bn_id)
                                     if bn_row is not None:
-                                        rsi = resolve_footprint_rsi(bn_row, parent_lookup=p_lookup)
+                                        rsi = resolve_footprint_rsi(bn_row, parent_lookup=aoi_lookup)
                             return rsi
                         # No child roof — use BL's own RSI
                         return extract_rsi_from_feature(bl_records[i])
@@ -2097,8 +2166,9 @@ def _compute_feature_class_data(
                     bl_records_for_scores = _dataframe_to_records_with_index(class_features)
 
                     def _resolve_bl_scores(i):
+                        aoi_lookup = p_lookup_by_aoi.get(bl_aois[i], {})
                         pcr_id = primary_ids[i]
-                        roof_row = p_lookup.get(pcr_id) if pcr_id is not None else None
+                        roof_row = aoi_lookup.get(pcr_id) if pcr_id is not None else None
                         return resolve_scores_with_bl_fallback(roof_row, bl_records_for_scores[i], country=country)
 
                     score_batch = _resolve_scores_batch(n_rows, _resolve_bl_scores, added_cols)

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -1020,15 +1020,17 @@ def _aoi_id_values(df):
 
     The chunk frame is indexed by aoi_id in the standalone export path but carries
     aoi_id as a column with a RangeIndex in the streaming path (the on=aoi_id merges
-    in process_chunk reset the index). Roof attribute lookups key on (aoi_id,
-    feature_id), so both layouts must resolve to the same aoi_id series that the
-    cache producer (via _dataframe_to_records_with_index) sees.
+    in process_chunk reset the index). Roof attribute cache keys are (aoi_id,
+    feature_id); the cache producer and all consumers resolve aoi_id through this
+    helper so their keys always agree. Raises rather than degrading: a frame with
+    no aoi_id would collapse the cache back to feature_id-only keys — the exact
+    multiparcel collision this keying exists to prevent.
     """
     if AOI_ID_COLUMN_NAME in df.columns:
         return df[AOI_ID_COLUMN_NAME].values
     if df.index.name == AOI_ID_COLUMN_NAME:
         return df.index.values
-    return [None] * len(df)
+    raise ValueError(f"Frame has no '{AOI_ID_COLUMN_NAME}' column or index; cannot key roof attributes per parcel")
 
 
 def _description_to_cname(description: str) -> str:
@@ -1156,9 +1158,10 @@ def _compute_all_per_class_data(
             )
             roof_attrs_cache_chunk = {}
             roof_records = _dataframe_to_records_with_index(roof_features_chunk)
+            roof_aoi_vals = _aoi_id_values(roof_features_chunk)
             for ridx, row in enumerate(roof_records):
                 try:
-                    roof_aoi = row.get(AOI_ID_COLUMN_NAME)
+                    roof_aoi = roof_aoi_vals[ridx]
                     aoi_children = child_by_aoi.get(roof_aoi) if roof_aoi is not None else None
                     attrs = flatten_roof_attributes(
                         [row],
@@ -1277,7 +1280,9 @@ def _compute_feature_class_data(
         roof_features: Pre-filtered roof features
         non_roof_features: Pre-filtered non-roof features
         roof_instance_features: Pre-filtered roof instance features
-        roof_attrs_cache: Pre-computed dict mapping roof feature_id to flattened attribute dicts
+        roof_attrs_cache: Pre-computed dict mapping (aoi_id, feature_id) to flattened attribute
+            dicts. Keyed per parcel because in parcelMode a multiparcel roof appears once per
+            parcel with attributes recomputed on that parcel's clipped geometry.
         parent_lookup: Pre-built dict mapping feature_id to feature record, for parent-chain
             traversal (rebuilt from features_gdf if not provided)
         roof_to_building_lookup: Pre-built dict mapping roof feature_id to parent building
@@ -1734,10 +1739,11 @@ def _compute_feature_class_data(
                     t_bldg_roof_flatten = time.monotonic()
                     roof_attrs = {}
                     roof_records = _dataframe_to_records_with_index(roofs_linked)
+                    roof_aoi_vals = _aoi_id_values(roofs_linked)
 
                     for idx, row in enumerate(roof_records):
                         try:
-                            roof_aoi = row.get(AOI_ID_COLUMN_NAME)
+                            roof_aoi = roof_aoi_vals[idx]
                             aoi_children = child_by_aoi_bldg.get(roof_aoi) if roof_aoi is not None else None
                             attrs = flatten_roof_attributes(
                                 [row],
@@ -1763,9 +1769,7 @@ def _compute_feature_class_data(
                     attr_keys = list(roof_attrs.keys())
                     roof_attrs_df = pd.DataFrame([roof_attrs[k] for k in attr_keys])
                     roof_attrs_df.columns = [f"primary_child_roof_{c}" for c in roof_attrs_df.columns]
-                    roof_attrs_df.index = pd.MultiIndex.from_tuples(
-                        attr_keys, names=[AOI_ID_COLUMN_NAME, "feature_id"]
-                    )
+                    roof_attrs_df.index = pd.MultiIndex.from_tuples(attr_keys, names=[AOI_ID_COLUMN_NAME, "feature_id"])
                     lookup_keys = list(
                         zip(_aoi_id_values(buildings_linked), buildings_linked["primary_child_roof_id"].values)
                     )
@@ -2030,9 +2034,13 @@ def _compute_feature_class_data(
                     df_parts.append(pd.DataFrame(bl_linkage_batch, index=range(n_rows)))
 
                 # Map primary child roof attributes to BL features.
-                # Cache is keyed by (aoi_id, feature_id); pull each roof's own
-                # parcel while keeping this dict keyed by feature_id for the
-                # primary_child_roof reindex below.
+                # Cache is keyed by (aoi_id, feature_id); each roof row pulls its
+                # own parcel's clip, but this dict is keyed by feature_id because
+                # the whole BL linkage chain (roof_to_bl, bl_primary_roof,
+                # primary_ids) is fid-keyed — for a multiparcel roof the last row
+                # wins, so BL primary_child_roof_* attrs can still carry another
+                # parcel's clip. Pre-existing behaviour, part of the fid-keyed
+                # parent-chain limitation (see PR #210 follow-up note).
                 roof_attrs = (
                     {
                         fid: roof_attrs_cache.get((aoi, fid), {})
@@ -2212,9 +2220,10 @@ def export_feature_class(
         roof_features: Pre-filtered roof features (avoids repeated features_gdf scans)
         non_roof_features: Pre-filtered non-roof features (avoids repeated features_gdf scans)
         roof_instance_features: Pre-filtered roof instance features (avoids repeated features_gdf scans)
-        roof_attrs_cache: Pre-computed dict mapping roof feature_id to flattened attribute dicts.
-                         When provided, skips the per-row flatten_roof_attributes loop for both
-                         ROOF_ID and BUILDING_NEW_ID paths (avoids duplicate flattening).
+        roof_attrs_cache: Pre-computed dict mapping (aoi_id, feature_id) to flattened attribute
+                         dicts (keyed per parcel — see _compute_feature_class_data). When provided,
+                         skips the per-row flatten_roof_attributes loop for both ROOF_ID and
+                         BUILDING_NEW_ID paths (avoids duplicate flattening).
 
     Returns:
         Tuple of (tabular_path, geo_parquet_path) or (None, None) if no features

--- a/nmaipy/parcels.py
+++ b/nmaipy/parcels.py
@@ -81,6 +81,7 @@ __all__ = [
     "link_roof_instances_to_roofs",
     "link_roofs_to_buildings",
     "build_parent_lookup",
+    "build_parent_lookup_by_aoi",
     "extract_rsi_from_feature",
     "resolve_footprint_rsi",
     "calculate_child_feature_attributes",
@@ -771,6 +772,12 @@ def build_parent_lookup(features_gdf: gpd.GeoDataFrame) -> dict:
     Returns plain dicts (not pd.Series views) so the lookup is lightweight
     and decoupled from the source DataFrame.  Resets a named index (e.g.
     aoi_id) into the dict so it is not silently dropped.
+
+    Only valid for a single AOI's features: in parcelMode a feature that
+    overlaps multiple parcels appears once per parcel (same feature_id) with
+    attributes computed on that parcel's clipped geometry, so on a multi-AOI
+    frame this dict would collapse those rows to whichever parcel came last.
+    For chunk-level (multi-AOI) frames use build_parent_lookup_by_aoi().
     """
     if features_gdf is None or len(features_gdf) == 0 or "feature_id" not in features_gdf.columns:
         return {}
@@ -781,6 +788,32 @@ def build_parent_lookup(features_gdf: gpd.GeoDataFrame) -> dict:
     if filtered.index.name is not None:
         filtered = filtered.reset_index()
     return dict(zip(filtered["feature_id"].values, filtered.to_dict("records")))
+
+
+def build_parent_lookup_by_aoi(features_gdf: gpd.GeoDataFrame) -> dict:
+    """Build {aoi_id: {feature_id: row dict}} for parent_id chain traversal.
+
+    Parent chains never cross parcels — a feature's parent is returned in the
+    same parcel's response — so scoping the lookup per AOI keeps every
+    traversal inside the parcel whose clip produced the row, and feature_id is
+    unique within each sub-dict. Consumers take their parcel's sub-dict
+    (`lookup.get(aoi_id, {})`) and use it exactly like build_parent_lookup()
+    output; resolve_footprint_rsi() / _traverse_to_bl() work unchanged on it.
+    """
+    if features_gdf is None or len(features_gdf) == 0 or "feature_id" not in features_gdf.columns:
+        return {}
+    mask = features_gdf["feature_id"].notna()
+    filtered = features_gdf[mask]
+    if filtered.index.name is not None:
+        filtered = filtered.reset_index()
+    if AOI_ID_COLUMN_NAME not in filtered.columns:
+        raise ValueError(f"Frame has no '{AOI_ID_COLUMN_NAME}' column or index; cannot scope parent lookup per parcel")
+    lookup: dict = {}
+    for aoi, fid, rec in zip(
+        filtered[AOI_ID_COLUMN_NAME].values, filtered["feature_id"].values, filtered.to_dict("records")
+    ):
+        lookup.setdefault(aoi, {})[fid] = rec
+    return lookup
 
 
 def resolve_footprint_rsi(
@@ -803,9 +836,12 @@ def resolve_footprint_rsi(
     Args:
         feature: A feature row (pd.Series or dict) with parent_id and roof_spotlight_index.
             For BL fallback, pass the IoU-linked Building(New) row, not the Roof row.
-        features_gdf: The full features GeoDataFrame for parent_id lookups.
-            Used to build parent_lookup if not provided.
-        parent_lookup: Pre-built feature_id → row dict for fast traversal.
+        features_gdf: Features GeoDataFrame for parent_id lookups, used to build
+            parent_lookup if not provided. Must be scoped to the feature's own
+            AOI (see build_parent_lookup); pass a per-AOI sub-dict of
+            build_parent_lookup_by_aoi() output for chunk-level frames.
+        parent_lookup: Pre-built feature_id → row dict for fast traversal,
+            scoped to the feature's own AOI.
             Pass this when calling in a loop to avoid rebuilding per call.
 
     Returns:
@@ -1509,8 +1545,10 @@ def parcel_rollup(
             df["_geometry_projected"] = temp_gdf.to_crs(projected_crs).geometry.values
             geometry_projected_col = "_geometry_projected"
 
-    # Build parent lookup once for the whole chunk; feature_ids are globally unique across AOIs
-    chunk_parent_lookup = build_parent_lookup(features_gdf)
+    # Build parent lookup once for the whole chunk, scoped per AOI: in parcelMode
+    # a multiparcel feature appears once per parcel (same feature_id, per-clip
+    # attributes), so each parcel must traverse only its own rows.
+    chunk_parent_lookup = build_parent_lookup_by_aoi(features_gdf)
 
     rollups = []
     # Loop over parcels with features in them
@@ -1547,7 +1585,7 @@ def parcel_rollup(
             primary_lon=primary_lon,
             geometry_projected_col=geometry_projected_col,
             projected_crs=projected_crs,
-            parent_lookup=chunk_parent_lookup,
+            parent_lookup=chunk_parent_lookup.get(aoi_id) or {},
         )
         parcel[AOI_ID_COLUMN_NAME] = aoi_id
         if "mesh_date" in group.columns:
@@ -1577,7 +1615,7 @@ def parcel_rollup(
             country=country,
             parcel_geom=row.geometry if hasgeom else None,
             primary_decision=primary_decision,
-            parent_lookup=chunk_parent_lookup,
+            parent_lookup={},
         )
         aoi_id = row._asdict()["Index"]
         parcel[AOI_ID_COLUMN_NAME] = aoi_id

--- a/tests/test_multiparcel_roof_attrs.py
+++ b/tests/test_multiparcel_roof_attrs.py
@@ -1,0 +1,131 @@
+"""Regression tests for multiparcel roof attribute cache keying.
+
+In ``parcelMode`` a roof that overlaps more than one parcel is returned once per
+parcel, each row carrying attributes (RSI, component areas, ...) recomputed on
+*that* parcel's clipped geometry. The per-class attribute cache in
+``_compute_all_per_class_data`` must therefore key on ``(aoi_id, feature_id)`` —
+keying by ``feature_id`` alone lets one parcel's clip overwrite another's, so
+every duplicate row inherits whichever parcel was flattened last.
+
+See the roof-only bug: same roof, two parcels, RSI 15/0.57 (this parcel) vs
+96/0.92 (neighbour) — both rows used to export 96/0.92.
+"""
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Polygon
+
+from nmaipy.constants import AOI_ID_COLUMN_NAME, BUILDING_NEW_ID, ROOF_ID
+from nmaipy.exporter import _compute_all_per_class_data
+
+SHARED_ROOF_FID = "2aa2818b-50ba-5470-9c34-59ed24fb7fa4"
+
+# Square geometries per parcel — distinct locations so each AOI's roof/building
+# pair matches by IoU without cross-AOI overlap.
+_SOUTH_GEOM = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
+_NORTH_GEOM = Polygon([(10, 10), (10, 11), (11, 11), (11, 10)])
+
+
+def _roof_row(aoi_id, geom, rsi_value, rsi_conf, clipped_sqft):
+    return {
+        AOI_ID_COLUMN_NAME: aoi_id,
+        "feature_id": SHARED_ROOF_FID,
+        "class_id": ROOF_ID,
+        "description": "Roof",
+        "confidence": 0.9,
+        "fidelity": 0.9,
+        "parent_id": None,
+        "is_primary": True,
+        "geometry": geom,
+        "area_sqft": clipped_sqft,
+        "clipped_area_sqft": clipped_sqft,
+        "unclipped_area_sqft": 1147.0,
+        "area_sqm": round(clipped_sqft / 10.7639, 2),
+        "clipped_area_sqm": round(clipped_sqft / 10.7639, 2),
+        "unclipped_area_sqm": 106.6,
+        "attributes": [],
+        "roof_spotlight_index": {"value": rsi_value, "confidence": rsi_conf, "modelVersion": "B.0"},
+        "survey_date": "2026-03-28",
+        "mesh_date": "",
+        "belongs_to_parcel": True,
+    }
+
+
+def _building_row(aoi_id, feature_id, geom):
+    return {
+        AOI_ID_COLUMN_NAME: aoi_id,
+        "feature_id": feature_id,
+        "class_id": BUILDING_NEW_ID,
+        "description": "Building",
+        "confidence": 0.95,
+        "fidelity": 0.95,
+        "parent_id": None,
+        "is_primary": True,
+        "geometry": geom,
+        "area_sqft": 900.0,
+        "clipped_area_sqft": 900.0,
+        "unclipped_area_sqft": 900.0,
+        "area_sqm": 83.6,
+        "clipped_area_sqm": 83.6,
+        "unclipped_area_sqm": 83.6,
+        "attributes": [],
+        "survey_date": "2026-03-28",
+        "mesh_date": "",
+        "belongs_to_parcel": True,
+    }
+
+
+def _make_chunk(rows, indexed=True):
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+    # Standalone layout indexes by aoi_id; streaming layout keeps it as a column
+    # with a RangeIndex (after the on=aoi_id merges). Both must resolve the same.
+    return gdf.set_index(AOI_ID_COLUMN_NAME) if indexed else gdf
+
+
+@pytest.mark.parametrize("indexed", [True, False], ids=["aoi_index", "aoi_column"])
+def test_multiparcel_roof_gets_own_clip_rsi(indexed):
+    """Roof-only export: each parcel's row keeps its own clipped RSI."""
+    chunk = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, 15, 0.57, 691.0),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+        ],
+        indexed=indexed,
+    )
+    res = _compute_all_per_class_data(
+        chunk, country="us", aoi_input_columns=[], whitelisted_classes=[ROOF_ID], threads=1
+    )
+    roof = res[ROOF_ID]["tabular"].to_pandas().set_index(AOI_ID_COLUMN_NAME)
+
+    assert roof.loc["parcel_south", "roof_spotlight_index"] == 15
+    assert roof.loc["parcel_south", "roof_spotlight_index_confidence"] == 0.57
+    assert roof.loc["parcel_north", "roof_spotlight_index"] == 96
+    assert roof.loc["parcel_north", "roof_spotlight_index_confidence"] == 0.92
+
+
+def test_multiparcel_building_min_max_rsi_uses_own_parcel_clip():
+    """Building(New) export: per-building child-roof RSI min/max resolve to the
+    building's own parcel clip of a shared multiparcel roof (Section D layer-1)."""
+    chunk = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, 15, 0.57, 691.0),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+            _building_row("parcel_south", "bldg-south", _SOUTH_GEOM),
+            _building_row("parcel_north", "bldg-north", _NORTH_GEOM),
+        ]
+    )
+    res = _compute_all_per_class_data(
+        chunk,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[ROOF_ID, BUILDING_NEW_ID],
+        threads=1,
+    )
+    bldg = res[BUILDING_NEW_ID]["tabular"].to_pandas().set_index(AOI_ID_COLUMN_NAME)
+
+    # Single child roof per building → min == max == that parcel's own clip RSI.
+    assert bldg.loc["parcel_south", "roof_spotlight_index_min"] == 15
+    assert bldg.loc["parcel_south", "roof_spotlight_index_max"] == 15
+    assert bldg.loc["parcel_north", "roof_spotlight_index_min"] == 96
+    assert bldg.loc["parcel_north", "roof_spotlight_index_max"] == 96

--- a/tests/test_multiparcel_roof_attrs.py
+++ b/tests/test_multiparcel_roof_attrs.py
@@ -1,14 +1,22 @@
-"""Regression tests for multiparcel roof attribute cache keying.
+"""Regression tests for multiparcel per-parcel row identity in parcelMode.
 
-In ``parcelMode`` a roof that overlaps more than one parcel is returned once per
-parcel, each row carrying attributes (RSI, component areas, ...) recomputed on
-*that* parcel's clipped geometry. The per-class attribute cache in
-``_compute_all_per_class_data`` must therefore key on ``(aoi_id, feature_id)`` —
-keying by ``feature_id`` alone lets one parcel's clip overwrite another's, so
-every duplicate row inherits whichever parcel was flattened last.
+In ``parcelMode`` ANY feature (roof, building, building lifecycle) that overlaps
+more than one parcel is returned once per parcel, each row carrying attributes
+(RSI, component areas, ...) recomputed on *that* parcel's clipped geometry. The
+row identity is therefore ``(aoi_id, feature_id)`` — every cross-row structure
+keyed by ``feature_id`` alone (attribute caches, parent-chain lookups,
+roof→building→BL linkage) lets one parcel's clip overwrite another's, so
+duplicate rows inherit whichever parcel came last.
 
-See the roof-only bug: same roof, two parcels, RSI 15/0.57 (this parcel) vs
-96/0.92 (neighbour) — both rows used to export 96/0.92.
+Covered here:
+- roof attribute cache (roof class, both frame layouts)
+- Building(New): child-roof RSI min/max AND headline resolved RSI
+- Building Lifecycle: primary-child-roof linkage and resolved RSI
+- roof-class RSI fallback via BL when the roof has no RSI of its own
+- parcel_rollup: per-parcel RSI min/max via the chunk-hoisted parent lookup
+
+See the original roof-only bug: same roof, two parcels, RSI 15/0.57 (this
+parcel) vs 96/0.92 (neighbour) — both rows used to export 96/0.92.
 """
 
 import geopandas as gpd
@@ -16,10 +24,13 @@ import pandas as pd
 import pytest
 from shapely.geometry import Polygon
 
-from nmaipy.constants import AOI_ID_COLUMN_NAME, BUILDING_NEW_ID, ROOF_ID
+from nmaipy.constants import AOI_ID_COLUMN_NAME, BUILDING_LIFECYCLE_ID, BUILDING_NEW_ID, ROOF_ID
 from nmaipy.exporter import _compute_all_per_class_data
+from nmaipy.parcels import parcel_rollup
 
 SHARED_ROOF_FID = "2aa2818b-50ba-5470-9c34-59ed24fb7fa4"
+SHARED_BUILDING_FID = "7f3d9c01-1b2a-5e4d-8f6c-0123456789ab"
+SHARED_BL_FID = "9e8d7c65-4b3a-52f1-8e0d-fedcba987654"
 
 # Square geometries per parcel — distinct locations so each AOI's roof/building
 # pair matches by IoU without cross-AOI overlap.
@@ -27,7 +38,7 @@ _SOUTH_GEOM = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
 _NORTH_GEOM = Polygon([(10, 10), (10, 11), (11, 11), (11, 10)])
 
 
-def _roof_row(aoi_id, geom, rsi_value, rsi_conf, clipped_sqft):
+def _roof_row(aoi_id, geom, rsi_value, rsi_conf, clipped_sqft, with_rsi=True):
     return {
         AOI_ID_COLUMN_NAME: aoi_id,
         "feature_id": SHARED_ROOF_FID,
@@ -45,14 +56,43 @@ def _roof_row(aoi_id, geom, rsi_value, rsi_conf, clipped_sqft):
         "clipped_area_sqm": round(clipped_sqft / 10.7639, 2),
         "unclipped_area_sqm": 106.6,
         "attributes": [],
-        "roof_spotlight_index": {"value": rsi_value, "confidence": rsi_conf, "modelVersion": "B.0"},
+        "roof_spotlight_index": (
+            {"value": rsi_value, "confidence": rsi_conf, "modelVersion": "B.0"} if with_rsi else None
+        ),
         "survey_date": "2026-03-28",
         "mesh_date": "",
         "belongs_to_parcel": True,
     }
 
 
-def _building_row(aoi_id, feature_id, geom):
+def _bl_row(aoi_id, geom, rsi_value=None, rsi_conf=None):
+    return {
+        AOI_ID_COLUMN_NAME: aoi_id,
+        "feature_id": SHARED_BL_FID,
+        "class_id": BUILDING_LIFECYCLE_ID,
+        "description": "Building Lifecycle",
+        "confidence": 0.9,
+        "fidelity": 0.9,
+        "parent_id": None,
+        "is_primary": True,
+        "geometry": geom,
+        "area_sqft": 900.0,
+        "clipped_area_sqft": 900.0,
+        "unclipped_area_sqft": 900.0,
+        "area_sqm": 83.6,
+        "clipped_area_sqm": 83.6,
+        "unclipped_area_sqm": 83.6,
+        "attributes": [],
+        "roof_spotlight_index": (
+            {"value": rsi_value, "confidence": rsi_conf, "modelVersion": "B.0"} if rsi_value is not None else None
+        ),
+        "survey_date": "2026-03-28",
+        "mesh_date": "",
+        "belongs_to_parcel": True,
+    }
+
+
+def _building_row(aoi_id, feature_id, geom, parent_id=None):
     return {
         AOI_ID_COLUMN_NAME: aoi_id,
         "feature_id": feature_id,
@@ -60,7 +100,7 @@ def _building_row(aoi_id, feature_id, geom):
         "description": "Building",
         "confidence": 0.95,
         "fidelity": 0.95,
-        "parent_id": None,
+        "parent_id": parent_id,
         "is_primary": True,
         "geometry": geom,
         "area_sqft": 900.0,
@@ -129,3 +169,131 @@ def test_multiparcel_building_min_max_rsi_uses_own_parcel_clip():
     assert bldg.loc["parcel_south", "roof_spotlight_index_max"] == 15
     assert bldg.loc["parcel_north", "roof_spotlight_index_min"] == 96
     assert bldg.loc["parcel_north", "roof_spotlight_index_max"] == 96
+
+
+def test_multiparcel_building_headline_rsi_uses_own_parcel_clip():
+    """Building(New) export: the headline resolved roof_spotlight_index goes
+    through the parent lookup (building → primary child roof row), which must be
+    scoped to the building's own parcel — a shared multiparcel building must not
+    read the other parcel's roof clip."""
+    chunk = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, 15, 0.57, 691.0),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+            _building_row("parcel_south", SHARED_BUILDING_FID, _SOUTH_GEOM),
+            _building_row("parcel_north", SHARED_BUILDING_FID, _NORTH_GEOM),
+        ]
+    )
+    res = _compute_all_per_class_data(
+        chunk,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[ROOF_ID, BUILDING_NEW_ID],
+        threads=1,
+    )
+    bldg = res[BUILDING_NEW_ID]["tabular"].to_pandas().set_index(AOI_ID_COLUMN_NAME)
+
+    assert bldg.loc["parcel_south", "roof_spotlight_index"] == 15
+    assert bldg.loc["parcel_south", "roof_spotlight_index_confidence"] == 0.57
+    assert bldg.loc["parcel_north", "roof_spotlight_index"] == 96
+    assert bldg.loc["parcel_north", "roof_spotlight_index_confidence"] == 0.92
+
+
+def test_multiparcel_bl_rsi_and_linkage_use_own_parcel_clip():
+    """Building Lifecycle export: the Roof →(IoU)→ BN →(parent_id)→ BL chain and
+    the resolved RSI must stay within each BL row's own parcel for a shared
+    multiparcel roof/building/BL."""
+    chunk = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, 15, 0.57, 691.0),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+            _building_row("parcel_south", SHARED_BUILDING_FID, _SOUTH_GEOM, parent_id=SHARED_BL_FID),
+            _building_row("parcel_north", SHARED_BUILDING_FID, _NORTH_GEOM, parent_id=SHARED_BL_FID),
+            _bl_row("parcel_south", _SOUTH_GEOM),
+            _bl_row("parcel_north", _NORTH_GEOM),
+        ]
+    )
+    res = _compute_all_per_class_data(
+        chunk,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[ROOF_ID, BUILDING_NEW_ID, BUILDING_LIFECYCLE_ID],
+        threads=1,
+    )
+    bl = res[BUILDING_LIFECYCLE_ID]["tabular"].to_pandas().set_index(AOI_ID_COLUMN_NAME)
+
+    # Linkage resolves within each parcel
+    assert bl.loc["parcel_south", "primary_child_roof_id"] == SHARED_ROOF_FID
+    assert bl.loc["parcel_north", "primary_child_roof_id"] == SHARED_ROOF_FID
+    assert bl.loc["parcel_south", "child_roof_count"] == 1
+    assert bl.loc["parcel_north", "child_roof_count"] == 1
+
+    # Resolved RSI comes from the BL row's own parcel clip of the shared roof
+    assert bl.loc["parcel_south", "roof_spotlight_index"] == 15
+    assert bl.loc["parcel_south", "roof_spotlight_index_confidence"] == 0.57
+    assert bl.loc["parcel_north", "roof_spotlight_index"] == 96
+    assert bl.loc["parcel_north", "roof_spotlight_index_confidence"] == 0.92
+
+
+def test_multiparcel_roof_bl_fallback_rsi_uses_own_parcel_bl():
+    """Roof export, no-own-RSI case: RSI falls back through Roof →(IoU)→ BN
+    →(parent_id)→ BL, and must land on the roof row's own parcel's BL clip.
+    This is the 'RSI applied to the building lifecycle instead of the roof'
+    scenario (e.g. structural damage)."""
+    chunk = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, None, None, 691.0, with_rsi=False),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+            _building_row("parcel_south", SHARED_BUILDING_FID, _SOUTH_GEOM, parent_id=SHARED_BL_FID),
+            _building_row("parcel_north", SHARED_BUILDING_FID, _NORTH_GEOM, parent_id=SHARED_BL_FID),
+            _bl_row("parcel_south", _SOUTH_GEOM, rsi_value=44, rsi_conf=0.61),
+            _bl_row("parcel_north", _NORTH_GEOM, rsi_value=77, rsi_conf=0.71),
+        ]
+    )
+    res = _compute_all_per_class_data(
+        chunk,
+        country="us",
+        aoi_input_columns=[],
+        whitelisted_classes=[ROOF_ID],
+        threads=1,
+    )
+    roof = res[ROOF_ID]["tabular"].to_pandas().set_index(AOI_ID_COLUMN_NAME)
+
+    # South roof has no RSI of its own → resolved from parcel_south's BL clip (44),
+    # not parcel_north's BL clip (77). North roof keeps its own RSI.
+    assert roof.loc["parcel_south", "roof_spotlight_index"] == 44
+    assert roof.loc["parcel_north", "roof_spotlight_index"] == 96
+
+
+def test_multiparcel_rollup_rsi_min_max_use_own_parcel_clip():
+    """parcel_rollup: the RSI min/max/weighted-mean loop reads roof rows through
+    the chunk-hoisted parent lookup, which must be scoped per parcel — each
+    parcel's rollup row reflects its own clip of a shared multiparcel roof."""
+    features = _make_chunk(
+        [
+            _roof_row("parcel_south", _SOUTH_GEOM, 15, 0.57, 691.0),
+            _roof_row("parcel_north", _NORTH_GEOM, 96, 0.92, 455.0),
+        ]
+    )
+    parcels_gdf = gpd.GeoDataFrame(
+        {"geometry": [_SOUTH_GEOM, _NORTH_GEOM]},
+        index=pd.Index(["parcel_south", "parcel_north"], name=AOI_ID_COLUMN_NAME),
+        crs="EPSG:4326",
+    )
+    classes_df = pd.DataFrame({"id": [ROOF_ID], "description": ["roof"]}).set_index("id")
+
+    rollup = parcel_rollup(
+        parcels_gdf,
+        features,
+        classes_df,
+        country="us",
+        primary_decision="largest_intersection",
+    )
+
+    assert rollup.loc["parcel_south", "roof_spotlight_index_min"] == 15
+    assert rollup.loc["parcel_south", "roof_spotlight_index_max"] == 15
+    assert rollup.loc["parcel_north", "roof_spotlight_index_min"] == 96
+    assert rollup.loc["parcel_north", "roof_spotlight_index_max"] == 96
+    # Primary-roof RSI resolves from each parcel's own primary roof row
+    assert rollup.loc["parcel_south", "primary_roof_spotlight_index"] == 15
+    assert rollup.loc["parcel_north", "primary_roof_spotlight_index"] == 96


### PR DESCRIPTION
## Problem

In `parcelMode`, a roof that crosses a parcel boundary (clipped area < unclipped) is returned once per parcel it overlaps, each row carrying attributes (`roof_spotlight_index`, component areas, …) computed on **that parcel's clipped geometry**. In the per-class export (`roof.parquet`), such a roof is assigned attributes computed on a **different parcel's clip** — a value the Feature API never returns for that parcel.

Manifests with roof-only pack sets (no `building`/`building_structures`/damage packs). Masked for RSI when a building/damage pack is present, because the `if bl_in_features:` branch re-resolves RSI from the raw feature; component areas are never re-resolved and stay wrong either way. Raw `features.parquet` is unaffected.

### Reproduction

Roof `feature_id = 2aa2818b-…-59ed24fb7fa4` spans two adjacent parcels; direct Feature API calls (same packs/include/`parcelMode=true`/`gen6-`) score each clip independently:

| aoi_id | clip | Feature API `roofSpotlightIndex` | export (before) |
|---|---|---|---|
| `3343859589737964797` | 64.2 m² | `{value: 15, confidence: 0.57}` | **96 / 0.92 ❌** |
| `3343859589752522187` | 42.3 m² | `{value: 96, confidence: 0.92}` | 96 / 0.92 |

## Mechanism

`feature_id` values originate in the raw vector tiles, and features can be large (span parcel boundaries and grid cells). They are **stable within a survey** — two AOIs that hit the same feature from the same survey share the ID, which is what gridding dedup and cross-AOI matching rely on — but **not stable across survey dates**. Each per-AOI row of a shared feature carries attributes computed on that parcel's clip, so the row identity in any multi-AOI frame is `(aoi_id, feature_id)`, never `feature_id` alone. This is now documented in `CLAUDE.md` (Feature ID Semantics).

## Root cause

Cross-row structures in the per-class export and rollup were keyed by `feature_id` alone, so for a multiparcel feature the last parcel processed overwrote the entry and every consumer read that single entry for all of the feature's rows.

## Fix

**Layer 1 — roof attribute cache** (`75e2548`): key `roof_attrs_cache` by `(aoi_id, feature_id)` and look up per parcel — roof class attributes, Building(New) `primary_child_roof_*` reindex, and child-roof RSI min/max. `_aoi_id_values()` resolves `aoi_id` whether it is the frame index (standalone path) or a column (streaming path), and raises if neither.

**Layer 2 — parent-chain and linkage lookups** (`144f94e`): parent chains and IoU linkage never cross parcels, so chunk-level lookups are hoisted as nested `{aoi_id: {feature_id: …}}` (`build_parent_lookup_by_aoi`) and every consumer takes its row's own parcel sub-dict. Traversal helpers (`resolve_footprint_rsi`, `_traverse_to_bl`) and `feature_attributes`' per-parcel internals work unchanged on the scoped flat dict. Fixed consumers:

- **Building(New)**: headline resolved `roof_spotlight_index` + peril scores (`_resolve_bn_rsi` / `_resolve_bn_scores`)
- **Building Lifecycle**: the whole Roof →(IoU)→ BN →(parent_id)→ BL chain — primary-child-roof selection (largest-roof choice previously used another parcel's clipped area), `primary_child_roof_*` attributes, resolved RSI/scores
- **Roof**: RSI/peril-score BL fallback when the roof has no RSI of its own (the structural-damage case where RSI lives on the BL)
- **rollup.csv**: `parcel_rollup`'s chunk-hoisted lookup (its comment asserted "feature_ids are globally unique across AOIs", which parcelMode violates) — RSI min/max/area-weighted-mean and primary-roof BL fallback were exposed
- **Roof-age instance maps** (`roof_to_ri`, `ri_lookup`): clip-independent values today, but re-keyed per parcel so future clip-dependent columns can't silently regress

Semantic consequence: cross-parcel "borrowing" is gone — a parent chain that is broken within a parcel now yields null rather than another parcel's clip value.

## Tests

`tests/test_multiparcel_roof_attrs.py` — 7 regression tests, each verified to fail on the commit preceding its fix:

- roof class keeps its own clip RSI (both frame layouts)
- Building(New) child-roof RSI min/max
- Building(New) headline resolved RSI
- Building Lifecycle linkage + resolved RSI
- roof RSI BL-fallback resolves through the roof row's own parcel's BL
- `parcel_rollup` RSI min/max per parcel

Full `pytest` non-live suite green (770 passed). Live end-to-end validation: a real NJ parcel split into two AOIs through its roof (guaranteed multiparcel roof, real API data) — before: one parcel inherited the other's flattened values across 16 columns, including `shingle_area_sqft` larger than the parcel's entire roof clip; after: each parcel's `roof.csv` and `building.csv` `primary_child_roof_*` values match its own clip and stay internally consistent.
