### PR TITLE
feat: add A.1Q2 Roof Age dataset alias

### DIFF
--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -29,6 +29,9 @@ ROOF_AGE_DEFAULT_RESOURCE_ID = "latest"
 # bumped to A.1 (and beyond) as new datasets are released.
 ROOF_AGE_A0_RESOURCE_ID = "81b605d0-d70d-592d-a1f0-a14c7d020912"
 ROOF_AGE_A1_RESOURCE_ID = "cf6bf06a-c8f7-58bd-9b1e-bce8e089a9bc"
+# Same A.1 model as above, re-run over refreshed imagery. A sibling of A.1, not a
+# replacement — both stay reachable so configs saved against "A.1" keep their dataset.
+ROOF_AGE_A1Q2_RESOURCE_ID = "6fac55e6-5e19-5ad1-9fed-9d389442d1f8"
 
 # Friendly aliases for known datasets. Unknown values pass through and are
 # treated as raw resource UUIDs.
@@ -36,6 +39,7 @@ ROOF_AGE_DATASET_ALIASES: dict[str, str] = {
     "latest": "latest",
     "A.0": ROOF_AGE_A0_RESOURCE_ID,
     "A.1": ROOF_AGE_A1_RESOURCE_ID,
+    "A.1Q2": ROOF_AGE_A1Q2_RESOURCE_ID,
 }
 
 # Datasets that do not support the `untilAsOfDate` / `sinceAsOfDate` body parameters.

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -2469,7 +2469,8 @@ def parse_arguments():
         "--roof-age-dataset",
         help=(
             "Roof Age dataset to query when --roof-age is set. Known aliases: 'latest' (default, "
-            "returns A.0), 'A.0', 'A.1'. Any other value is sent to the API as a literal resource UUID."
+            "returns A.0), 'A.0', 'A.1', 'A.1Q2'. Any other value is sent to the API as a literal "
+            "resource UUID."
         ),
         type=str,
         default="latest",

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -172,8 +172,8 @@ def parse_arguments():
         "--roof-age-dataset",
         help=(
             "Roof Age dataset to query. Known aliases: 'latest' (default, currently a pointer to A.0), "
-            "'A.0', 'A.1'. Any other value is sent to the API as a literal resource UUID, which lets "
-            "you target newly published datasets without a code change."
+            "'A.0', 'A.1', 'A.1Q2'. Any other value is sent to the API as a literal resource UUID, "
+            "which lets you target newly published datasets without a code change."
         ),
         type=str,
         default="latest",

--- a/tests/test_roof_age_api.py
+++ b/tests/test_roof_age_api.py
@@ -128,14 +128,18 @@ def test_resolve_roof_age_dataset():
     from nmaipy.constants import (
         ROOF_AGE_A0_RESOURCE_ID,
         ROOF_AGE_A1_RESOURCE_ID,
+        ROOF_AGE_A1Q2_RESOURCE_ID,
         resolve_roof_age_dataset,
     )
 
     # `latest` is a pointer maintained by the API team; it stays a string alias.
     assert resolve_roof_age_dataset("latest") == "latest"
-    # A.0 / A.1 resolve to their real resource UUIDs.
+    # A.0 / A.1 / A.1Q2 resolve to their real resource UUIDs.
     assert resolve_roof_age_dataset("A.0") == ROOF_AGE_A0_RESOURCE_ID
     assert resolve_roof_age_dataset("A.1") == ROOF_AGE_A1_RESOURCE_ID
+    assert resolve_roof_age_dataset("A.1Q2") == ROOF_AGE_A1Q2_RESOURCE_ID
+    # A.1Q2 is a sibling of A.1, not a repoint of it.
+    assert ROOF_AGE_A1Q2_RESOURCE_ID != ROOF_AGE_A1_RESOURCE_ID
     # Unknown UUID is passed through verbatim — escape hatch for new datasets.
     raw = "12345678-1234-5678-1234-567812345678"
     assert resolve_roof_age_dataset(raw) == raw


### PR DESCRIPTION
## What

The Roof Age API published a new dataset resource running the same A.1 model over newer imagery. This adds it to `ROOF_AGE_DATASET_ALIASES` as `A.1Q2` so it is selectable by alias, which also makes it appear automatically in the AI Exporter's Roof Age version dropdown (the dropdown iterates that dict).

Added as a **sibling** of `A.1`, not a repoint of it — configs saved against `A.1` keep resolving to the same dataset. Alias name confirmed.

## Changes

- `nmaipy/constants.py`: new `ROOF_AGE_A1Q2_RESOURCE_ID` constant + one `ROOF_AGE_DATASET_ALIASES` entry. `ROOF_AGE_NO_CUTOFF_RESOURCE_IDS` deliberately unchanged (see below).
- `tests/test_roof_age_api.py`: alias assertion in `test_resolve_roof_age_dataset`, plus one asserting A.1Q2 != A.1 so a future repoint of `"A.1"` can't slip through silently.
- `nmaipy/exporter.py`, `nmaipy/roof_age_exporter.py`: both `--roof-age-dataset` help strings hardcode the known-alias list, so they'd have gone stale. Text only.

No other code changes needed: `resolve_roof_age_dataset()` and both exporters already handle any alias in the dict, and the cache path keys on the resolved UUID so old A.1 cache entries can't be served for the new resource.

## Verification

Unit: full suite passes, 794 passed / 11 skipped. (`tests/test_bearer_auth.py` fails collection on `ModuleNotFoundError: responses` — pre-existing missing test dep in the conda env, reproduces on a clean tree, unrelated.)

Live end-to-end, `tests/data/test_parcels_2.csv` (100 NJ parcels), `--roof-age-dataset A.1Q2`:

- 100 successful, 0 errors, 122 roofs. 
- Same run with `--until 2024-01-01`: 100 successful, 0 errors, and the cutoff took effect (as-of date `2024-01-01`, max capture `2023-09-14`). This is why the resource stays **out** of `ROOF_AGE_NO_CUTOFF_RESOURCE_IDS` — it accepts `untilAsOfDate`, where A.0 returns HTTP 500 for the same request.

## Notes for reviewers

- `latest` still resolves to A.0, so this improvement is invisible unless the dataset is selected explicitly. SE guidance that currently says "select A.1, do not leave at latest" needs updating to A.1Q2.
- Downstream (AI Exporter, separate repo): after a release is published, bump the nmaipy pin and exporter version. Dropdown, Load Config round-trip, README, and validation all pick the alias up from the dict with no exporter code changes.