### PR TITLE
fix: clarify retired roof shape classes (shed, flat_(deprecated)) in data dictionaries

### DIFF
--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -22,9 +22,23 @@ from functools import lru_cache
 from importlib import resources
 from typing import Optional
 
+from nmaipy.constants import RETIRED_ROOF_SHAPE_DESCRIPTIONS
+
 # Sentinel string for fields that the PM must fill in. Surfaces visibly in
 # generated dictionaries so missing descriptions are easy to spot.
 UNKNOWN_SENTINEL = "?"
+
+# Appended to pattern-matched descriptions whose {class} capture is in
+# RETIRED_ROOF_SHAPE_DESCRIPTIONS, so data dictionaries flag columns that only
+# carry data for historical/precomputed responses.
+_RETIRED_CLASS_NOTE = "This class was retired from the Feature API and only appears in historical/precomputed data."
+
+# Snake_cased {class} captures whose bare name is ambiguous to customers.
+# Rendered in place of the default humanised phrase wherever {class} appears
+# (e.g. "shed" alone reads as a garden shed rather than the roof shape).
+_CLASS_PHRASE_CLARIFICATIONS: dict[str, str] = {
+    "shed": "shed roof (a single-slope roof shape, not a freestanding garden shed)",
+}
 
 # Long-form unit names paired with their short column-suffix form.
 _AREA_UNIT_LONG_NAMES = {"sqft": "square feet", "sqm": "square metres"}
