### PR TITLE
Escalate empty-body 502s to the gridding fallback

### DIFF
--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -269,8 +269,11 @@ class APIError(Exception):
                 self.status_code = response["status_code"]
                 self.text = response["text"]
             try:
-                err_body = response.json()
-                self.message = err_body["message"] if "message" in err_body else err_body.get("error", "")
+                if not self.text:
+                    self.message = f"Empty response body (HTTP {self.status_code})"
+                else:
+                    err_body = response.json()
+                    self.message = err_body["message"] if "message" in err_body else err_body.get("error", "")
             except json.JSONDecodeError:
                 self.message = "JSONDecodeError"
             except ValueError:

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -830,7 +830,13 @@ class FeatureApi(GriddedApiClient):
                 if self.overwrite_cache and cache_path:
                     storage.remove_file(cache_path)
 
-                if status_code in AIFeatureAPIRequestSizeError.status_codes:
+                # An empty-body 502 is the API gateway timing out the backend (it answers at its
+                # 60s limit with no payload), which the client read timeout can never catch.
+                # urllib3 has already exhausted its transient retries by this point, so escalate
+                # to gridding like a 504. A 502 with an error payload keeps standard handling.
+                if status_code in AIFeatureAPIRequestSizeError.status_codes or (
+                    status_code == HTTPStatus.BAD_GATEWAY and not text
+                ):
                     logger.debug(f"Raising AIFeatureAPIRequestSizeError from status code {status_code=}")
                     raise AIFeatureAPIRequestSizeError(response, self._clean_api_key(request_info))
                 elif status_code == HTTPStatus.BAD_REQUEST:

--- a/tests/test_feature_api.py
+++ b/tests/test_feature_api.py
@@ -1,9 +1,11 @@
+import json
 import math
 import os
 import sys
 import tempfile
 import threading
 import time
+from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1201,6 +1203,75 @@ class TestFeatureAPI:
         assert error is not None, "Expected error dict when all grid cells fail"
         assert "message" in error, "Error should contain a message"
         assert error["failure_type"] == "grid", "Error should be marked as grid failure"
+
+
+class TestEmptyBody502Handling:
+    """An empty-body 502 (gateway timeout) must escalate to gridding like a 504.
+
+    Mocking Session.post to return the final response simulates the state after
+    urllib3 has exhausted its transient retries, since those live inside the adapter.
+    """
+
+    @staticmethod
+    def _mock_502_response(text=""):
+        class Mock502Response:
+            ok = False
+            status_code = HTTPStatus.BAD_GATEWAY
+
+            def json(self):
+                return json.loads(self.text)
+
+        response = Mock502Response()
+        response.text = text
+        return response
+
+    @staticmethod
+    def _test_polygon():
+        return Polygon([(0, 0), (0.001, 0), (0.001, 0.001), (0, 0.001), (0, 0)])
+
+    def test_empty_body_502_treated_as_size_error(self):
+        """A 502 with an empty body is escalated to a size error"""
+        from nmaipy.feature_api import AIFeatureAPIRequestSizeError
+
+        api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+
+        with patch("requests.Session.post", return_value=self._mock_502_response()):
+            with pytest.raises(AIFeatureAPIRequestSizeError) as exc_info:
+                api._get_results(geometry=self._test_polygon(), region="au", in_gridding_mode=False)
+
+        assert exc_info.value.status_code == HTTPStatus.BAD_GATEWAY
+        assert exc_info.value.message == "Empty response body (HTTP 502)"
+
+    def test_empty_body_502_triggers_gridding(self):
+        """At the get_features_gdf level, an empty-body 502 attempts gridding"""
+        api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+
+        with patch("requests.Session.post", return_value=self._mock_502_response()):
+            with patch("time.sleep"):
+                with patch.object(api, "_attempt_gridding", return_value=(None, None, None, None)) as mock_grid:
+                    api.get_features_gdf(
+                        geometry=self._test_polygon(), region="au", packs=["building"], aoi_id="test_aoi"
+                    )
+
+        mock_grid.assert_called_once()
+
+    def test_502_with_error_body_stays_standard_error(self):
+        """A 502 carrying an error payload keeps standard error handling, no gridding"""
+        api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+        response = self._mock_502_response(text='{"message": "upstream application error"}')
+
+        with patch("requests.Session.post", return_value=response):
+            with patch("time.sleep"):
+                with patch.object(api, "_attempt_gridding") as mock_grid:
+                    _, _, error, _ = api.get_features_gdf(
+                        geometry=self._test_polygon(), region="au", packs=["building"], aoi_id="test_aoi"
+                    )
+
+        mock_grid.assert_not_called()
+        assert error is not None
+        assert error["status_code"] == HTTPStatus.BAD_GATEWAY
+        assert error["message"] == "upstream application error"
+        assert error["failure_type"] == "standard"
 
 
 class TestBulkUnexpectedErrorHandling:


### PR DESCRIPTION
## Issue

When a bulk Feature API request is heavy enough that the backend exceeds the API gateway's 60s limit (observed on a large dense multi-building parcel with all packs requested), the gateway returns HTTP 502 with a zero-byte body rather than a 504. nmaipy treats 502 as transient, so urllib3 re-sends the identical oversized request until retries are exhausted (~60s each), the gridding fallback never engages, and the AOI is silently dropped with a misleading `JSONDecodeError` error record. The client read timeout (90s) can never rescue this since the gateway answers at 60s. A 504 on the same request would have gridded and succeeded.

## Change

- After urllib3's transient retries are exhausted, a 502 with an empty body raises `AIFeatureAPIRequestSizeError` (same as 504/413), so the AOI is gridded. A 502 carrying an error payload keeps standard handling.
- Error records for empty-body responses now say `Empty response body (HTTP 502)` instead of `JSONDecodeError`.

## For consideration (hence draft)

The handling choice is nuanced: 502 is ambiguous, and some 502s (backend crash, bad deploy) won't be fixed by gridding and retrying smaller AOIs; the grid cells will fail the same way, so the cost of a wrong guess is extra request volume after the retry budget is already spent. The empty body is the discriminator for the timeout-shaped case, based on replay of the failing request (reproducible 502, 0 bytes, no content-type, at 60.26s on every attempt). Two questions:

1. Is empty-body-plus-502 a safe fingerprint, or are there other gateway conditions that produce a bodyless 502 where gridding is the wrong response?
2. Should the gateway returning 502 instead of 504 for its own timeout also be raised API-side? That's arguably the root defect; this client fix still helps the installed base either way.

## Testing

- New unit tests: escalation on empty-body 502, gridding attempted at the `get_features_gdf` level, and a guard that a 502 with a JSON error body does not grid.
- Full non-live suite green (786 passed, 11 skipped); existing 504/ReadTimeout gridding tests unchanged.
- Live e2e export of the standard 100-parcel test set clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)