### PR TITLE
Separate the read-timeout retry budget from MAX_RETRIES (follow-up to #222)

### DIFF
--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -41,6 +41,7 @@ from nmaipy.constants import (
     BACKOFF_MAX,
     DUMMY_STATUS_CODE,
     MAX_RETRIES,
+    READ_TIMEOUT_MAX_RETRIES,
     READ_TIMEOUT_SECONDS,
     S3_PARALLEL_READ_WORKERS,
     TIMEOUT_SECONDS,
@@ -184,6 +185,13 @@ class RetryRequest(Retry):
     passed at construction (see ``BaseApiClient._session_scope``) plus urllib3's
     built-in handling of connection/read errors.
 
+    ``read_timeout_retries`` caps read timeouts specifically. urllib3's ``read`` budget
+    covers read timeouts and connection-aborted errors together (``_is_read_error``), but
+    they deserve very different budgets: an aborted connection means the server produced
+    nothing and retrying is cheap, whereas a read timeout means the server is still
+    computing and every retry re-sends work it must redo from scratch. So ``read`` keeps
+    the full budget and read timeouts get their own, enforced in ``increment()``.
+
     ``on_retry``, if given, is called once per retry urllib3 performs, with the retry
     cause (an exception instance or an HTTP status int). urllib3's retry state objects
     are immutable — every ``increment()`` returns a fresh instance via ``new()`` — so
@@ -193,9 +201,11 @@ class RetryRequest(Retry):
     (each a full request the server pays for) were burned along the way.
     """
 
-    def __init__(self, *args, on_retry=None, **kwargs):
+    def __init__(self, *args, on_retry=None, read_timeout_retries=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.on_retry = on_retry
+        self.read_timeout_retries = read_timeout_retries
+        self.read_timeout_count = 0
         # Statuses whose Retry-After header is honoured (urllib3 consults this in
         # is_retry/sleep). Deliberately excludes 413 (urllib3's default includes it):
         # 413 means the AOI is too large and triggers gridding, not a retry.
@@ -209,13 +219,15 @@ class RetryRequest(Retry):
         )
 
     def new(self, **kw):
-        """Propagate the on_retry callback through urllib3's immutable-copy pattern.
+        """Carry custom state through urllib3's immutable-copy pattern.
 
         ``Retry.new()`` reconstructs the instance from its known constructor params
         only, so custom state is dropped unless re-attached here.
         """
         instance = super().new(**kw)
         instance.on_retry = self.on_retry
+        instance.read_timeout_retries = self.read_timeout_retries
+        instance.read_timeout_count = self.read_timeout_count
         return instance
 
     def get_backoff_time(self) -> float:
@@ -240,14 +252,23 @@ class RetryRequest(Retry):
         _pool=None,
         _stacktrace=None,
     ):
-        """Override to count every retry and log the interesting ones."""
+        """Override to enforce the read-timeout budget, count every retry, and log the interesting ones."""
+        is_read_timeout = error is not None and isinstance(error, ReadTimeoutError)
+
+        # Read timeouts have their own budget, tracked here because urllib3's `read`
+        # counter is shared with connection-aborted errors (see class docstring).
+        # Surfacing the bare ReadTimeoutError makes requests raise ReadTimeout.
+        if is_read_timeout and self.read_timeout_retries is not None:
+            if self.read_timeout_count >= self.read_timeout_retries:
+                raise error.with_traceback(_stacktrace)
+
         result = super().increment(method, url, response, error, _pool, _stacktrace)
+        if is_read_timeout:
+            result.read_timeout_count = self.read_timeout_count + 1
 
         # Report every retry urllib3 performs to the owning client (see class docstring).
         if result and self.on_retry is not None:
             self.on_retry(error if error is not None else (response.status if response is not None else None))
-
-        is_read_timeout = error is not None and isinstance(error, ReadTimeoutError)
 
         # Read-timeout retries are logged EVERY time: each one means the server got no
         # byte out for READ_TIMEOUT_SECONDS, the connection was closed mid-flight
@@ -279,18 +300,19 @@ class RetryRequest(Retry):
 def is_read_timeout_error(exc: Exception) -> bool:
     """True if this exception is rooted in a read timeout (no bytes for READ_TIMEOUT_SECONDS).
 
-    Read timeouts reach the caller down two distinct paths, neither of which is
-    ``requests.exceptions.ReadTimeout``:
+    Read timeouts reach the caller down more than one path:
 
-    - Waiting for response headers (server still computing): urllib3 retries these
-      internally up to the ``read`` budget, then raises ``MaxRetryError`` whose
-      ``reason`` is a ``ReadTimeoutError``; requests wraps that in ``ConnectionError``.
+    - Waiting for response headers (server still computing): ``RetryRequest`` surfaces the
+      bare ``ReadTimeoutError`` once READ_TIMEOUT_MAX_RETRIES is spent, which requests
+      raises as ``ReadTimeout``. Should urllib3's shared ``read``/``total`` budget run out
+      first, it instead arrives as ``ConnectionError`` wrapping
+      ``MaxRetryError(ReadTimeoutError)``.
     - Mid-body (headers received, body stalled): raised while requests consumes the
       content, surfacing as ``ConnectionError`` wrapping a bare ``ReadTimeoutError``.
 
-    Both mean the same thing for this client — the server could not finish producing
+    All mean the same thing for this client — the server could not finish producing
     the response in time — and must be distinguished from other ``ConnectionError``
-    causes (DNS failure, connection refused, reset), which are infrastructure faults
+    causes (DNS failure, connection refused, aborted), which are infrastructure faults
     and must NOT be treated as an oversized/slow AOI.
     """
     seen = set()
@@ -743,6 +765,7 @@ class BaseApiClient:
                 connect=self.maxretry,
                 read=self.maxretry,
                 redirect=self.maxretry,
+                read_timeout_retries=READ_TIMEOUT_MAX_RETRIES,
                 on_retry=self._weak_retry_counter(),
             )
             pool_size = min(max(self.threads, 10), 50)

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -18,6 +18,7 @@ import os
 import random
 import re
 import threading
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from itertools import takewhile
@@ -576,6 +577,23 @@ class BaseApiClient:
             if isinstance(cause, ReadTimeoutError):
                 self._timeout_count += 1
 
