### PR TITLE
Release version 5.1.2

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -3588,7 +3588,10 @@ class NearmapAIExporter(BaseExporter):
             # set now, before metadata_df's columns are filtered for the rollup merge.
             gridded_aoi_ids = set()
             if "gridded" in metadata_df.columns:
-                gridded_mask = metadata_df["gridded"].fillna(False).astype(bool)
+                # .eq(True) rather than .fillna(False).astype(bool): the column is
+                # object-dtype (True for gridded AOIs, NaN otherwise) and fillna
+                # downcasting raises a pandas FutureWarning.
+                gridded_mask = metadata_df["gridded"].eq(True)
                 gridded_aoi_ids = set(metadata_df.index[gridded_mask])
 
             # Filter out deprecated feature classes. RSI resolution now uses IoU-based


### PR DESCRIPTION
Patch release containing the empty-body 502 gridding fallback (#215).

## Validation
- Full test suite including live API on this branch: **844 passed, 12 skipped** (0:08:39)
- Independent pre-release code review of the v5.1.1..HEAD diff: no correctness, breaking-change, or security concerns
- Formatting (black -l 120, isort): clean

Release notes to follow on the GitHub release after merge + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)