### PR TITLE
chore: bump version to 5.1.5

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.1.4"
+__version__ = "5.1.5"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )


### PR DESCRIPTION
Version bump for the 5.1.5 patch release.

Ships the read-timeout retry fixes from #222 and #223:
- `READ_TIMEOUT_SECONDS` 90 → 300, clearing the legitimate 60–250s generation envelope for feature-dense AOIs
- read timeouts get their own `READ_TIMEOUT_MAX_RETRIES = 1` budget, separate from `MAX_RETRIES`, so connection aborts keep full resilience
- surfaced read timeouts route to gridding instead of losing the AOI
- retry counters actually record in-transport retries (`response.history` was redirect history)
- retry-counting callback held weakly so connection pools close deterministically
- three live roof-age tests marked `live_api`

Full release notes go on the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)