+    def _weak_retry_counter(self):
+        """Build the ``RetryRequest.on_retry`` callback without keeping this client alive.
+
+        A bound method would close a reference cycle (client → ``_adapters`` → adapter →
+        ``max_retries`` → callback → client), pushing ``cleanup()`` off deterministic
+        refcount teardown onto a cyclic gc pass and holding connection pools (and their
+        file descriptors) open past the client's last use.
+        """
+        counter = weakref.WeakMethod(self._count_urllib3_retry)
+
+        def on_retry(cause):
+            method = counter()
+            if method is not None:
+                method(cause)
+
+        return on_retry
+
     def __del__(self):
         """Cleanup when instance is destroyed"""
         self.cleanup()
@@ -723,20 +741,9 @@ class BaseApiClient:
                 allowed_methods=["GET", "POST"],
                 raise_on_status=False,
                 connect=self.maxretry,
-                # Read timeouts get ONE silent in-transport retry (covers a transient
-                # dead connection, e.g. a NAT-dropped socket), then surface to the
-                # caller. They must NOT share the big status-retry budget: each read
-                # retry silently closes the connection (a client-closed-request in
-                # server logs) and re-sends the same request, so the server pays for
-                # every attempt while the client sees one long successful call —
-                # no exception, nothing in the retry/timeout counters. With the old
-                # read=maxretry(20) budget, one response that legitimately needs
-                # longer than READ_TIMEOUT_SECONDS to generate became a ~half-hour
-                # silent resend storm. Callers handle the surfaced timeout instead
-                # (FeatureApi treats it as a 504 and grids the AOI).
-                read=1,
+                read=self.maxretry,
                 redirect=self.maxretry,
