### PR TITLE
Dedupe conflated damage buildings that straddle adjacent AOIs

### DIFF
--- a/nmaipy/damage_conflation_exporter.py
+++ b/nmaipy/damage_conflation_exporter.py
@@ -6,9 +6,12 @@ Nearmap Damage Conflation API (ai/damage/v2) for multiple areas of interest (AOI
 
 Given an ``--event-id`` and an AOI file, this exporter:
 - Queries the conflation API per-AOI in parallel (pagination handles large AOIs)
-- Always emits per-building damage polygons with flattened attributes
+- Always emits per-building damage polygons with flattened attributes, deduplicated
+  on ``feature_id`` (the API returns whole, unclipped buildings, so a building
+  straddling adjacent AOIs would otherwise appear once per AOI)
 - Optionally (``--rollup``) emits a per-AOI rollup (one row per AOI: rating counts +
-  the primary building's attributes)
+  the primary building's attributes; a straddling building counts in each AOI it
+  intersects)
 - Caches API responses, tracks progress, and reports errors
 
 Example usage:
@@ -80,6 +83,7 @@ _BUILDINGS_CSV_BASE_FIELDS = (
     "presentation_version",
     "resource_id",
     "geomatched_address",
+    "n_aois",
 )
 
 
@@ -399,6 +403,28 @@ class DamageConflationExporter(BaseExporter):
                 successful_aoi_ids=set(metadata_df.index),
                 primary_decision=self.primary_decision,
             )
+
+        # The API returns whole (unclipped) buildings per queried AOI, so a building
+        # straddling two adjacent AOIs comes back once per AOI with identical
+        # attributes and geometry — only aoi_id differs. Dedupe the delivered
+        # per-building file on feature_id (matching the discrete-class behaviour of
+        # the feature export), keeping the lowest aoi_id for determinism. n_aois
+        # records how many AOI units each building intersected, so per-AOI
+        # memberships stay reconcilable against the rollup (sum(rollup.n_buildings)
+        # == sum(buildings.n_aois)). This runs AFTER the rollup, which deliberately
+        # keeps per-(building × AOI) semantics: a straddler belongs in both AOIs'
+        # counts.
+        if len(features_gdf) > 0:
+            features_gdf["n_aois"] = features_gdf.groupby("feature_id")["feature_id"].transform("size")
+            if features_gdf["feature_id"].duplicated().any():
+                n_rows_before = len(features_gdf)
+                features_gdf = features_gdf.sort_values(AOI_ID_COLUMN_NAME, kind="stable").drop_duplicates(
+                    subset="feature_id", keep="first"
+                )
+                self.logger.info(
+                    f"Deduplicated {n_rows_before - len(features_gdf)} building rows that straddle "
+                    f"more than one AOI ({n_rows_before} rows -> {len(features_gdf)} unique buildings)"
+                )
 
         if self.include_aoi_geometry and len(features_gdf) > 0:
             self.logger.info("Merging building data with AOI attributes...")

--- a/tests/test_damage_conflation_exporter.py
+++ b/tests/test_damage_conflation_exporter.py
@@ -295,3 +295,69 @@ def test_run_end_to_end_consolidates_and_rolls_up(tmp_path, milton_response):
     assert rollup["query_succeeded"].all()
     assert rollup["n_buildings"].sum() == len(features)
     assert rollup["primary_damage_event_rating"].notna().all()