@@ -211,7 +225,7 @@ def _substitute(
             cls_phrase = cls_phrase[: -len(suffix)]
             suffix_phrase = parenthetical
             break
-    cls_phrase = cls_phrase.replace("_", " ") + suffix_phrase
+    cls_phrase = _CLASS_PHRASE_CLARIFICATIONS.get(cls_phrase, cls_phrase.replace("_", " ")) + suffix_phrase
     # {class_label_primary} falls back to plain {class_label} when no scope-aware
     # primary phrase is supplied.
     primary_label = class_label_primary or class_label
@@ -544,7 +558,7 @@ def lookup_column(
                 scope_phrase_override = f"on this {class_label}"
             if extras:
                 extra_groups.update(extras)
-            return _instantiate(
+            rendered = _instantiate(
                 pattern.template,
                 area_unit=area_unit,
                 scope=scope,
@@ -553,6 +567,9 @@ def lookup_column(
                 scope_phrase_override=scope_phrase_override,
                 extra_groups=extra_groups,
             )
+            if cls in RETIRED_ROOF_SHAPE_DESCRIPTIONS and rendered.description:
+                rendered = replace(rendered, description=f"{rendered.description.rstrip('.')}. {_RETIRED_CLASS_NOTE}")
+            return rendered
 
     # 4. Sentinel.
     return ColumnMeta(description=UNKNOWN_SENTINEL, source=UNKNOWN_SENTINEL)

--- a/nmaipy/column_metadata.py
+++ b/nmaipy/column_metadata.py
@@ -81,6 +81,21 @@ _SUFFIX_STRIP_RULES: tuple[tuple[str, str], ...] = (
     ("_total", ""),
 )
 
+
+def _split_class_suffix(cls: str) -> tuple[str, str]:
+    """Split a pattern-captured ``{class}`` value into (base, parenthetical).
+
+    Applies ``_SUFFIX_STRIP_RULES``; the first matching suffix wins — order in
+    the constant is load-bearing. Single normalisation path for both the
+    ``{class}`` phrase rendering in ``_substitute`` and the retired-class
+    membership check in ``lookup_column``, so the two can't drift.
+    """
+    for suffix, parenthetical in _SUFFIX_STRIP_RULES:
+        if cls.endswith(suffix):
+            return cls[: -len(suffix)], parenthetical
+    return cls, ""
+
+
 # Terse labels for scope-stripped lookup, appended in parens to the resolved
 # description (e.g. "Estimated roof installation date (primary roof's roof
 # age)."). Used only when the underlying template doesn't already carry scope
@@ -214,18 +229,10 @@ def _substitute(
         return value
     unit_long = _AREA_UNIT_LONG_NAMES.get(area_unit, area_unit)
     scope_phrase = scope_phrase_override or _format_scope_phrase(scope)
-    # Render {class} as a human-readable phrase by applying the
-    # suffix-stripping rules (see ``_SUFFIX_STRIP_RULES`` above), then
-    # replacing remaining underscores with spaces. The first matching
-    # suffix wins — order in the constant is load-bearing.
-    cls_phrase = cls
-    suffix_phrase = ""
-    for suffix, parenthetical in _SUFFIX_STRIP_RULES:
-        if cls_phrase.endswith(suffix):
-            cls_phrase = cls_phrase[: -len(suffix)]
-            suffix_phrase = parenthetical
-            break
-    cls_phrase = _CLASS_PHRASE_CLARIFICATIONS.get(cls_phrase, cls_phrase.replace("_", " ")) + suffix_phrase
+    # Render {class} as a human-readable phrase: strip any area-variant suffix,
+    # apply customer-facing clarifications, and replace underscores with spaces.
+    cls_base, suffix_phrase = _split_class_suffix(cls)
+    cls_phrase = _CLASS_PHRASE_CLARIFICATIONS.get(cls_base, cls_base.replace("_", " ")) + suffix_phrase
     # {class_label_primary} falls back to plain {class_label} when no scope-aware
     # primary phrase is supplied.
     primary_label = class_label_primary or class_label
@@ -567,7 +574,7 @@ def lookup_column(
                 scope_phrase_override=scope_phrase_override,
                 extra_groups=extra_groups,
             )
-            if cls in RETIRED_ROOF_SHAPE_DESCRIPTIONS and rendered.description:
+            if _split_class_suffix(cls)[0] in RETIRED_ROOF_SHAPE_DESCRIPTIONS and rendered.description:
                 rendered = replace(rendered, description=f"{rendered.description.rstrip('.')}. {_RETIRED_CLASS_NOTE}")
             return rendered
 

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -317,6 +317,16 @@ DEPRECATED_CLASS_IDS = [
     FLAT_DEPRECATED_ROOF_ID,  # Replaced by CLASS_1191_FLAT
 ]
 
+# Roof shape classes retired from the Feature API but still present as roof-type
+# components in historical/precomputed attribute data. Keyed two ways because
+# "Shed" was removed outright and no longer has a registered class ID (matched
+# by snake_cased description only), while "Flat (deprecated)" retains one.
+# Consumers: dominant_roof_types_* selection excludes them
+# (feature_attributes.py), and generated data dictionaries flag them as retired
+# (column_metadata.py).
+RETIRED_ROOF_SHAPE_CLASS_IDS = frozenset({FLAT_DEPRECATED_ROOF_ID})
+RETIRED_ROOF_SHAPE_DESCRIPTIONS = frozenset({"shed", "flat_(deprecated)"})
+
 # Roof Instance - a temporal slice of a roof from the Roof Age API
 # This is a "virtual" feature class that represents roof installation date information
 # Roof instances may spatially correspond to roof objects from the Feature API, but are

--- a/nmaipy/feature_attributes.py
+++ b/nmaipy/feature_attributes.py
@@ -28,9 +28,10 @@ from shapely import wkb
 from nmaipy import log
 from nmaipy.constants import (
     DAMAGE_CONFLATION_RAW_RATING_KEYS,
-    FLAT_DEPRECATED_ROOF_ID,
     IMPERIAL_COUNTRIES,
     METERS_TO_FEET,
+    RETIRED_ROOF_SHAPE_CLASS_IDS,
+    RETIRED_ROOF_SHAPE_DESCRIPTIONS,
     ROOF_AGE_PREFIX_COLUMNS,
     country_area_suffix,
 )
@@ -603,14 +604,6 @@ _DOMINANT_ATTRIBUTE_DESCRIPTIONS = {"roof_material", "roof_types"}
 # Minimum ratio for a material to be considered dominant (below this → UNKNOWN).
 DOMINANT_MATERIAL_MIN_RATIO = 0.5
 
-# Class IDs to exclude from dominant shape selection.
-_IGNORED_DOMINANT_SHAPE_CLASS_IDS = {FLAT_DEPRECATED_ROOF_ID}
-
-# Description strings (snake_cased) to exclude from dominant shape selection.
-# Used for components that may appear in pre-computed API data but no longer
-# have a registered class ID (e.g. "Shed" was removed from the Feature API).
-_IGNORED_DOMINANT_SHAPE_DESCRIPTIONS = {"shed"}
-
 
 def _get_component_stats(component: dict, recalc_attrs: Optional[dict], country: str) -> dict:
     """Get ratio, area, confidence, class_id for a component from the best available source.
@@ -649,11 +642,12 @@ def _build_dominant_columns(components: list, recalc_attrs: Optional[dict], coun
 
     stats = [_get_component_stats(c, recalc_attrs, country) for c in components]
     if attr_key == "roof_types":
+        # Retired shape classes still appear as components in historical /
+        # precomputed data; they never win dominant selection.
         stats = [
             s
             for s in stats
-            if s["class_id"] not in _IGNORED_DOMINANT_SHAPE_CLASS_IDS
-            and s["name"] not in _IGNORED_DOMINANT_SHAPE_DESCRIPTIONS
+            if s["class_id"] not in RETIRED_ROOF_SHAPE_CLASS_IDS and s["name"] not in RETIRED_ROOF_SHAPE_DESCRIPTIONS
         ]
     prefix = f"dominant_{attr_key}"
     area_suffix = "_area_sqft" if country in IMPERIAL_COUNTRIES else "_area_sqm"

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -242,6 +242,9 @@ class TestRetiredRoofShapeClasses:
             "primary_roof_shed_area_sqm",
             "flat_(deprecated)_present",
             "primary_roof_flat_(deprecated)_ratio",
+            # Suffixed area variant: pins that the note check keys off the same
+            # suffix-stripped base as the {class} phrase clarification.
+            "shed_total_clipped_area_sqm",
         ],
     )
     def test_retired_note_appended_exactly_once(self, name):

--- a/tests/test_data_dictionary_generator.py
+++ b/tests/test_data_dictionary_generator.py
@@ -211,6 +211,51 @@ class TestGenericPatterns:
         assert expected_class_phrase in meta.description
 
 
+class TestRetiredRoofShapeClasses:
+    """Retired shape classes (shed, flat_(deprecated)) get clarified descriptions.
+
+    "shed" is the single-slope roof shape, not a garden shed — the bare class
+    name has confused customers. Both classes are retired from the Feature API
+    and only appear in historical/precomputed data, which the description
+    must state.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "shed_present",
+            "shed_ratio",
+            "shed_area_sqm",
+            "shed_confidence",
+            "primary_roof_shed_present",
+        ],
+    )
+    def test_shed_clarified_as_roof_shape(self, name):
+        meta = lookup_column(name, area_unit="sqm", class_label="roof")
+        assert "single-slope roof shape" in meta.description
+        assert "not a freestanding garden shed" in meta.description
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "shed_present",
+            "primary_roof_shed_area_sqm",
+            "flat_(deprecated)_present",
+            "primary_roof_flat_(deprecated)_ratio",
+        ],
+    )
+    def test_retired_note_appended_exactly_once(self, name):
+        meta = lookup_column(name, area_unit="sqm", class_label="roof")
+        assert meta.description.count("retired from the Feature API") == 1
+        assert meta.description.endswith("historical/precomputed data.")
+
+    @pytest.mark.parametrize("name", ["gable_present", "hip_ratio", "tile_area_sqm"])
+    def test_live_classes_unaffected(self, name):
+        meta = lookup_column(name, area_unit="sqm", class_label="roof")
+        assert "retired" not in meta.description
+        assert "garden shed" not in meta.description
+
+
 # ---------------------------------------------------------------------------
 # 4. Unknown columns
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A customer asked support whether `shed_present`/`shed_area_sqm`/`shed_ratio` in the roof data dictionary means a garden shed or the shed-roof (single-slope) shape. It's the roof shape — confirmed via the old labelling docs and the SHAPE_NAMES list in the AI Exporter's roof_char validation pack — but the auto-generated description didn't say so:

> `primary_roof_shed_present` → "Whether any shed is detected on the primary roof of the parcel."

`flat_(deprecated)` self-documents only because "(deprecated)" is baked into the class name. Both are retired legacy classes, already excluded from `dominant_roof_types_*` (INDS-2036), but `shed` has no live classId and no naming signal, so the generic `{class}_present` template rendered it ambiguously.

## Change

- **`constants.py`**: promote the dominant-shape exclusion sets to shared constants `RETIRED_ROOF_SHAPE_CLASS_IDS` / `RETIRED_ROOF_SHAPE_DESCRIPTIONS`, next to `FLAT_DEPRECATED_ROOF_ID`.
- **`feature_attributes.py`**: `_build_dominant_columns` now filters on the shared constants. Adding `flat_(deprecated)` to the description set widens the dominant filter to match that class by name as well as by class ID — vacuous today (the live flat class snake-cases to `flat`, so no live component carries that name), but consistent with the INDS-2036 intent that retired shapes never win dominant selection.
- **`column_metadata.py`**: wherever a pattern captures `shed` as `{class}`, render it as "shed roof (a single-slope roof shape, not a freestanding garden shed)"; and for any retired shape class, append "This class was retired from the Feature API and only appears in historical/precomputed data." to the description. Both checks key off the same suffix-stripped class base via a new `_split_class_suffix()` helper (extracted from the inline loop in `_substitute`), so the phrase clarification and the retirement note can't drift apart on suffixed variants like `_total_clipped_area_*`.

Rendered result:

> `primary_roof_shed_present` → "Whether any shed roof (a single-slope roof shape, not a freestanding garden shed) is detected on the primary roof of the parcel. This class was retired from the Feature API and only appears in historical/precomputed data."

The clarification applies uniformly across the `_present`/`_ratio`/`_area_*`/`_count`/`_confidence`/`_dominant` pattern family.

No column renames or schema changes — data dictionary wording only, so nothing breaks for existing consumers.

## Testing

- New `TestRetiredRoofShapeClasses` in `tests/test_data_dictionary_generator.py`: shed clarification across suffix patterns, retirement note appended exactly once (shed + flat_(deprecated), scoped/unscoped/suffixed variants), live shape classes unaffected.
- Full non-live suite: 778 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
