### PR TITLE
Release v5.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ exporter = RoofAgeExporter(
 exporter.run()
 ```
 
-**Dataset selection:** pass `roof_age_dataset='latest'` (default — pointer maintained by the Nearmap team), `'A.0'`, `'A.1'`, or any raw resource UUID. **Historical "as-of" queries:** combine with `since` / `until` to ask "what was this roof like in the past?" — these drive the API's `sinceAsOfDate` / `untilAsOfDate` body parameters. Note: `--until` / `--since` are not supported on the `A.0` dataset and are rejected client-side with a clear error.
+**Dataset selection:** pass `roof_age_dataset='latest'` (default — pointer maintained by the Nearmap team), `'A.0'`, `'A.1'`, `'A.1Q2'`, or any raw resource UUID. **Historical "as-of" queries:** combine with `since` / `until` to ask "what was this roof like in the past?" — these drive the API's `sinceAsOfDate` / `untilAsOfDate` body parameters. Note: `--until` / `--since` are not supported on the `A.0` dataset and are rejected client-side with a clear error.
 
 Each roof carries:
 - Predicted installation date
@@ -346,7 +346,7 @@ Key options:
 | `--packs` | AI packs to extract (`building`, `vegetation`, `surfaces`, `pools`, `solar`, `damage`, etc.) |
 | `--include` | Additional calculated includes (`roofSpotlightIndex`, `defensibleSpace`, `hurricaneScore`, `windScore`, `hailScore`, `wildfireScore`, `windHailRisk`) |
 | `--roof-age` | Include Roof Age API data (US only) |
-| `--roof-age-dataset` | `latest` (default), `A.0`, `A.1`, or any raw resource UUID |
+| `--roof-age-dataset` | `latest` (default), `A.0`, `A.1`, `A.1Q2`, or any raw resource UUID |
 | `--prefer3d` | Prefer 3D surveys, fall back to 2D per AOI when no 3D coverage exists in the window. Mutually exclusive with `--only3d` |
 | `--only3d` | Restrict every query to 3D surveys (no fallback) |
 | `--system-version-prefix` | Restrict to a specific AI generation (e.g. `gen6-`) |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,8 +43,13 @@ __version__ = "4.0.1"  # Increment following semver
 
 **Semantic Versioning:**
 - MAJOR: Breaking API changes
-- MINOR: New features, backwards compatible
-- PATCH: Bug fixes, backwards compatible
+- MINOR: New capability, backwards compatible — something users could not do before
+- PATCH: Bug fixes, plus small additive changes that add no new capability
+
+Judge MINOR vs PATCH on *capability*, not on diff shape or commit type. A change is a
+PATCH if users could already achieve the same result before it landed and the change only
+makes it easier. Registering a friendly alias for a dataset that was already reachable by
+raw resource UUID is a PATCH, not a MINOR — a new constant is not a new feature.
 
 **Pre-release Versions (PEP 440):**
 - Alpha: `4.0.0a1` - early testing, API may change

--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.1.3"
+__version__ = "5.1.4"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/tests/test_roof_age_api.py
+++ b/tests/test_roof_age_api.py
@@ -25,11 +25,16 @@ from nmaipy.constants import (
     AOI_ID_COLUMN_NAME,
     API_CRS,
     FEATURE_CLASS_DESCRIPTIONS,
+    ROOF_AGE_A0_RESOURCE_ID,
+    ROOF_AGE_A1_RESOURCE_ID,
+    ROOF_AGE_A1Q2_RESOURCE_ID,
     ROOF_AGE_AREA_FIELD,
     ROOF_AGE_NEXT_CURSOR_FIELD,
+    ROOF_AGE_NO_CUTOFF_RESOURCE_IDS,
     ROOF_AGE_PREFIX_COLUMNS,
     ROOF_ID,
     ROOF_INSTANCE_CLASS_ID,
+    resolve_roof_age_dataset,
 )
 from nmaipy.exporter import export_feature_class
 from nmaipy.roof_age_api import RoofAgeApi, RoofAgeAPIError
@@ -115,8 +120,6 @@ def test_a0_resource_id_matches_cached_latest_response():
     A.0; its top-level resourceId is therefore A.0's UUID. If the API team bumps `latest` to a
     new dataset, this test will fail and the constant needs updating in lockstep.
     """
-    from nmaipy.constants import ROOF_AGE_A0_RESOURCE_ID
-
     fixture_path = Path(__file__).parent / "data" / "test_roof_age_nj_response.json"
     with open(fixture_path) as f:
         payload = json.load(f)
@@ -125,13 +128,6 @@ def test_a0_resource_id_matches_cached_latest_response():
 
 def test_resolve_roof_age_dataset():
     """Aliases resolve, unknown values pass through unchanged."""
-    from nmaipy.constants import (
-        ROOF_AGE_A0_RESOURCE_ID,
-        ROOF_AGE_A1_RESOURCE_ID,
-        ROOF_AGE_A1Q2_RESOURCE_ID,
-        resolve_roof_age_dataset,
-    )
-
     # `latest` is a pointer maintained by the API team; it stays a string alias.
     assert resolve_roof_age_dataset("latest") == "latest"
     # A.0 / A.1 / A.1Q2 resolve to their real resource UUIDs.
@@ -140,6 +136,9 @@ def test_resolve_roof_age_dataset():
     assert resolve_roof_age_dataset("A.1Q2") == ROOF_AGE_A1Q2_RESOURCE_ID
     # A.1Q2 is a sibling of A.1, not a repoint of it.
     assert ROOF_AGE_A1Q2_RESOURCE_ID != ROOF_AGE_A1_RESOURCE_ID
+    # A.1Q2 accepts untilAsOfDate/sinceAsOfDate (verified against the live API), so it must
+    # stay out of the reject-list — adding it there would silently break cutoff queries.
+    assert ROOF_AGE_A1Q2_RESOURCE_ID not in ROOF_AGE_NO_CUTOFF_RESOURCE_IDS
     # Unknown UUID is passed through verbatim — escape hatch for new datasets.
     raw = "12345678-1234-5678-1234-567812345678"
     assert resolve_roof_age_dataset(raw) == raw


### PR DESCRIPTION
Patch release covering the `A.1Q2` Roof Age dataset alias merged in #220, plus review follow-ups.

## Changes

- **`chore: bump version to 5.1.4`** — version file only.
- **`docs,test: document A.1Q2 alias in README and lock its cutoff support`** — follow-ups from the pre-release review of #220:
  - The README (PyPI-facing) still listed only `A.0`/`A.1` for `--roof-age-dataset`. Since the whole value of the alias is discoverability — the UUID was already reachable via `resolve_roof_age_dataset()` passthrough — omitting it there partly defeated the point.
  - Added `assert ROOF_AGE_A1Q2_RESOURCE_ID not in ROOF_AGE_NO_CUTOFF_RESOURCE_IDS`. That omission is the one judgement call in #220 (A.1Q2 accepts `untilAsOfDate`/`sinceAsOfDate`) and was previously untested, so adding it to that frozenset would have silently broken cutoff queries with nothing failing.
  - Hoisted the two in-function `nmaipy.constants` imports in the touched tests to module level.
- **`docs: judge MINOR vs PATCH on capability, not diff shape`** — the old `VERSIONING.md` wording ("MINOR: New features") reads as though any additive change earns a minor bump. A friendly alias for a dataset already reachable by raw UUID is a patch; clarified so the next alias-shaped change doesn't re-litigate it.

## Verification

- Full test suite including live API on the merged tree: **879 passed, 12 skipped**.
- `tests/test_roof_age_api.py` re-run after the test edits: 42 passed, 1 skipped.
- `python -m build` + `twine check`: both artifacts PASSED.

Release notes, PyPI upload, and tagging follow once this merges (tag must land on the merge commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)