-                on_retry=self._count_urllib3_retry,
+                on_retry=self._weak_retry_counter(),
             )
             pool_size = min(max(self.threads, 10), 50)
             adapter = HTTPAdapter(

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -191,6 +191,14 @@ TIMEOUT_SECONDS = 120
 #     the client would instead hang on a dead socket. Keep this comfortably below 350.
 READ_TIMEOUT_SECONDS = 300
 
+# Retries allowed for read timeouts specifically, separate from MAX_RETRIES. A read
+# timeout means the server is still computing, so every retry re-sends work it must redo
+# from scratch — one covers a transient stall, more just multiplies backend load. Other
+# read-phase errors (connection aborted before any response byte) keep MAX_RETRIES: the
+# server produced nothing, so retrying those is cheap. Once this is exhausted the timeout
+# surfaces to the caller, which grids the AOI instead of resending it whole.
+READ_TIMEOUT_MAX_RETRIES = 1
+
 # Delay between retries for ChunkedEncodingError (network-level errors)
 CHUNKED_ENCODING_RETRY_DELAY = 1.0
 

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -759,12 +759,11 @@ class FeatureApi(GriddedApiClient):
 
                     break  # Success, exit retry loop
                 except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
-                    # Read timeouts surface down two paths, and neither is plain ReadTimeout
-                    # in practice (see is_read_timeout_error): waiting-for-headers timeouts
-                    # exhaust urllib3's read budget and arrive as ConnectionError wrapping
-                    # MaxRetryError(ReadTimeoutError); mid-body timeouts arrive as
-                    # ConnectionError wrapping a bare ReadTimeoutError. Other ConnectionError
-                    # causes (DNS, refused, reset) are infrastructure faults — re-raise.
+                    # Waiting-for-headers timeouts arrive as ReadTimeout once
+                    # READ_TIMEOUT_MAX_RETRIES is spent; mid-body timeouts arrive as
+                    # ConnectionError wrapping a bare ReadTimeoutError (see
+                    # is_read_timeout_error). Other ConnectionError causes (DNS, refused,
+                    # aborted connection) are infrastructure faults — re-raise.
                     if isinstance(e, requests.exceptions.ConnectionError) and not is_read_timeout_error(e):
                         raise
 

--- a/tests/test_read_timeout_retries.py
+++ b/tests/test_read_timeout_retries.py
@@ -1,26 +1,34 @@
-"""Tests for read-timeout retry semantics (silent-resend storm fix).
+"""Tests for read-timeout retry semantics and visibility.
 
-Read timeouts while waiting for response headers are retried INSIDE urllib3, invisibly
-to the caller: each retry closes the connection (a client-closed-request entry in
-server-side logs) and re-sends the same request, which the server pays for in full.
-With the old ``read=maxretry`` budget, one response that legitimately needed longer
-than READ_TIMEOUT_SECONDS to generate became a ~half-hour silent resend storm per AOI.
+Read timeouts while waiting for response headers are retried INSIDE urllib3: each retry
+closes the connection (a client-closed-request entry in server-side logs) and re-sends
+the same request, which the server pays for in full. Those retries used to be entirely
+invisible — the old counting keyed off ``response.history``, which is requests' REDIRECT
+history and never records retries, so ``_retry_count``/``_timeout_count`` read 0 while
+urllib3 re-sent freely. READ_TIMEOUT_SECONDS is now sized above the longest legitimate
+response-generation time so the retries are rare; ``RetryRequest.on_retry`` makes them
+visible when they do happen.
 
-These tests pin the fixed behaviour:
-  - urllib3 performs exactly ONE silent read retry, then the timeout surfaces
-  - the surfaced exception is ``requests.exceptions.ConnectionError`` (NOT
-    ``ReadTimeout``), and ``is_read_timeout_error`` recognises it
+These tests pin:
+  - every in-transport retry (read timeout and status-code alike) is reported to the
+    owning client, and the callback survives urllib3's immutable ``Retry.new()`` copies
+  - a transient stall recovers silently on retry
+  - once the read budget is exhausted the timeout surfaces as
+    ``requests.exceptions.ConnectionError`` (NOT ``ReadTimeout``), and
+    ``is_read_timeout_error`` recognises it down both surfacing paths
   - non-timeout ConnectionErrors (DNS, refused) are NOT classified as read timeouts
-  - ``RetryRequest.on_retry`` counts every in-transport retry (the old
-    ``response.history`` counting was redirect history — always zero)
   - FeatureApi converts surfaced read timeouts into AIFeatureAPIRequestSizeError
     so the AOI grids instead of erroring
+  - the production session wires the retry budgets and the counting callback, and the
+    callback does not keep the client alive
 """
 
+import gc
 import json
 import socket
 import threading
 import time
+import weakref
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import patch
@@ -32,14 +40,16 @@ from requests.adapters import HTTPAdapter
 from shapely.geometry import Polygon
 
 from nmaipy.api_common import RetryRequest, is_read_timeout_error
+from nmaipy.constants import READ_TIMEOUT_SECONDS, TIMEOUT_SECONDS
 from nmaipy.feature_api import AIFeatureAPIRequestSizeError, FeatureApi
 
 TEST_READ_TIMEOUT = 0.5  # seconds — fast stand-in for READ_TIMEOUT_SECONDS
+TEST_MAXRETRY = 3  # fast stand-in for MAX_RETRIES (production sets every budget to it)
 SLOW = 2.0  # server-side delay that exceeds the read timeout
 
 
 class _RecordingHandler(BaseHTTPRequestHandler):
-    """POST handler that sleeps per a plan and records how each attempt ended."""
+    """POST handler that sleeps per a plan, so an attempt can be made to exceed the read timeout."""
 
     protocol_version = "HTTP/1.1"
 
@@ -59,8 +69,7 @@ class _RecordingHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
         except (BrokenPipeError, ConnectionResetError):
-            with server.state_lock:
-                server.aborted_attempts += 1
+            pass  # client already gave up on this attempt and closed the connection
 
     def log_message(self, *args):
         pass
@@ -71,30 +80,30 @@ def slow_server():
     server = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingHandler)
     server.state_lock = threading.Lock()
     server.request_count = 0
-    server.aborted_attempts = 0
     server.sleep_plan = [0]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     yield server
     server.shutdown()
+    server.server_close()
 
 
-def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503)):
+def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503), maxretry=TEST_MAXRETRY):
     """Build a session with the same retry shape as BaseApiClient._session_scope."""
 
     def on_retry(cause):
         retry_counts.append(cause)
 
     retries = RetryRequest(
-        total=20,
+        total=maxretry,
         backoff_factor=0.01,
         backoff_max=0.05,
         status_forcelist=list(status_forcelist),
         allowed_methods=["GET", "POST"],
         raise_on_status=False,
-        connect=20,
-        read=1,
-        redirect=20,
+        connect=maxretry,
+        read=maxretry,
+        redirect=maxretry,
         on_retry=on_retry,
     )
     session = requests.Session()
@@ -102,9 +111,9 @@ def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503)):
     return session
 
 
-def test_read_timeout_surfaces_after_one_silent_retry(slow_server):
-    """A persistently slow response must burn exactly 2 attempts (1 + 1 read retry),
-    then surface as ConnectionError — not loop through the whole retry budget."""
+def test_read_timeout_surfaces_once_budget_exhausted(slow_server):
+    """A persistently slow response must burn the read budget (one full request per
+    attempt, each reported), then surface as ConnectionError rather than a ReadTimeout."""
     slow_server.sleep_plan = [SLOW]  # always slower than the read timeout
     retry_causes = []
     session = _make_session(retry_causes)
@@ -113,16 +122,15 @@ def test_read_timeout_surfaces_after_one_silent_retry(slow_server):
     with pytest.raises(requests.exceptions.ConnectionError) as exc_info:
         session.post(url, json={"aoi": "x"}, timeout=(5, TEST_READ_TIMEOUT))
 
-    time.sleep(SLOW + 0.5)  # let aborted handler threads finish and record
-    assert slow_server.request_count == 2, "expected exactly 1 original attempt + 1 silent retry"
+    assert slow_server.request_count == TEST_MAXRETRY + 1, "every retry re-sends the request in full"
     assert is_read_timeout_error(exc_info.value), "surfaced exception must be recognised as a read timeout"
-    assert len(retry_causes) == 1
-    assert isinstance(retry_causes[0], urllib3.exceptions.ReadTimeoutError)
+    assert len(retry_causes) == TEST_MAXRETRY, "each in-transport retry must be reported exactly once"
+    assert all(isinstance(cause, urllib3.exceptions.ReadTimeoutError) for cause in retry_causes)
 
 
 def test_transient_read_timeout_recovers_silently(slow_server):
-    """One slow attempt followed by a fast one must succeed with no surfaced error —
-    the single silent retry covers transient stalls / dead connections."""
+    """One slow attempt followed by a fast one must succeed with no surfaced error,
+    and still report the retry that got it there."""
     slow_server.sleep_plan = [SLOW, 0]
     retry_causes = []
     session = _make_session(retry_causes)
@@ -132,7 +140,7 @@ def test_transient_read_timeout_recovers_silently(slow_server):
 
     assert response.status_code == 200
     assert response.json() == {"attempt": 1}
-    assert len(retry_causes) == 1, "the one silent read retry must be counted"
+    assert len(retry_causes) == 1, "the silent read retry must be counted"
 
 
 def test_status_retries_counted_via_on_retry(slow_server):
@@ -179,7 +187,9 @@ def test_is_read_timeout_error_rejects_other_connection_errors():
     """DNS failures / connection-refused must NOT be classified as read timeouts —
     gridding an AOI because DNS is down would silently degrade its results."""
     refused = requests.exceptions.ConnectionError(
-        urllib3.exceptions.MaxRetryError(None, "/features.json", reason=urllib3.exceptions.NewConnectionError(None, "refused"))
+        urllib3.exceptions.MaxRetryError(
+            None, "/features.json", reason=urllib3.exceptions.NewConnectionError(None, "refused")
+        )
     )
     assert not is_read_timeout_error(refused)
 
@@ -192,7 +202,9 @@ def test_is_read_timeout_error_accepts_both_surfacing_paths():
     timeouts must both be recognised."""
     header_phase = requests.exceptions.ConnectionError(
         urllib3.exceptions.MaxRetryError(
-            None, "/features.json", reason=urllib3.exceptions.ReadTimeoutError(None, "/features.json", "Read timed out.")
+            None,
+            "/features.json",
+            reason=urllib3.exceptions.ReadTimeoutError(None, "/features.json", "Read timed out."),
         )
     )
     assert is_read_timeout_error(header_phase)
@@ -210,7 +222,9 @@ def test_surfaced_read_timeout_triggers_size_error_for_gridding():
     polygon = Polygon([(0, 0), (0.001, 0), (0.001, 0.001), (0, 0.001), (0, 0)])
     surfaced = requests.exceptions.ConnectionError(
         urllib3.exceptions.MaxRetryError(
-            None, "/features.json", reason=urllib3.exceptions.ReadTimeoutError(None, "/features.json", "Read timed out.")
+            None,
+            "/features.json",
+            reason=urllib3.exceptions.ReadTimeoutError(None, "/features.json", "Read timed out."),
         )
     )
 
@@ -226,10 +240,42 @@ def test_non_timeout_connection_error_propagates():
     api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
     polygon = Polygon([(0, 0), (0.001, 0), (0.001, 0.001), (0, 0.001), (0, 0)])
     refused = requests.exceptions.ConnectionError(
-        urllib3.exceptions.MaxRetryError(None, "/features.json", reason=urllib3.exceptions.NewConnectionError(None, "refused"))
+        urllib3.exceptions.MaxRetryError(
+            None, "/features.json", reason=urllib3.exceptions.NewConnectionError(None, "refused")
+        )
     )
 
     with patch("requests.Session.post", side_effect=refused):
         with pytest.raises(requests.exceptions.ConnectionError):
             api._get_results(geometry=polygon, region="au", in_gridding_mode=False)
     assert api._timeout_count == 0
+
+
+def test_production_session_wires_budgets_and_counting():
+    """Pin the real _session_scope config: every budget is maxretry, and retries are counted.
+
+    The tests above build their own session, so without this a revert of _session_scope
+    to uncounted retries would pass the whole suite.
+    """
+    api = FeatureApi(api_key="TEST_KEY", cache_dir=None, maxretry=7)
+    with api._session_scope() as session:
+        retries = session.adapters["https://"].max_retries
+        assert (retries.total, retries.connect, retries.read, retries.redirect) == (7, 7, 7, 7)
+        assert retries.on_retry is not None, "in-transport retries must be reported to the client"
+        assert session._timeout == (TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS)
+
+
+def test_retry_callback_does_not_keep_client_alive():
+    """The counting callback must not close a client → adapter → callback reference cycle,
+    or cleanup() (which closes the connection pools) is deferred to a cyclic gc pass."""
+    api = FeatureApi(api_key="TEST_KEY", cache_dir=None)
+    with api._session_scope():
+        pass
+    ref = weakref.ref(api)
+
+    gc.disable()
+    try:
+        del api
+        assert ref() is None, "client must be freed by refcounting, not left to cyclic gc"
+    finally:
+        gc.enable()

--- a/tests/test_read_timeout_retries.py
+++ b/tests/test_read_timeout_retries.py
@@ -1,25 +1,28 @@
 """Tests for read-timeout retry semantics and visibility.
 
 Read timeouts while waiting for response headers are retried INSIDE urllib3: each retry
-closes the connection (a client-closed-request entry in server-side logs) and re-sends
-the same request, which the server pays for in full. Those retries used to be entirely
-invisible — the old counting keyed off ``response.history``, which is requests' REDIRECT
-history and never records retries, so ``_retry_count``/``_timeout_count`` read 0 while
-urllib3 re-sent freely. READ_TIMEOUT_SECONDS is now sized above the longest legitimate
-response-generation time so the retries are rare; ``RetryRequest.on_retry`` makes them
-visible when they do happen.
+closes the connection (a client-closed-request entry in server-side logs) and re-sends a
+request the server is still computing, which it must then redo from scratch. urllib3
+budgets those together with connection-aborted errors under one ``read`` counter, so
+``RetryRequest`` enforces READ_TIMEOUT_MAX_RETRIES separately — aborts stay cheap to
+retry and keep the full MAX_RETRIES.
+
+Those retries also used to be invisible: the old counting keyed off ``response.history``,
+which is requests' REDIRECT history and never records retries, so ``_retry_count`` and
+``_timeout_count`` read 0 while urllib3 re-sent freely.
 
 These tests pin:
+  - read timeouts get READ_TIMEOUT_MAX_RETRIES, then surface as
+    ``requests.exceptions.ReadTimeout``; a transient stall recovers on retry
+  - connection aborts (ProtocolError) keep the full budget despite sharing urllib3's
+    ``read`` counter with read timeouts
   - every in-transport retry (read timeout and status-code alike) is reported to the
     owning client, and the callback survives urllib3's immutable ``Retry.new()`` copies
-  - a transient stall recovers silently on retry
-  - once the read budget is exhausted the timeout surfaces as
-    ``requests.exceptions.ConnectionError`` (NOT ``ReadTimeout``), and
-    ``is_read_timeout_error`` recognises it down both surfacing paths
-  - non-timeout ConnectionErrors (DNS, refused) are NOT classified as read timeouts
+  - ``is_read_timeout_error`` recognises both surfacing paths — the mid-body one arrives
+    as ``ConnectionError``, not ``ReadTimeout`` — and rejects DNS/refused
   - FeatureApi converts surfaced read timeouts into AIFeatureAPIRequestSizeError
     so the AOI grids instead of erroring
-  - the production session wires the retry budgets and the counting callback, and the
+  - the production session wires both budgets and the counting callback, and the
     callback does not keep the client alive
 """
 
@@ -40,11 +43,11 @@ from requests.adapters import HTTPAdapter
 from shapely.geometry import Polygon
 
 from nmaipy.api_common import RetryRequest, is_read_timeout_error
-from nmaipy.constants import READ_TIMEOUT_SECONDS, TIMEOUT_SECONDS
+from nmaipy.constants import READ_TIMEOUT_MAX_RETRIES, READ_TIMEOUT_SECONDS, TIMEOUT_SECONDS
 from nmaipy.feature_api import AIFeatureAPIRequestSizeError, FeatureApi
 
 TEST_READ_TIMEOUT = 0.5  # seconds — fast stand-in for READ_TIMEOUT_SECONDS
-TEST_MAXRETRY = 3  # fast stand-in for MAX_RETRIES (production sets every budget to it)
+TEST_MAXRETRY = 3  # fast stand-in for MAX_RETRIES; must exceed READ_TIMEOUT_MAX_RETRIES
 SLOW = 2.0  # server-side delay that exceeds the read timeout
 
 
@@ -88,6 +91,44 @@ def slow_server():
     server.server_close()
 
 
+@pytest.fixture
+def aborting_server():
+    """Server that closes the connection before any response byte, for the first N attempts.
+
+    urllib3 sees that as ProtocolError ("Connection aborted."), which shares its ``read``
+    budget with read timeouts but is cheap to retry — the server produced nothing.
+    """
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(50)
+    state = {"attempts": 0, "abort_first": 0, "port": sock.getsockname()[1], "lock": threading.Lock()}
+
+    def handle(conn):
+        with state["lock"]:
+            state["attempts"] += 1
+            abort = state["attempts"] <= state["abort_first"]
+        try:
+            conn.recv(65536)
+            if not abort:
+                conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    def accept_loop():
+        while True:
+            try:
+                conn, _ = sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=accept_loop, daemon=True).start()
+    yield state
+    sock.close()
+
+
 def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503), maxretry=TEST_MAXRETRY):
     """Build a session with the same retry shape as BaseApiClient._session_scope."""
 