+
+
+def test_run_dedupes_buildings_straddling_aois_but_rollup_counts_both(tmp_path, milton_response):
+    """The API returns whole (unclipped) buildings per queried AOI, so a building
+    straddling two adjacent AOIs comes back once per AOI. The delivered
+    damage_buildings file must carry it once (deduped on feature_id, lowest aoi_id
+    kept), while the per-AOI rollup still counts it in each AOI it intersects."""
+    aoi_csv = tmp_path / "aois.csv"
+    pd.DataFrame(
+        {"aoi_id": ["p1", "p2"], "geometry": [box(0, 0, 0.001, 0.001).wkt, box(0, 0, 0.001, 0.001).wkt]}
+    ).to_csv(aoi_csv, index=False)
+
+    exporter = DamageConflationExporter(
+        aoi_file=str(aoi_csv),
+        output_dir=str(tmp_path / "out"),
+        event_id=EVENT_ID,
+        api_key="test_key",
+        output_format="both",
+        rollup=True,
+        processes=1,
+    )
+
+    # Overlapping slices: features 4-5 intersect both AOIs (the straddlers).
+    api = DamageConflationApi(event_id=EVENT_ID, api_key="t")
+    f1 = api._parse_response({**milton_response, "features": milton_response["features"][:6]}, "p1")
+    f2 = api._parse_response({**milton_response, "features": milton_response["features"][4:]}, "p2")
+    features = gpd.GeoDataFrame(pd.concat([f1, f2], ignore_index=True), crs=API_CRS)
+    n_unique = features["feature_id"].nunique()
+    assert len(features) == n_unique + 2  # sanity: exactly the two straddlers duplicate
+
+    metadata = pd.DataFrame(
+        {"event_uuid": [milton_response["eventUuid"]] * 2},
+        index=pd.Index(["p1", "p2"], name=AOI_ID_COLUMN_NAME),
+    )
+    Path(exporter.chunk_path).mkdir(parents=True, exist_ok=True)
+    storage.write_parquet(features, str(Path(exporter.chunk_path) / "damage_features_0000.parquet"))
+    storage.write_parquet(metadata, str(Path(exporter.chunk_path) / "metadata_0000.parquet"))
+
+    with (
+        patch.object(exporter, "run_parallel", return_value=[]),
+        patch("nmaipy.damage_conflation_exporter.combine_chunk_latency_stats", return_value=[]),
+    ):
+        exporter.run()
+
+    final = Path(exporter.final_path)
+
+    # Delivered buildings: one row per unique building, straddlers kept under the
+    # lowest aoi_id, with n_aois recording their AOI memberships; CSV and parquet agree.
+    buildings = gpd.read_parquet(final / "damage_buildings.parquet")
+    assert len(buildings) == n_unique
+    assert not buildings["feature_id"].duplicated().any()
+    straddler_ids = f1["feature_id"].iloc[4:6]
+    by_id = buildings.set_index("feature_id")
+    assert (by_id.loc[straddler_ids, "aoi_id"] == "p1").all()
+    assert (by_id.loc[straddler_ids, "n_aois"] == 2).all()
+    assert by_id["n_aois"].sum() == len(features)  # memberships reconcile with the rollup
+    csv = pd.read_csv(final / "damage_buildings.csv")
+    assert len(csv) == n_unique
+    assert "n_aois" in csv.columns
+
+    # Rollup keeps per-(building × AOI) semantics: each AOI counts every building
+    # it intersects, so the straddlers are counted twice across the two AOIs.
+    rollup = pd.read_csv(final / "damage_rollup.csv").set_index("aoi_id")
+    assert rollup.loc["p1", "n_buildings"] == 6
+    assert rollup.loc["p2", "n_buildings"] == len(milton_response["features"]) - 4
+    assert rollup["n_buildings"].sum() == n_unique + 2


### PR DESCRIPTION
## Summary

The damage conflation API returns whole (unclipped) buildings for every queried AOI, so a building straddling two adjacent AOIs appeared once per AOI in the delivered `damage_buildings` file — identical attributes and geometry, only `aoi_id` differing. Downstream consumers had to know to dedupe on `feature_id` themselves.

- `DamageConflationExporter` now dedupes the per-building output on `feature_id` at consolidation, keeping the lowest `aoi_id` for determinism — matching the discrete-class behaviour of the feature export.
- A new `n_aois` column records how many AOI units each building intersected, so per-AOI memberships stay reconcilable against the rollup: `sum(rollup.n_buildings) == sum(buildings.n_aois)`. The column is carried in both the parquet and CSV outputs.
- The per-AOI rollup is computed before the dedupe and deliberately keeps per-(building × AOI) semantics: a straddling building still counts in each AOI it intersects.

## Tests

- New end-to-end test: overlapping AOI responses collapse to unique buildings in the delivered file (lowest `aoi_id` kept, `n_aois` recorded, CSV/parquet agree) while the rollup still counts straddlers in each AOI.
- Full offline suite: 842 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)