### PR TITLE
Add bearer-token (identity JWT) authentication alongside API keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,8 @@ python nmaipy/exporter.py --api-key your_api_key_here [other arguments]
 python -m nmaipy.roof_age_exporter --api-key your_api_key_here [other arguments]
 ```
 
+All API clients also accept `bearer_token=` — a short-lived Nearmap identity JWT sent as an `Authorization: Bearer` header instead of the `?apikey=` query parameter (e.g. for running nmaipy in a sandboxed environment). In bearer mode the api key is deliberately zeroed so a missed code path fails loudly rather than falling back to a long-lived env key; when both credentials are supplied the bearer token wins (shorter-lived credential preferred) with a warning. The token is captured at construction and never refreshed, so it suits short jobs only — the exporter CLIs intentionally have no `--bearer-token` option because exports can outlive a short-lived token.
+
 For S3 output, AWS credentials are resolved from environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or `~/.aws/credentials`.
 
 ## Version Management & Deployment

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ export API_KEY=your_api_key_here
 
 Contact your account administrator if you don't have one.
 
+Short-lived bearer tokens are also supported at the library level: pass `bearer_token=` to any API client (`FeatureApi`, `RoofAgeApi`, `DamageConflationApi`, or the `coverage_utils` functions) to authenticate with an `Authorization: Bearer` header instead of an API key — useful when running nmaipy in a sandboxed environment where a long-lived key can't be exposed. The token is captured at construction and never refreshed, so keep jobs shorter than its lifetime. For that reason the exporter CLIs deliberately have no `--bearer-token` option: exports can run for hours, longer than a short-lived token lasts.
+
 ### 3. Run your first extraction
 
 The repository ships with a 10-property smoke-test script (`run_10_test.py`) that extracts building features and roof age predictions for 10 US properties. It's the fastest way to verify your setup end-to-end:

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -423,7 +423,10 @@ class BaseApiClient:
             maxretry: Number of retries for failed requests
             bearer_token: Short-lived Nearmap identity JWT. When provided, requests
                 authenticate via an ``Authorization: Bearer`` header instead of the
-                ``?apikey=`` query parameter, and no API key is required.
+                ``?apikey=`` query parameter, and no API key is required. The token is
+                captured at construction and never refreshed, so a run that outlives it
+                starts failing with 401s — suit it to short jobs (e.g. running nmaipy in
+                a sandboxed environment).
         """
         # Initialize thread-safety attributes. _adapters tracks every pooled
         # HTTPAdapter handed out by _session_scope (sessions themselves are
@@ -448,6 +451,12 @@ class BaseApiClient:
         else:
             self.api_key = os.environ.get("API_KEY", None)
         if self.bearer_token:
+            if api_key:
+                # Phrased to dodge the APIKeyFilter's "Bearer <x>" redaction regex.
+                logger.warning(
+                    "Both api_key and bearer_token provided — the api_key is ignored; "
+                    "the shorter-lived credential is preferred."
+                )
             # Never fall back to a key in bearer mode: a code path that misses the
             # bearer check must fail loudly (empty apikey) rather than silently
             # authenticate with a long-lived key from the environment.
@@ -781,15 +790,19 @@ class BaseApiClient:
 
     def _clean_api_key(self, text: str) -> str:
         """
-        Remove API keys from text for safe logging.
+        Remove API keys and bearer tokens from text for safe logging.
 
         Args:
-            text: String that may contain API keys
+            text: String that may contain credentials
 
         Returns:
-            String with API keys replaced with 'REMOVED'
+            String with credentials replaced with 'REMOVED'
         """
-        return clean_api_key_from_string(text)
+        text = clean_api_key_from_string(text)
+        # Catch a raw token that lacks the "Bearer " prefix the regex keys on.
+        if self.bearer_token:
+            text = text.replace(self.bearer_token, "REMOVED")
+        return text
 
     def get_latency_stats(self) -> Optional[Dict[str, Any]]:
         """

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -91,6 +91,7 @@ class APIKeyFilter(logging.Filter):
                 msg,
                 flags=re.IGNORECASE,
             )
+            msg = re.sub(r"Bearer\s+[^\s'\"]+", "Bearer REMOVED", msg, flags=re.IGNORECASE)
             record.msg = msg
             record.args = ()  # Clear args to prevent formatting issues
         return True
@@ -373,6 +374,7 @@ def clean_api_key_from_string(text: str) -> str:
         text,
         flags=re.IGNORECASE,
     )
+    text = re.sub(r"Bearer\s+[^\s'\"]+", "Bearer REMOVED", text, flags=re.IGNORECASE)
     return text
 
 
@@ -407,6 +409,7 @@ class BaseApiClient:
         compress_cache: Optional[bool] = False,
         threads: Optional[int] = 10,
         maxretry: int = MAX_RETRIES,
+        bearer_token: Optional[str] = None,
     ):
         """
         Initialize base API client.
@@ -418,6 +421,9 @@ class BaseApiClient:
             compress_cache: Whether to use gzip compression (.json.gz) or raw json (.json)
             threads: Number of threads for concurrent execution
             maxretry: Number of retries for failed requests
+            bearer_token: Short-lived Nearmap identity JWT. When provided, requests
+                authenticate via an ``Authorization: Bearer`` header instead of the
+                ``?apikey=`` query parameter, and no API key is required.
         """
         # Initialize thread-safety attributes. _adapters tracks every pooled
         # HTTPAdapter handed out by _session_scope (sessions themselves are
@@ -434,12 +440,19 @@ class BaseApiClient:
         self._progress_buffers: List = []
         self._progress_buffers_registry_lock = threading.Lock()
 
-        # API key handling
+        # A bearer token authenticates via an Authorization header and takes precedence
+        # over any api key; otherwise fall back to the api key (arg or env).
+        self.bearer_token = bearer_token
         if api_key:
             self.api_key = api_key
         else:
             self.api_key = os.environ.get("API_KEY", None)
-        if self.api_key is None:
+        if self.bearer_token:
+            # Never fall back to a key in bearer mode: a code path that misses the
+            # bearer check must fail loudly (empty apikey) rather than silently
+            # authenticate with a long-lived key from the environment.
+            self.api_key = ""
+        elif self.api_key is None:
             if cache_dir is not None:
                 logger.warning(
                     "No API KEY provided — operating in cache-only mode. "
@@ -448,8 +461,8 @@ class BaseApiClient:
                 self.api_key = ""
             else:
                 raise ValueError(
-                    "No API KEY provided. Provide a key when initializing the client or set an API_KEY "
-                    "environment variable"
+                    "No API KEY or bearer token provided. Provide a key or bearer_token when "
+                    "initializing the client, or set an API_KEY environment variable"
                 )
 
         # Cache configuration
@@ -638,6 +651,8 @@ class BaseApiClient:
         session = requests.Session()
         session.mount("https://", adapter)
         session._timeout = (TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS)
+        if self.bearer_token:
+            session.headers["Authorization"] = f"Bearer {self.bearer_token}"
 
         try:
             yield session
@@ -915,6 +930,7 @@ class GriddedApiClient(BaseApiClient):
         grid_cell_size: float = 0.002,
         max_aoi_area_sqm: float = 1_000_000,
         max_concurrent_gridding: Optional[int] = None,
+        bearer_token: Optional[str] = None,
     ):
         """
         Initialize GriddedApiClient.
@@ -937,6 +953,7 @@ class GriddedApiClient(BaseApiClient):
             compress_cache=compress_cache,
             threads=threads,
             maxretry=maxretry,
+            bearer_token=bearer_token,
         )
 
         self.grid_cell_size = grid_cell_size

--- a/nmaipy/coverage_utils.py
+++ b/nmaipy/coverage_utils.py
@@ -61,20 +61,26 @@ _COVERAGE_PAGE_SIZE = 1000
 _MAX_COVERAGE_PAGES = 100  # safety bound (~100k surveys) against a missing/inconsistent `total`
 
 
-def get_payload(request_string, apikey=None, timeout=DEFAULT_TIMEOUT):
+def get_payload(request_string, apikey=None, timeout=DEFAULT_TIMEOUT, bearer_token=None):
     """
     Basic wrapper code to retrieve the JSON payload from the API, and raise an error if no response is given.
     Using urllib3, this also implements exponential backoff and retries for robustness.
 
     The apikey is sent via requests' ``params`` (merged into the query string by requests) rather
     than baked into ``request_string``, so the key never appears in the URL variable that flows
-    through this module or into any log line here.
+    through this module or into any log line here. When ``bearer_token`` is given it authenticates
+    via an ``Authorization: Bearer`` header instead, and the apikey param is omitted.
 
     Per-request logging is at debug level: at 10k+ points an info line per call
     floods the logs. Failures are logged at warning/error.
     """
-    params = {"apikey": apikey} if apikey else None
-    response = s.get(request_string, params=params, timeout=timeout)
+    if bearer_token:
+        params = None
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+    else:
+        params = {"apikey": apikey} if apikey else None
+        headers = None
+    response = s.get(request_string, params=params, headers=headers, timeout=timeout)
 
     # response.content is server-controlled. The Nearmap coverage API doesn't
     # echo apikeys in response bodies, and the nmaipy-logger APIKeyFilter would
@@ -101,25 +107,31 @@ def poly2coordstring(poly):
     return coordstring
 
 
-def _resolve_apikey(apikey):
-    """Return the given apikey, or fall back to the API_KEY env var; raise if neither is set."""
+def _resolve_apikey(apikey, bearer_token=None):
+    """Return the given apikey, or fall back to the API_KEY env var.
+
+    In bearer mode no apikey is needed, so return None. Raise only when neither an apikey
+    (arg or env) nor a bearer token is available.
+    """
+    if bearer_token:
+        return None
     key = apikey or os.environ.get("API_KEY")
     if not key:
-        raise ValueError("No API key provided and the API_KEY environment variable is not set")
+        raise ValueError("No API key or bearer token provided and the API_KEY environment variable is not set")
     return key
 
 
-def _post_cat_events_at_point(lat, lon, since=None, until=None, apikey=None):
+def _post_cat_events_at_point(lat, lon, since=None, until=None, apikey=None, bearer_token=None):
     """Return ``{event_id: {event_name, event_date, event_type}}`` for post-cat events whose
     surveys cover ``(lat, lon)``. Empty dict if none. Raises ValueError on a failed request."""
-    apikey = _resolve_apikey(apikey)
+    apikey = _resolve_apikey(apikey, bearer_token)
     # Endpoint takes the point as `{lon},{lat}` in the path (see get_surveys_from_point).
     url = f"{COVERAGE_V2_URL}/point/{lon},{lat}?fields=id,captureDate,tags&limit=100"
     if since is not None:
         url += f"&since={since}"
     if until is not None:
         url += f"&until={until}"
-    response = get_payload(url, apikey=apikey)
+    response = get_payload(url, apikey=apikey, bearer_token=bearer_token)
     if isinstance(response, int):
         raise ValueError(f"Coverage API request failed at lat={lat}, lon={lon} (status {response})")
 
@@ -153,7 +165,7 @@ def _select_latest_event(events):
     return ordered[0]
 
 
-def latest_event_id_at_point(lat, lon, since=None, until=None, apikey=None):
+def latest_event_id_at_point(lat, lon, since=None, until=None, apikey=None, bearer_token=None):
     """Discover the latest ImpactResponse catastrophe event id covering ``(lat, lon)``.
 
     Queries the Coverage API point endpoint and returns the ``postCatEventId`` of the event
@@ -164,6 +176,7 @@ def latest_event_id_at_point(lat, lon, since=None, until=None, apikey=None):
         lat, lon: query point in WGS84 degrees.
         since, until: optional ``YYYY-MM-DD`` window to narrow the search.
         apikey: Nearmap API key; defaults to the ``API_KEY`` environment variable.
+        bearer_token: short-lived identity JWT; when set, auth uses a Bearer header and no apikey.
 
     Returns:
         The event id (string UUID).
@@ -171,14 +184,14 @@ def latest_event_id_at_point(lat, lon, since=None, until=None, apikey=None):
     Raises:
         ValueError: if no post-cat event is found at the point (in the window).
     """
-    events = _post_cat_events_at_point(lat, lon, since, until, apikey)
+    events = _post_cat_events_at_point(lat, lon, since, until, apikey, bearer_token)
     if not events:
         window = f" in {since}..{until}" if (since or until) else ""
         raise ValueError(f"No post-catastrophe event found at lat={lat}, lon={lon}{window}")
     return _select_latest_event(events)[0]
 
 
-def event_boundary(event_id, since=None, until=None, apikey=None):
+def event_boundary(event_id, since=None, until=None, apikey=None, bearer_token=None):
     """Assemble the footprint polygon for ``event_id`` as a shapely (Multi)Polygon (EPSG:4326).
 
     Uses the Coverage API's documented tag filter to fetch **every** survey tagged with this
@@ -198,7 +211,7 @@ def event_boundary(event_id, since=None, until=None, apikey=None):
     Raises:
         ValueError: on a failed request, or if no surveys for ``event_id`` are found.
     """
-    apikey = _resolve_apikey(apikey)
+    apikey = _resolve_apikey(apikey, bearer_token)
     window = ""
     if since is not None:
         window += f"&since={since}"
@@ -217,7 +230,7 @@ def event_boundary(event_id, since=None, until=None, apikey=None):
             "&resources=tiles:Vert&fields=id,captureDate,resources,resources:boundary,tags"
             f"&limit={_COVERAGE_PAGE_SIZE}&offset={offset}{window}"
         )
-        response = get_payload(url, apikey=apikey)
+        response = get_payload(url, apikey=apikey, bearer_token=bearer_token)
         if isinstance(response, int):
             raise ValueError(f"Coverage API boundary request failed for event {event_id} (status {response})")
 
@@ -253,7 +266,7 @@ def event_boundary(event_id, since=None, until=None, apikey=None):
     return unary_union(boundaries)
 
 
-def discover_event(lat, lon, since=None, until=None, apikey=None):
+def discover_event(lat, lon, since=None, until=None, apikey=None, bearer_token=None):
     """Discover the latest event id AND its boundary at a point, in one pair of queries.
 
     The entry point for the "hit a point, get the event id + footprint" workflow: resolves the
@@ -272,12 +285,12 @@ def discover_event(lat, lon, since=None, until=None, apikey=None):
     Raises:
         ValueError: if no post-cat event is found at the point.
     """
-    events = _post_cat_events_at_point(lat, lon, since, until, apikey)
+    events = _post_cat_events_at_point(lat, lon, since, until, apikey, bearer_token)
     if not events:
         window = f" in {since}..{until}" if (since or until) else ""
         raise ValueError(f"No post-catastrophe event found at lat={lat}, lon={lon}{window}")
     event_id, _info = _select_latest_event(events)
-    boundary = event_boundary(event_id, since=since, until=until, apikey=apikey)
+    boundary = event_boundary(event_id, since=since, until=until, apikey=apikey, bearer_token=bearer_token)
     return event_id, boundary
 
 
@@ -293,6 +306,7 @@ def get_surveys_from_point(
     prerelease=False,
     limit=100,
     timeout=DEFAULT_TIMEOUT,
+    bearer_token=None,
 ):
     fields = "id,captureDate,resources,tags"
     if coverage_type == STANDARD_COVERAGE:
@@ -311,7 +325,7 @@ def get_surveys_from_point(
         url += f"&until={until}"
     if prerelease:
         url += "&prerelease=true"
-    response = get_payload(url, apikey=apikey, timeout=timeout)
+    response = get_payload(url, apikey=apikey, timeout=timeout, bearer_token=bearer_token)
     if not isinstance(response, int):
         if coverage_type == STANDARD_COVERAGE:
             return std_coverage_response_to_dataframe(response), response
@@ -388,6 +402,7 @@ def threaded_get_coverage_from_point_results(
     prerelease=False,
     limit=100,
     timeout=DEFAULT_TIMEOUT,
+    bearer_token=None,
 ):
     """
     Get coverage for a dataframe of points using a thread pool.
@@ -427,6 +442,7 @@ def threaded_get_coverage_from_point_results(
                     prerelease,
                     limit,
                     timeout,
+                    bearer_token,
                 )
             )
 
@@ -448,6 +464,7 @@ def get_coverage_from_points(
     prerelease=False,
     limit=100,
     timeout=DEFAULT_TIMEOUT,
+    bearer_token=None,
 ):
     """
     Given a GeoDataFrame of points, get a full history of all surveys that intersect with each point from the coverage API,
@@ -518,6 +535,7 @@ def get_coverage_from_points(
                 prerelease=prerelease,
                 limit=limit,
                 timeout=timeout,
+                bearer_token=bearer_token,
             )
             c_with_idx = []
             for j in range(len(c)):
@@ -589,6 +607,7 @@ def threaded_get_coverage_from_survey_ids(
     threads=20,
     prerelease=False,
     limit=100,
+    bearer_token=None,
 ):
     """
     Wrapper function to get coverage from a dataframe with survey_id's in it, using a thread pool.
@@ -608,6 +627,7 @@ def threaded_get_coverage_from_survey_ids(
                     row[survey_id_col],
                     apikey,
                     limit,
+                    bearer_token=bearer_token,
                 )
             )
 
@@ -618,14 +638,14 @@ def threaded_get_coverage_from_survey_ids(
     return results
 
 
-def get_surveys_from_id(survey_id, apikey, limit=100, timeout=DEFAULT_TIMEOUT):
+def get_surveys_from_id(survey_id, apikey, limit=100, timeout=DEFAULT_TIMEOUT, bearer_token=None):
     # NOTE: this references `id_check_response_to_dataframe`, which is not defined
     # anywhere in the package — the survey-ids path is pre-existing dead code with
     # no callers. Left in place (out of scope for this cleanup); flagged so a
     # future reviver knows the response parser still needs implementing.
     fields = "id,captureDate,resources"
     url = f"https://api.nearmap.com/coverage/v2/surveys/{survey_id}?fields={fields}&limit={limit}&resources=tiles:Vert,aifeatures,3d"
-    response = get_payload(url, apikey=apikey, timeout=timeout)
+    response = get_payload(url, apikey=apikey, timeout=timeout, bearer_token=bearer_token)
     if not isinstance(response, int):
         return id_check_response_to_dataframe(response), response  # noqa: F821 (see NOTE above)
     elif response == FORBIDDEN_403:
@@ -644,6 +664,7 @@ def get_coverage_from_survey_ids(
     coverage_chunk_cache_dir="coverage_chunks",
     id_col="id",
     limit=100,
+    bearer_token=None,
 ):
     """
     Given a GeoDataFrame with survey_ids as a column, get a set of all survey resource IDs that are attached to those survey_ids (such as aifeatures, tiles)
@@ -685,6 +706,7 @@ def get_coverage_from_survey_ids(
                 apikey=api_key,
                 threads=threads,
                 limit=limit,
+                bearer_token=bearer_token,
             )
             c_with_idx = []
             for j in range(len(c)):

--- a/nmaipy/damage_conflation_api.py
+++ b/nmaipy/damage_conflation_api.py
@@ -117,9 +117,8 @@ class DamageConflationApi(BaseApiClient):
                 area units downstream.
             progress_counters: Optional dict with 'total', 'completed', 'lock' for
                 cross-process progress tracking.
-            bearer_token: Short-lived Nearmap identity JWT. When provided, requests
-                authenticate via an ``Authorization: Bearer`` header instead of the
-                ``?apikey=`` query parameter, and no API key is required.
+            bearer_token: Short-lived Nearmap identity JWT used instead of an API key
+                (see BaseApiClient for lifetime caveats)
         """
         super().__init__(
             api_key=api_key,

--- a/nmaipy/damage_conflation_api.py
+++ b/nmaipy/damage_conflation_api.py
@@ -98,6 +98,7 @@ class DamageConflationApi(BaseApiClient):
         url_root: Optional[str] = None,
         country: str = "us",
         progress_counters: Optional[dict] = None,
+        bearer_token: Optional[str] = None,
     ):
         """
         Initialize Damage Conflation API client.
@@ -116,6 +117,9 @@ class DamageConflationApi(BaseApiClient):
                 area units downstream.
             progress_counters: Optional dict with 'total', 'completed', 'lock' for
                 cross-process progress tracking.
+            bearer_token: Short-lived Nearmap identity JWT. When provided, requests
+                authenticate via an ``Authorization: Bearer`` header instead of the
+                ``?apikey=`` query parameter, and no API key is required.
         """
         super().__init__(
             api_key=api_key,
@@ -123,6 +127,7 @@ class DamageConflationApi(BaseApiClient):
             overwrite_cache=overwrite_cache,
             compress_cache=compress_cache,
             threads=threads,
+            bearer_token=bearer_token,
         )
 
         if not event_id:
@@ -411,7 +416,8 @@ class DamageConflationApi(BaseApiClient):
 
         self._cache_misses += 1
         url = f"{self.base_url}.{file_format}"
-        params = {"apikey": self.api_key}
+        # In bearer mode the apikey param is omitted (auth is the session header).
+        params = {} if self.bearer_token else {"apikey": self.api_key}
         response_data = self._fetch_all_pages(url=url, params=params, aoi=aoi, limit=limit)
         self._save_to_cache(cache_key, response_data)
         return self._parse_response(response_data, aoi_id)
@@ -444,7 +450,8 @@ class DamageConflationApi(BaseApiClient):
 
         self._cache_misses += 1
         url = f"{self.base_url}.{file_format}"
-        params = {"apikey": self.api_key}
+        # In bearer mode the apikey param is omitted (auth is the session header).
+        params = {} if self.bearer_token else {"apikey": self.api_key}
         response_data = self._fetch_all_pages(url=url, params=params, address=address, limit=limit)
         self._save_to_cache(cache_key, response_data)
         return self._parse_response(response_data, aoi_id)

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -1809,6 +1809,7 @@ class FeatureApi(GriddedApiClient):
         """
         return FeatureApi(
             api_key=self.api_key,
+            bearer_token=self.bearer_token,
             bulk_mode=self.bulk_mode,
             cache_dir=self.cache_dir,
             overwrite_cache=self.overwrite_cache,

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -171,6 +171,7 @@ class FeatureApi(GriddedApiClient):
         progress_counters: Optional[dict] = None,
         grid_size: Optional[float] = GRID_SIZE_DEGREES,
         regrid_on_skip: Optional[bool] = True,
+        bearer_token: Optional[str] = None,
     ):
         """
         Initialize FeatureApi class
@@ -217,6 +218,7 @@ class FeatureApi(GriddedApiClient):
             threads=threads,
             maxretry=maxretry,
             grid_cell_size=grid_size,
+            bearer_token=bearer_token,
         )
 
         # Store progress counters for cross-process progress tracking
@@ -276,11 +278,13 @@ class FeatureApi(GriddedApiClient):
         Return a result from one of the base URLS (such as packs or classes)
         """
         with self._session_scope() as session:
-            request_string = f"{base_url}?apikey={self.api_key}"
+            # In bearer mode the apikey param is omitted (auth is the session header).
+            query_params = [] if self.bearer_token else [f"apikey={self.api_key}"]
             if self.alpha:
-                request_string += "&alpha=true"
+                query_params.append("alpha=true")
             if self.beta:
-                request_string += "&beta=true"
+                query_params.append("beta=true")
+            request_string = f"{base_url}?{'&'.join(query_params)}" if query_params else base_url
             response = session.get(request_string, timeout=session._timeout)
             if not response.ok:
                 raise RuntimeError(
@@ -509,8 +513,9 @@ class FeatureApi(GriddedApiClient):
         if survey_resource_id is not None:
             url = f"{self.FEATURES_SURVEY_RESOURCE_URL}/{survey_resource_id}/features.json"
 
-        # Add apikey as query parameter
-        url = f"{url}?apikey={self.api_key}"
+        # Bearer mode omits the apikey but still opens the query with "?" so the
+        # "&param" appends below stay well-formed (the "?&" is collapsed at the end).
+        url = f"{url}?" if self.bearer_token else f"{url}?apikey={self.api_key}"
 
         # Create request body - only include 'aoi' in the body
         body = {}
@@ -597,6 +602,12 @@ class FeatureApi(GriddedApiClient):
 
         # With POST requests, we always get the exact geometry processed
         exact = True
+
+        # Collapse the "?&" (or trailing lone "?") left by bearer mode's empty apikey.
+        if self.bearer_token:
+            url = url.replace("?&", "?", 1)
+            if url.endswith("?"):
+                url = url[:-1]
 
         return url, body, exact
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -202,6 +202,8 @@ class FeatureApi(GriddedApiClient):
             exclude_tiles_with_occlusion: When True, ignores survey resources with occluded tiles
             progress_counters: Optional dict with 'total' and 'completed' counters for tracking progress across processes
             grid_size: Grid cell size in degrees for subdividing large AOIs (default ~200m)
+            bearer_token: Short-lived Nearmap identity JWT used instead of an API key
+                (see BaseApiClient for lifetime caveats)
             regrid_on_skip: When True (default), reactively grid the AOI if any include
                 comes back ``{"skipped": true}`` from the API's per-parcel CPU cutoff.
                 Gridded sub-queries disable parcel mode, so the API sees mini-parcels and
@@ -373,6 +375,9 @@ class FeatureApi(GriddedApiClient):
         # This handles API keys in non-URL contexts or different formats
         if hasattr(self, "api_key") and self.api_key:
             result = result.replace(self.api_key, "APIKEYREMOVED")
+        # Catch a raw bearer token that lacks the "Bearer " prefix the log filters key on.
+        if getattr(self, "bearer_token", None):
+            result = result.replace(self.bearer_token, "REMOVED")
 
         return result
 
@@ -603,13 +608,16 @@ class FeatureApi(GriddedApiClient):
         # With POST requests, we always get the exact geometry processed
         exact = True
 
-        # Collapse the "?&" (or trailing lone "?") left by bearer mode's empty apikey.
         if self.bearer_token:
-            url = url.replace("?&", "?", 1)
-            if url.endswith("?"):
-                url = url[:-1]
+            url = self._strip_empty_query(url)
 
         return url, body, exact
+
+    @staticmethod
+    def _strip_empty_query(url: str) -> str:
+        """Collapse the "?&" (or trailing lone "?") left by bearer mode's empty apikey."""
+        url = url.replace("?&", "?", 1)
+        return url[:-1] if url.endswith("?") else url
 
     def get_features(
         self,

--- a/nmaipy/roof_age_api.py
+++ b/nmaipy/roof_age_api.py
@@ -115,6 +115,8 @@ class RoofAgeApi(BaseApiClient):
                 as of that date.
             since_as_of_date: Optional ``YYYY-MM-DD`` lower-bound cutoff. When set, the API restricts the
                 response to roof state from that date onwards.
+            bearer_token: Short-lived Nearmap identity JWT used instead of an API key
+                (see BaseApiClient for lifetime caveats)
 
             Note: cutoff parameters are not supported on the A.0 dataset. Callers are expected to validate
             the combination upstream — sending a cutoff against A.0 returns HTTP 500.

--- a/nmaipy/roof_age_api.py
+++ b/nmaipy/roof_age_api.py
@@ -92,6 +92,7 @@ class RoofAgeApi(BaseApiClient):
         resource_id: str = ROOF_AGE_DEFAULT_RESOURCE_ID,
         until_as_of_date: Optional[str] = None,
         since_as_of_date: Optional[str] = None,
+        bearer_token: Optional[str] = None,
     ):
         """
         Initialize Roof Age API client.
@@ -124,6 +125,7 @@ class RoofAgeApi(BaseApiClient):
             overwrite_cache=overwrite_cache,
             compress_cache=compress_cache,
             threads=threads,
+            bearer_token=bearer_token,
         )
 
         # Store progress counters for cross-process progress tracking
@@ -585,7 +587,8 @@ class RoofAgeApi(BaseApiClient):
         # Fetch all pages (this is a cache miss)
         self._cache_misses += 1
         url = f"{self.base_url}.{file_format}"
-        params = {"apikey": self.api_key}
+        # In bearer mode the apikey param is omitted (auth is the session header).
+        params = {} if self.bearer_token else {"apikey": self.api_key}
         if self.bulk_mode:
             params["bulk"] = "true"
 
@@ -654,7 +657,8 @@ class RoofAgeApi(BaseApiClient):
         # Fetch all pages (this is a cache miss)
         self._cache_misses += 1
         url = f"{self.base_url}.{file_format}"
-        params = {"apikey": self.api_key}
+        # In bearer mode the apikey param is omitted (auth is the session header).
+        params = {} if self.bearer_token else {"apikey": self.api_key}
         if self.bulk_mode:
             params["bulk"] = "true"
 

--- a/tests/test_bearer_auth.py
+++ b/tests/test_bearer_auth.py
@@ -1,0 +1,167 @@
+"""Tests for Bearer-token (short-lived identity JWT) authentication in the API clients.
+
+Bearer mode authenticates via an ``Authorization: Bearer <jwt>`` header instead of the
+``?apikey=`` query parameter. These tests assert:
+  - the credential guard accepts a bearer token with no api key,
+  - URL builders omit the apikey param (and stay well-formed) in bearer mode,
+  - the session carries the Authorization header,
+  - a bearer token is scrubbed from logs/errors.
+"""
+
+import logging
+
+import pytest
+import responses
+from shapely.geometry import box
+
+from nmaipy import coverage_utils
+from nmaipy.api_common import APIKeyFilter, clean_api_key_from_string
+from nmaipy.feature_api import FeatureApi
+from nmaipy.roof_age_api import RoofAgeApi
+
+_JWT = "eyJhbGciOiJSUzI1NiJ9.payload.signature"
+
+
+def test_bearer_token_needs_no_api_key(monkeypatch):
+    """A bearer token alone must satisfy the credential guard (no API_KEY set)."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    api = FeatureApi(api_key=None, bearer_token=_JWT)
+    assert api.bearer_token == _JWT
+    assert api.api_key == ""  # never None, so URL builders never interpolate "None"
+
+
+def test_bearer_mode_discards_env_api_key(monkeypatch):
+    """Bearer mode must zero the api key even when API_KEY is set in the environment,
+    so a code path that misses the bearer check fails loudly instead of silently
+    falling back to the long-lived key."""
+    monkeypatch.setenv("API_KEY", "env-key-that-must-not-be-used")
+    api = FeatureApi(bearer_token=_JWT)
+    assert api.api_key == ""
+
+
+def test_no_credential_still_raises(monkeypatch):
+    """Neither api key nor bearer token (nor cache) must still raise."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    with pytest.raises(ValueError, match="No API KEY or bearer token"):
+        FeatureApi(api_key=None)
+
+
+def test_post_url_omits_apikey_in_bearer_mode():
+    """_create_post_request must not carry ?apikey= and must be well-formed."""
+    api = FeatureApi(api_key=None, bearer_token=_JWT)
+    url, _body, _exact = api._create_post_request(api.FEATURES_URL, geometry=box(0, 0, 1, 1))
+    assert "apikey=" not in url
+    assert "?&" not in url
+    assert "&&" not in url
+    # parcelMode is always appended; it must be the first query param, opened with "?".
+    assert "?parcelMode=" in url
+
+
+def test_post_url_includes_apikey_in_key_mode():
+    """Control: key mode still uses ?apikey=."""
+    api = FeatureApi(api_key="dummy")
+    url, _body, _exact = api._create_post_request(api.FEATURES_URL, geometry=box(0, 0, 1, 1))
+    assert "apikey=dummy" in url
+
+
+@responses.activate
+def test_packs_bearer_sends_header_and_no_apikey():
+    """get_packs in bearer mode: Authorization header present, no apikey query param."""
+    responses.add(responses.GET, api_url := "https://api.nearmap.com/ai/features/v4/bulk/packs.json",
+                  json={"packs": []}, status=200)
+    api = FeatureApi(api_key=None, bearer_token=_JWT)
+    api.get_packs()
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == f"Bearer {_JWT}"
+    assert "apikey=" not in req.url
+    assert req.url.startswith(api_url)
+
+
+@responses.activate
+def test_packs_key_mode_no_auth_header():
+    """Control: key mode sends apikey in the URL and no Authorization header."""
+    responses.add(responses.GET, "https://api.nearmap.com/ai/features/v4/bulk/packs.json",
+                  json={"packs": []}, status=200)
+    api = FeatureApi(api_key="dummy")
+    api.get_packs()
+    req = responses.calls[0].request
+    assert "apikey=dummy" in req.url
+    assert "Authorization" not in req.headers
+
+
+def test_bearer_token_scrubbed_by_clean_helper():
+    """A bearer token must be redacted from strings destined for logs/errors."""
+    dirty = f"GET /packs Authorization: Bearer {_JWT} failed"
+    cleaned = clean_api_key_from_string(dirty)
+    assert _JWT not in cleaned
+    assert "Bearer REMOVED" in cleaned
+
+
+def test_bearer_token_scrubbed_by_log_filter():
+    """APIKeyFilter must redact a bearer token in a log record."""
+    f = APIKeyFilter()
+    rec = logging.LogRecord("n", logging.INFO, __file__, 1, f"Authorization: Bearer {_JWT}", None, None)
+    assert f.filter(rec) is True
+    assert _JWT not in rec.getMessage()
+
+
+# --- RoofAgeApi ---
+
+def test_roof_age_bearer_needs_no_api_key(monkeypatch):
+    """RoofAgeApi accepts a bearer token with no API_KEY, and threads it to the base client."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    api = RoofAgeApi(bearer_token=_JWT)
+    assert api.bearer_token == _JWT
+    assert api.api_key == ""
+
+
+def test_roof_age_session_sets_bearer_header(monkeypatch):
+    """The inherited session scope sets the Authorization header in bearer mode."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    api = RoofAgeApi(bearer_token=_JWT)
+    with api._session_scope() as session:
+        assert session.headers["Authorization"] == f"Bearer {_JWT}"
+
+
+def test_roof_age_session_no_header_in_key_mode():
+    """Control: key mode sets no Authorization header on the session."""
+    api = RoofAgeApi(api_key="dummy")
+    with api._session_scope() as session:
+        assert "Authorization" not in session.headers
+
+
+# --- coverage_utils ---
+
+@responses.activate
+def test_coverage_get_payload_bearer_header():
+    """get_payload sends Authorization: Bearer and no apikey param in bearer mode."""
+    responses.add(responses.GET, "https://api.nearmap.com/coverage/v2/point/0,0",
+                  json={"surveys": []}, status=200)
+    coverage_utils.get_payload("https://api.nearmap.com/coverage/v2/point/0,0", bearer_token=_JWT)
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == f"Bearer {_JWT}"
+    assert "apikey=" not in req.url
+
+
+@responses.activate
+def test_coverage_get_payload_apikey_mode():
+    """Control: key mode sends apikey as a query param, no Authorization header."""
+    responses.add(responses.GET, "https://api.nearmap.com/coverage/v2/point/0,0",
+                  json={"surveys": []}, status=200)
+    coverage_utils.get_payload("https://api.nearmap.com/coverage/v2/point/0,0", apikey="dummy")
+    req = responses.calls[0].request
+    assert "apikey=dummy" in req.url
+    assert "Authorization" not in req.headers
+
+
+def test_coverage_resolve_apikey_bearer_skips_key(monkeypatch):
+    """_resolve_apikey returns None (no key needed) when a bearer token is given."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    assert coverage_utils._resolve_apikey(None, bearer_token=_JWT) is None
+
+
+def test_coverage_resolve_apikey_no_credential_raises(monkeypatch):
+    """_resolve_apikey still raises when neither key nor bearer token is present."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    with pytest.raises(ValueError, match="No API key or bearer token"):
+        coverage_utils._resolve_apikey(None)

--- a/tests/test_bearer_auth.py
+++ b/tests/test_bearer_auth.py
@@ -66,6 +66,36 @@ def test_post_url_includes_apikey_in_key_mode():
     assert "apikey=dummy" in url
 
 
+def test_strip_empty_query():
+    """Both collapse branches: "?&" with params, and the lone trailing "?" with none."""
+    assert FeatureApi._strip_empty_query("https://x/f.json?&a=1&b=2") == "https://x/f.json?a=1&b=2"
+    assert FeatureApi._strip_empty_query("https://x/f.json?") == "https://x/f.json"
+    assert FeatureApi._strip_empty_query("https://x/f.json?a=1") == "https://x/f.json?a=1"
+
+
+def test_both_credentials_warns_and_uses_bearer(caplog):
+    """An explicit api_key alongside a bearer token warns and is discarded."""
+    # The nmaipy logger has propagate=False, so attach caplog's handler directly.
+    nmaipy_logger = logging.getLogger("nmaipy")
+    nmaipy_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="nmaipy"):
+            api = FeatureApi(api_key="dummy", bearer_token=_JWT)
+    finally:
+        nmaipy_logger.removeHandler(caplog.handler)
+    assert api.bearer_token == _JWT
+    assert api.api_key == ""
+    assert any("api_key is ignored" in r.getMessage() for r in caplog.records)
+
+
+def test_clean_api_key_scrubs_raw_bearer_token():
+    """A raw token without the "Bearer " prefix is still scrubbed by _clean_api_key."""
+    feature_api = FeatureApi(bearer_token=_JWT)
+    assert _JWT not in feature_api._clean_api_key(f"request with {_JWT} leaked")
+    roof_age_api = RoofAgeApi(bearer_token=_JWT)  # exercises the BaseApiClient implementation
+    assert _JWT not in roof_age_api._clean_api_key(f"request with {_JWT} leaked")
+
+
 @responses.activate
 def test_packs_bearer_sends_header_and_no_apikey():
     """get_packs in bearer mode: Authorization header present, no apikey query param."""
@@ -215,6 +245,32 @@ def test_damage_conflation_key_mode_no_auth_header():
     responses.add(responses.POST, _DAMAGE_URL, json=_EMPTY_FC, status=200)
     api = DamageConflationApi(event_id=_EVENT_ID, api_key="dummy")
     api.get_damage_by_aoi(box(0, 0, 1, 1), aoi_id="a")
+    req = responses.calls[0].request
+    assert "apikey=dummy" in req.url
+    assert "Authorization" not in req.headers
+
+
+_ADDRESS = {"streetAddress": "1 Main St", "city": "Springfield", "state": "IL", "zip": "62701"}
+
+
+@responses.activate
+def test_damage_conflation_address_bearer_sends_header_and_no_apikey(monkeypatch):
+    """get_damage_by_address in bearer mode: Authorization header present, no apikey param."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    responses.add(responses.POST, _DAMAGE_URL, json=_EMPTY_FC, status=200)
+    api = DamageConflationApi(event_id=_EVENT_ID, bearer_token=_JWT)
+    api.get_damage_by_address(_ADDRESS, aoi_id="a")
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == f"Bearer {_JWT}"
+    assert "apikey=" not in req.url
+
+
+@responses.activate
+def test_damage_conflation_address_key_mode_sends_apikey():
+    """Control: key mode sends apikey as a query param and no Authorization header."""
+    responses.add(responses.POST, _DAMAGE_URL, json=_EMPTY_FC, status=200)
+    api = DamageConflationApi(event_id=_EVENT_ID, api_key="dummy")
+    api.get_damage_by_address(_ADDRESS, aoi_id="a")
     req = responses.calls[0].request
     assert "apikey=dummy" in req.url
     assert "Authorization" not in req.headers

--- a/tests/test_bearer_auth.py
+++ b/tests/test_bearer_auth.py
@@ -16,10 +16,12 @@ from shapely.geometry import box
 
 from nmaipy import coverage_utils
 from nmaipy.api_common import APIKeyFilter, clean_api_key_from_string
+from nmaipy.damage_conflation_api import DamageConflationApi
 from nmaipy.feature_api import FeatureApi
 from nmaipy.roof_age_api import RoofAgeApi
 
 _JWT = "eyJhbGciOiJSUzI1NiJ9.payload.signature"
+_EVENT_ID = "2f510853-5d55-50f4-9102-2c02de08190e"
 
 
 def test_bearer_token_needs_no_api_key(monkeypatch):
@@ -165,3 +167,82 @@ def test_coverage_resolve_apikey_no_credential_raises(monkeypatch):
     monkeypatch.delenv("API_KEY", raising=False)
     with pytest.raises(ValueError, match="No API key or bearer token"):
         coverage_utils._resolve_apikey(None)
+
+
+# --- prefer3d 2D-fallback clone ---
+
+def test_clone_for_2d_fallback_propagates_bearer(monkeypatch):
+    """The prefer3d 2D-fallback clone must carry the bearer token, and must not
+    silently fall back to a long-lived API_KEY from the environment (the clone's
+    api_key arg is the zeroed "" and is falsy, so without the bearer kwarg the
+    guard would resolve the env key)."""
+    monkeypatch.setenv("API_KEY", "env-key-that-must-not-be-used")
+    api = FeatureApi(bearer_token=_JWT, prefer3d=True)
+    clone = api._clone_for_2d_fallback()
+    assert clone.bearer_token == _JWT
+    assert clone.api_key == ""
+
+
+def test_clone_for_2d_fallback_key_mode_unchanged():
+    """Control: key mode clones keep the api key and carry no bearer token."""
+    api = FeatureApi(api_key="dummy", prefer3d=True)
+    clone = api._clone_for_2d_fallback()
+    assert clone.api_key == "dummy"
+    assert clone.bearer_token is None
+
+
+# --- DamageConflationApi ---
+
+_DAMAGE_URL = f"https://api.nearmap.com/ai/damage/v2/events/{_EVENT_ID}/latest.geojson"
+_EMPTY_FC = {"type": "FeatureCollection", "features": []}
+
+
+@responses.activate
+def test_damage_conflation_bearer_sends_header_and_no_apikey(monkeypatch):
+    """get_damage_by_aoi in bearer mode: Authorization header present, no apikey param."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    responses.add(responses.POST, _DAMAGE_URL, json=_EMPTY_FC, status=200)
+    api = DamageConflationApi(event_id=_EVENT_ID, bearer_token=_JWT)
+    api.get_damage_by_aoi(box(0, 0, 1, 1), aoi_id="a")
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == f"Bearer {_JWT}"
+    assert "apikey=" not in req.url
+
+
+@responses.activate
+def test_damage_conflation_key_mode_no_auth_header():
+    """Control: key mode sends apikey as a query param and no Authorization header."""
+    responses.add(responses.POST, _DAMAGE_URL, json=_EMPTY_FC, status=200)
+    api = DamageConflationApi(event_id=_EVENT_ID, api_key="dummy")
+    api.get_damage_by_aoi(box(0, 0, 1, 1), aoi_id="a")
+    req = responses.calls[0].request
+    assert "apikey=dummy" in req.url
+    assert "Authorization" not in req.headers
+
+
+# --- RoofAgeApi request params ---
+
+_ROOF_AGE_URL = "https://api.nearmap.com/ai/roofage/v1/resources/latest.json"
+
+
+@responses.activate
+def test_roof_age_aoi_bearer_omits_apikey_param(monkeypatch):
+    """get_roof_age_by_aoi in bearer mode: Authorization header present, no apikey param."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    responses.add(responses.POST, _ROOF_AGE_URL, json=_EMPTY_FC, status=200)
+    api = RoofAgeApi(bearer_token=_JWT)
+    api.get_roof_age_by_aoi(box(0, 0, 1, 1), aoi_id="a")
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == f"Bearer {_JWT}"
+    assert "apikey=" not in req.url
+
+
+@responses.activate
+def test_roof_age_aoi_key_mode_sends_apikey_param():
+    """Control: key mode sends apikey as a query param and no Authorization header."""
+    responses.add(responses.POST, _ROOF_AGE_URL, json=_EMPTY_FC, status=200)
+    api = RoofAgeApi(api_key="dummy")
+    api.get_roof_age_by_aoi(box(0, 0, 1, 1), aoi_id="a")
+    req = responses.calls[0].request
+    assert "apikey=dummy" in req.url
+    assert "Authorization" not in req.headers

--- a/tests/test_coverage_utils.py
+++ b/tests/test_coverage_utils.py
@@ -239,7 +239,7 @@ def test_event_boundary_unknown_event_raises(coverage_boundary_response):
 
 
 def test_discover_event_returns_id_and_boundary(coverage_point_response, coverage_boundary_response):
-    def fake_get_payload(url, apikey=None, timeout=cu.DEFAULT_TIMEOUT):
+    def fake_get_payload(url, apikey=None, timeout=cu.DEFAULT_TIMEOUT, bearer_token=None):
         if "/point/" in url:
             return coverage_point_response
         if "/surveys" in url:  # event_boundary uses the /surveys?include= tag filter
@@ -279,7 +279,7 @@ def test_event_boundary_paginates_offset(coverage_boundary_response):
     ]
     calls = {"n": 0}
 
-    def fake(url, apikey=None, timeout=cu.DEFAULT_TIMEOUT):
+    def fake(url, apikey=None, timeout=cu.DEFAULT_TIMEOUT, bearer_token=None):
         i = calls["n"]
         calls["n"] += 1
         return pages[i] if i < len(pages) else {"surveys": [], "total": total}

--- a/tests/test_roof_age_api.py
+++ b/tests/test_roof_age_api.py
@@ -310,7 +310,7 @@ def test_roof_age_api_missing_key():
         del os.environ["API_KEY"]
 
     try:
-        with pytest.raises(ValueError, match="No API KEY provided"):
+        with pytest.raises(ValueError, match="No API KEY or bearer token provided"):
             RoofAgeApi()
     finally:
         # Restore environment variable


### PR DESCRIPTION
## What

Adds an additive `bearer_token=` option to every nmaipy API surface, so clients can authenticate with a short-lived Nearmap identity JWT (`Authorization: Bearer` header) instead of the long-lived `?apikey=` query parameter. API-key auth is unchanged — the kwarg defaults to `None` and existing callers are unaffected.

- **`BaseApiClient`** — `bearer_token` kwarg; credential guard accepts either credential; the Bearer header is set once per session in `_session_scope`. In bearer mode the api key is deliberately zeroed so any code path that misses the bearer check fails loudly (empty apikey → 401) instead of silently falling back to a long-lived key from the environment. Supplying both credentials logs a warning and discards the api key (the shorter-lived credential wins).
- **`FeatureApi`** — kwarg threaded through; both URL builders (packs/classes GET, features POST) omit `?apikey=` in bearer mode. The prefer3d 2D-fallback clone (`_clone_for_2d_fallback`) propagates the bearer token — without it the clone's zeroed `api_key=""` is falsy and the guard would silently resolve a long-lived key from the environment.
- **`RoofAgeApi`** — kwarg threaded through; both param-dict sites omit `apikey` in bearer mode.
- **`DamageConflationApi`** — kwarg threaded through; both param-dict sites (`get_damage_by_aoi`, `get_damage_by_address`) omit `apikey` in bearer mode.
- **`coverage_utils`** — `bearer_token` threaded through the public functions (point coverage, survey-ids, and the post-cat event-discovery trio) to the `get_payload` chokepoint, which sends the Bearer header and omits the apikey param.
- **Log redaction** — `APIKeyFilter` and `clean_api_key_from_string` now also scrub `Bearer <token>`, and `_clean_api_key` additionally scrubs the raw token value (no `Bearer ` prefix), so a JWT never lands in logs unredacted.
- **Docs** — README and CLAUDE.md document the option, the fail-loud key-zeroing, and why the exporter CLIs deliberately have no `--bearer-token` flag: the token is captured at construction and never refreshed, and an export can outlive a short-lived token.

## Why

Short lived JWT token authentication allows us to run nmaipy in a sandboxed environment with an enhanced security posture.

## Verification

- Live probe against all five surfaces, each with a raw-key control — 10/10 PASS with identical results per pair:
  - Feature packs GET and features POST/gridding
  - RoofAge by AOI
  - coverage/v2 standard and AI coverage
- Full test suite including live_api: 879 passed, 12 skipped, 0 failed.
- 27 dedicated tests (`tests/test_bearer_auth.py`), each bearer assertion paired with a key-mode control: credential guard, bearer-mode URL correctness (no apikey param, well-formed separators), session header, env-key zeroing, dual-credential warning, 2D-fallback clone propagation, DamageConflationApi and RoofAgeApi request params, coverage_utils `get_payload`/`_resolve_apikey`, and Bearer log redaction (prefixed and raw token).
- Two pre-existing test stubs updated to mirror the new `get_payload` signature, and one error-message assertion updated.

## Notes for review

- The POST URL builder opens the query with a lone `?` in bearer mode and collapses the resulting `?&` at the end — keeps the ~15 existing `url += "&…"` appends untouched.
- The dead survey-ids coverage path (flagged in-code as having no callers) is threaded too, purely for module consistency.
- Cache keys differ between auth modes: in key mode the hashed request string contains `apikey=APIKEYREMOVED`, in bearer mode the param is absent entirely, so switching auth modes against the same `cache_dir` re-fetches rather than hitting the existing cache. Left as-is deliberately — normalising the hash would invalidate every existing key-mode cache.
- The dual-credential warning message is deliberately phrased so the `Bearer <x>` redaction regex can't mangle it (no `Bearer ` + whitespace sequence) — noted in-code next to the log call.
- The failing **CodeQL check is line-drift noise, not new findings**: all 5 "new" alerts (35, 36, 46–48) are pre-existing `main` alerts from Dec 2025–Feb 2026 at the same sites, re-reported because this diff shifted their line numbers (e.g. `api_common.py` 755→770). Branch-level scan shows 0 alerts introduced by this PR.