@@ -104,6 +145,7 @@ def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503), maxretry=
         connect=maxretry,
         read=maxretry,
         redirect=maxretry,
+        read_timeout_retries=READ_TIMEOUT_MAX_RETRIES,
         on_retry=on_retry,
     )
     session = requests.Session()
@@ -111,21 +153,37 @@ def _make_session(retry_counts, status_forcelist=(429, 500, 502, 503), maxretry=
     return session
 
 
-def test_read_timeout_surfaces_once_budget_exhausted(slow_server):
-    """A persistently slow response must burn the read budget (one full request per
-    attempt, each reported), then surface as ConnectionError rather than a ReadTimeout."""
+def test_read_timeout_surfaces_once_its_own_budget_is_spent(slow_server):
+    """Read timeouts get READ_TIMEOUT_MAX_RETRIES, not the full budget — every retry
+    re-sends work the server is still computing — then surface as ReadTimeout."""
     slow_server.sleep_plan = [SLOW]  # always slower than the read timeout
     retry_causes = []
     session = _make_session(retry_causes)
     url = f"http://127.0.0.1:{slow_server.server_address[1]}/features.json"
 
-    with pytest.raises(requests.exceptions.ConnectionError) as exc_info:
+    with pytest.raises(requests.exceptions.ReadTimeout) as exc_info:
         session.post(url, json={"aoi": "x"}, timeout=(5, TEST_READ_TIMEOUT))
 
-    assert slow_server.request_count == TEST_MAXRETRY + 1, "every retry re-sends the request in full"
+    assert slow_server.request_count == READ_TIMEOUT_MAX_RETRIES + 1, "every retry re-sends the request in full"
     assert is_read_timeout_error(exc_info.value), "surfaced exception must be recognised as a read timeout"
-    assert len(retry_causes) == TEST_MAXRETRY, "each in-transport retry must be reported exactly once"
+    assert len(retry_causes) == READ_TIMEOUT_MAX_RETRIES, "each in-transport retry must be reported exactly once"
     assert all(isinstance(cause, urllib3.exceptions.ReadTimeoutError) for cause in retry_causes)
+
+
+def test_connection_aborts_keep_the_full_retry_budget(aborting_server):
+    """Aborts share urllib3's `read` counter with read timeouts but must NOT share their
+    budget: the server produced nothing, so resending is cheap and must stay resilient."""
+    aborting_server["abort_first"] = TEST_MAXRETRY - 1
+    retry_causes = []
+    session = _make_session(retry_causes)
+    url = f"http://127.0.0.1:{aborting_server['port']}/features.json"
+
+    response = session.post(url, json={"aoi": "x"}, timeout=(5, TEST_READ_TIMEOUT))
+
+    assert response.status_code == 200, "aborts must be retried past the read-timeout budget"
+    assert aborting_server["attempts"] == TEST_MAXRETRY
+    assert len(retry_causes) == TEST_MAXRETRY - 1 > READ_TIMEOUT_MAX_RETRIES
+    assert all(isinstance(cause, urllib3.exceptions.ProtocolError) for cause in retry_causes)
 
 
 def test_transient_read_timeout_recovers_silently(slow_server):
@@ -252,15 +310,17 @@ def test_non_timeout_connection_error_propagates():
 
 
 def test_production_session_wires_budgets_and_counting():
-    """Pin the real _session_scope config: every budget is maxretry, and retries are counted.
+    """Pin the real _session_scope config: general budgets are maxretry, read timeouts get
+    their own smaller one, and retries are counted.
 
     The tests above build their own session, so without this a revert of _session_scope
-    to uncounted retries would pass the whole suite.
+    to a shared or uncounted budget would pass the whole suite.
     """
     api = FeatureApi(api_key="TEST_KEY", cache_dir=None, maxretry=7)
     with api._session_scope() as session:
         retries = session.adapters["https://"].max_retries
         assert (retries.total, retries.connect, retries.read, retries.redirect) == (7, 7, 7, 7)
+        assert retries.read_timeout_retries == READ_TIMEOUT_MAX_RETRIES < 7
         assert retries.on_retry is not None, "in-transport retries must be reported to the client"
         assert session._timeout == (TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS)
 

--- a/tests/test_roof_age_api.py
+++ b/tests/test_roof_age_api.py
@@ -461,6 +461,7 @@ def test_parse_empty_response(roof_age_api):
 
 
 @pytest.mark.integration
+@pytest.mark.live_api
 def test_get_roof_age_by_aoi_real_api(test_aoi_nj):
     """
     Integration test with real API.
@@ -834,6 +835,7 @@ def test_build_request_payload_with_pagination(roof_age_api, test_aoi_nj):
 
 
 @pytest.mark.integration
+@pytest.mark.live_api
 def test_pagination_real_api():
     """
     Integration test for pagination with real API.
@@ -912,6 +914,7 @@ def test_bulk_mode_parameter_not_included_when_disabled(cache_directory, test_ao
 
 
 @pytest.mark.integration
+@pytest.mark.live_api
 def test_bulk_export_with_parcels_2(parcels_2_gdf):
     """
     Integration test for bulk roof age query and export with 100 NJ parcels.


### PR DESCRIPTION
Follow-up to #222, which merged with only its first commit. Review of that commit found a regression it introduced, and this PR fixes it before 5.1.5 ships.

## The problem with what merged

#222 capped urllib3's `read` retry budget at 1 to stop read timeouts being silently re-sent. But `read` is not a read-*timeout* budget: `Retry._is_read_error` matches `ReadTimeoutError` **and** `ProtocolError`, and urllib3 wraps every `OSError`/`HTTPException` into `ProtocolError("Connection aborted.")` before incrementing. So `read=1` also cut retries for connections closed before any response byte (ECONNRESET, `RemoteDisconnected` on a recycled keep-alive socket) from 10 to 1.

Measured against a local server that closes the socket before responding, then answers on the 4th attempt:

```
read=1:   attempts=2  → requests.exceptions.ConnectionError   (retry_causes=['ProtocolError'])
read=10:  attempts=4  → OK 200                                (retry_causes=['ProtocolError'] × 3)
```

Those aborts are cheap to retry — the server produced nothing — and once surfaced they are (correctly) rejected by `is_read_timeout_error` and re-raised, so nothing in `get_features_gdf` catches them and the AOI lands as a per-AOI "Unexpected error" that counts toward `max_allowed_error_count`. The asymmetry that makes it clearly unintended: a *mid-body* `ProtocolError` becomes `ChunkedEncodingError` and still gets the full `MAX_RETRIES` client-loop retries, while the header-phase variant now hard-fails after 2 attempts.

## Changes

- **Separate budgets instead of a shared, shrunken one.** `RetryRequest` already overrides `increment()`, so `READ_TIMEOUT_MAX_RETRIES` (1) is enforced there and `read` keeps the full `maxretry`. Read timeouts stay capped; connection aborts stay as resilient as in 5.1.4. Because the bare `ReadTimeoutError` is re-raised rather than wrapped in `MaxRetryError`, requests surfaces the waiting-for-headers path as plain `requests.exceptions.ReadTimeout` — the exception `_get_results` was originally written for. `is_read_timeout_error` still covers the mid-body form and the `MaxRetryError`-wrapped form if the shared budget runs out first.
- **`WeakMethod` for the retry-counting callback.** Passing the bound method as `on_retry` closed a cycle (client → `_adapters` → adapter → `max_retries` → callback → client), moving `cleanup()` — which closes the connection pools — off refcount teardown onto a cyclic gc pass. Verified: with the bound method the client survives `del` under `gc.disable()`; with the weak callback it does not.
- **Removed the 11-line inline commentary** about the export incident from `_session_scope`.
- **Marked the three live roof-age tests `live_api`.** They reached the live API from inside `pytest -m "not live_api"`, so an API hiccup could redden an offline run. Two had no guard at all; the third's `os.environ.get("API_KEY")` guard never trips, because `load_dotenv()` populates `os.environ` at nmaipy import time.

## Test plan
- [x] `read=1` regression pinned: new `test_connection_aborts_keep_the_full_retry_budget` fails if the two budgets are ever collapsed back into one
- [x] Read-timeout budget test keys off `READ_TIMEOUT_MAX_RETRIES` and expects `ReadTimeout`
- [x] `test_production_session_wires_budgets_and_counting` pins the real `_session_scope` (both budgets + the counting callback) — nothing covered this before, so a revert would have passed the whole suite
- [x] `test_retry_callback_does_not_keep_client_alive`, mutation-checked: fails with the bound method, passes with `WeakMethod`
- [x] `-m "not live_api"`: **829 passed, 11 skipped, 62 deselected**; a socket-recording plugin confirms the marker fixes leave no roof-age API calls in the offline suite
- [ ] Full `pytest` including the 62 `live_api` tests — runs as part of `/publish` per `VERSIONING.md`

Known follow-up, not addressed here: `test_integration.py::test_error_handling_missing_file` and `::test_error_handling_invalid_geojson` also open outbound connections from the offline suite. Pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
