### PR TITLE
Request cache: orjson hot paths, in-flight duplicate coalescing, hit-rate visibility

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -16,6 +16,7 @@ dependencies:
 
   # Other core dependencies
   - requests >=2.32.5
+  - orjson >=3.9
   - python-dotenv >=1.2.1
   - tqdm >=4.67.1
   - psutil >=7.1.3

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -522,6 +522,13 @@ class BaseApiClient:
         self._thread_local = threading.local()
         self._lock = threading.Lock()
 
+        # In-flight request coalescing (see _coalesce_inflight): cache path ->
+        # [lock, in-flight request count]. Guarded by _inflight_guard; bounded
+        # because each entry is dropped when its last in-flight request leaves,
+        # so the map can never exceed this client's thread count.
+        self._inflight_requests: Dict[str, list] = {}
+        self._inflight_guard = threading.Lock()
+
         # Progress-counter plumbing. `progress_counters` is overridden by
         # subclasses that accept it as a constructor arg. The registry holds
         # one (buffer, lock) tuple per thread that has called
@@ -853,6 +860,47 @@ class BaseApiClient:
             storage.write_json(cache_path, data, compressed=self.compress_cache)
         except Exception as e:
             logger.warning(f"Failed to save to cache: {e}")
+
+    @contextlib.contextmanager
+    def _coalesce_inflight(self, cache_path: Optional[str]):
+        """
+        Serialize concurrent fetches that share a cache entry (in-flight coalescing).
+
+        Address-mode datasets carry many rows per physical parcel (e.g. strata
+        units sharing one polygon), and those duplicate requests sit adjacent in
+        input order — so on a cold cache they all miss together and fetch the
+        same payload concurrently. Holding a per-cache-path lock lets the first
+        requester fetch and write the cache; the caller's second cache check
+        (inside this context) then turns every waiter into a cache hit.
+
+        Callers must re-check the cache after entering the context (double-checked
+        read). If the first fetch fails, each waiter proceeds with its own fetch
+        in turn — same outcome as today's duplicate fetches, just serialized.
+
+        No-op when cache_path is None (no cache — nowhere to share a result) or
+        in overwrite mode (every request must refetch by design). The lock map is
+        per-process: workers in other processes still fetch independently.
+        """
+        if cache_path is None or self.overwrite_cache:
+            yield
+            return
+
+        with self._inflight_guard:
+            entry = self._inflight_requests.get(cache_path)
+            if entry is None:
+                entry = [threading.Lock(), 0]
+                self._inflight_requests[cache_path] = entry
+            entry[1] += 1
+            lock = entry[0]
+
+        try:
+            with lock:
+                yield
+        finally:
+            with self._inflight_guard:
+                entry[1] -= 1
+                if entry[1] == 0 and self._inflight_requests.get(cache_path) is entry:
+                    del self._inflight_requests[cache_path]
 
     def _sanitize_path_component(self, text: str) -> str:
         """

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -993,10 +993,34 @@ class BaseApiClient:
         - cache_hits: Number of cache hits
         - cache_misses: Number of cache misses (API calls made)
 
-        Returns None if no latencies have been recorded.
+        A chunk served entirely from cache records no latencies but still has
+        cache activity worth reporting (hit-rate display, latency sidecars), so
+        the latency fields are zeroed rather than dropping the whole dict —
+        every consumer already guards on count == 0.
+
+        Returns None only when there was no API activity at all.
         """
+        counters = {
+            "retry_count": self._retry_count,
+            "timeout_count": self._timeout_count,
+            "cache_hits": self._cache_hits,
+            "cache_misses": self._cache_misses,
+        }
         if not self._latencies:
-            return None
+            if not any(counters.values()):
+                return None
+            return {
+                "mean": 0.0,
+                "p50": 0.0,
+                "p90": 0.0,
+                "p95": 0.0,
+                "p99": 0.0,
+                "min": 0.0,
+                "max": 0.0,
+                "count": 0,
+                "histogram": [0] * (len(LATENCY_BUCKETS) - 1),
+                **counters,
+            }
 
         arr = np.array(self._latencies)
         n = len(arr)
@@ -1014,10 +1038,7 @@ class BaseApiClient:
             "max": float(np.max(arr)),
             "count": n,
             "histogram": hist.tolist(),
-            "retry_count": self._retry_count,
-            "timeout_count": self._timeout_count,
-            "cache_hits": self._cache_hits,
-            "cache_misses": self._cache_misses,
+            **counters,
         }
 
 
@@ -1042,7 +1063,8 @@ def collect_latency_stats_from_apis(
         total_duration_ms: Total wall-clock time for chunk processing in milliseconds
 
     Returns:
-        Dict with combined latency stats, or None if no latencies were recorded
+        Dict with combined latency stats (latency fields zeroed with count=0 for
+        a fully-cached chunk), or None if there was no API activity at all
     """
     combined_latencies = []
     combined_retry_count = 0
@@ -1058,8 +1080,38 @@ def collect_latency_stats_from_apis(
             combined_cache_hits += api._cache_hits
             combined_cache_misses += api._cache_misses
 
+    counters = {
+        "retry_count": combined_retry_count,
+        "timeout_count": combined_timeout_count,
+        "cache_hits": combined_cache_hits,
+        "cache_misses": combined_cache_misses,
+    }
+    timing = {
+        "start_time": chunk_start_time,
+        "end_time": chunk_end_time,
+        "total_duration_ms": total_duration_ms,
+    }
+
     if not combined_latencies:
-        return None
+        # A chunk served entirely from cache records no latencies but the cache
+        # counters still matter (hit-rate display, latency sidecars): keep the
+        # row with zeroed latency fields — consumers guard on count == 0.
+        if not any(counters.values()):
+            return None
+        return {
+            "chunk_id": chunk_id,
+            "mean": 0.0,
+            "p50": 0.0,
+            "p90": 0.0,
+            "p95": 0.0,
+            "p99": 0.0,
+            "min": 0.0,
+            "max": 0.0,
+            "count": 0,
+            "histogram": [0] * (len(LATENCY_BUCKETS) - 1),
+            **counters,
+            **timing,
+        }
 
     arr = np.array(combined_latencies)
     n = len(arr)
@@ -1076,13 +1128,8 @@ def collect_latency_stats_from_apis(
         "max": float(np.max(arr)),
         "count": n,
         "histogram": hist.tolist(),
-        "retry_count": combined_retry_count,
-        "timeout_count": combined_timeout_count,
-        "cache_hits": combined_cache_hits,
-        "cache_misses": combined_cache_misses,
-        "start_time": chunk_start_time,
-        "end_time": chunk_end_time,
-        "total_duration_ms": total_duration_ms,
+        **counters,
+        **timing,
     }
 
 

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -904,9 +904,12 @@ class BaseApiClient:
         instead of re-fetching the same payload.
 
         Yields ``(joined, entry)``: ``joined`` is False for the request that
-        created the in-flight entry (nothing was in flight — fetch immediately,
-        no cache re-check needed) and True for requests that waited behind an
-        in-flight fetch (re-check the cache, which should now hold the result).
+        created the in-flight entry (nothing was in flight) and True for
+        requests that waited behind an in-flight fetch. Callers must re-check
+        the cache after entering the context in BOTH cases — a joiner reads the
+        result of the fetch it queued behind, and even a fresh creator can be
+        looking at a warm key, because a competing fetch can complete and drain
+        its entry between this caller's fast-path cache check and lock entry.
         ``entry.fetch_failed`` is the escape hatch: the caller sets it when a
         fetch under this lock failed to produce a cache entry (fetch raised, or
         the best-effort cache write was skipped), and waiters that see it set
@@ -1644,6 +1647,26 @@ def combine_chunk_latency_stats(chunk_path: Path, output_csv_path: Path) -> List
     ]
 
     return stats_list
+
+
+def log_request_cache_summary(logger_, chunk_stats: List[Dict]) -> None:
+    """
+    Log the overall request-cache hit rate for an export closeout.
+
+    "Hits" are requests served without an API call: entries already cached
+    before the run plus duplicates coalesced onto an in-flight fetch. Stats
+    come from combine_chunk_latency_stats(), which always carries the cache
+    counters (fully-cached chunks report them with count=0).
+    """
+    total_hits = sum(s["cache_hits"] for s in chunk_stats)
+    total_misses = sum(s["cache_misses"] for s in chunk_stats)
+    checked = total_hits + total_misses
+    if checked == 0:
+        return
+    logger_.info(
+        f"Request cache: {total_hits}/{checked} requests served without an API call "
+        f"({100 * total_hits / checked:.1f}% - pre-existing entries + coalesced duplicates)"
+    )
 
 
 def read_latency_csv(csv_path) -> List[Dict]:

--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -476,6 +476,23 @@ def clean_api_key_from_string(text: str) -> str:
 PROGRESS_BATCH_SIZE = 50
 
 
+class _InflightEntry:
+    """State shared by concurrent requests coalescing on one cache path.
+
+    See BaseApiClient._coalesce_inflight. ``fetch_failed`` transitions
+    False -> True only (benign unlocked writes): once a fetch under this
+    entry's lock has failed to produce a cache entry, waiters stop
+    serializing behind the lock and fetch independently.
+    """
+
+    __slots__ = ("lock", "refcount", "fetch_failed")
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.refcount = 0
+        self.fetch_failed = False
+
+
 class BaseApiClient:
     """
     Base class for Nearmap AI API clients.
@@ -523,10 +540,10 @@ class BaseApiClient:
         self._lock = threading.Lock()
 
         # In-flight request coalescing (see _coalesce_inflight): cache path ->
-        # [lock, in-flight request count]. Guarded by _inflight_guard; bounded
-        # because each entry is dropped when its last in-flight request leaves,
-        # so the map can never exceed this client's thread count.
-        self._inflight_requests: Dict[str, list] = {}
+        # _InflightEntry. Guarded by _inflight_guard; bounded because each
+        # entry is dropped when its last in-flight request leaves, so the map
+        # can never exceed this client's thread count.
+        self._inflight_requests: Dict[str, _InflightEntry] = {}
         self._inflight_guard = threading.Lock()
 
         # Progress-counter plumbing. `progress_counters` is overridden by
@@ -580,14 +597,27 @@ class BaseApiClient:
         self.threads = threads
         self.maxretry = maxretry
 
-        # Latency and request tracking
-        # Note: These are safe because each chunk runs in a separate process (ProcessPoolExecutor),
-        # so each API client instance is isolated - no cross-thread access occurs.
+        # Latency and request tracking. One client instance is shared by all of
+        # a chunk's worker threads, so these ARE accessed cross-thread:
+        # list.append is atomic under the GIL, but the integer counters must be
+        # incremented under self._lock (see _count_cache_hit/_count_cache_miss
+        # and _count_urllib3_retry) — a bare `+= 1` loses updates.
         self._latencies = []
         self._retry_count = 0
         self._timeout_count = 0
         self._cache_hits = 0
         self._cache_misses = 0
+        self._cache_write_failures = 0
+
+    def _count_cache_hit(self):
+        """Thread-safe cache-hit increment; feeds sidecar stats and the progress-bar hit rate."""
+        with self._lock:
+            self._cache_hits += 1
+
+    def _count_cache_miss(self):
+        """Thread-safe cache-miss increment; feeds sidecar stats and the progress-bar hit rate."""
+        with self._lock:
+            self._cache_misses += 1
 
     def _count_urllib3_retry(self, cause):
         """RetryRequest.on_retry hook: count retries urllib3 performs inside the transport.
@@ -870,36 +900,51 @@ class BaseApiClient:
         units sharing one polygon), and those duplicate requests sit adjacent in
         input order — so on a cold cache they all miss together and fetch the
         same payload concurrently. Holding a per-cache-path lock lets the first
-        requester fetch and write the cache; the caller's second cache check
-        (inside this context) then turns every waiter into a cache hit.
+        requester fetch and write the cache; each waiter then reads the cache
+        instead of re-fetching the same payload.
 
-        Callers must re-check the cache after entering the context (double-checked
-        read). If the first fetch fails, each waiter proceeds with its own fetch
-        in turn — same outcome as today's duplicate fetches, just serialized.
+        Yields ``(joined, entry)``: ``joined`` is False for the request that
+        created the in-flight entry (nothing was in flight — fetch immediately,
+        no cache re-check needed) and True for requests that waited behind an
+        in-flight fetch (re-check the cache, which should now hold the result).
+        ``entry.fetch_failed`` is the escape hatch: the caller sets it when a
+        fetch under this lock failed to produce a cache entry (fetch raised, or
+        the best-effort cache write was skipped), and waiters that see it set
+        skip the wait-and-read protocol and fetch independently OUTSIDE the lock
+        — restoring the legacy concurrent-duplicates behaviour instead of
+        serializing repeated long-timeout failures behind one key.
 
-        No-op when cache_path is None (no cache — nowhere to share a result) or
-        in overwrite mode (every request must refetch by design). The lock map is
-        per-process: workers in other processes still fetch independently.
+        Deadlock safety: a coalesce lock is only ever held while a single
+        request fetches. Gridding never runs under it — an
+        APIRequestSizeError unwinds out of this context before the caller
+        grids, so no thread holds a coalesce lock while waiting on the
+        gridding semaphore or on another coalesce lock.
+
+        No-op (fresh unshared entry, joined=False) when cache_path is None
+        (no cache — nowhere to share a result) or in overwrite mode (every
+        request must refetch by design). The lock map is per-process and
+        bounded: an entry exists only while requests for its key are in
+        flight, so the map can never exceed this client's thread count.
         """
         if cache_path is None or self.overwrite_cache:
-            yield
+            yield False, _InflightEntry()
             return
 
         with self._inflight_guard:
             entry = self._inflight_requests.get(cache_path)
+            joined = entry is not None
             if entry is None:
-                entry = [threading.Lock(), 0]
+                entry = _InflightEntry()
                 self._inflight_requests[cache_path] = entry
-            entry[1] += 1
-            lock = entry[0]
+            entry.refcount += 1
 
         try:
-            with lock:
-                yield
+            with entry.lock:
+                yield joined, entry
         finally:
             with self._inflight_guard:
-                entry[1] -= 1
-                if entry[1] == 0 and self._inflight_requests.get(cache_path) is entry:
+                entry.refcount -= 1
+                if entry.refcount == 0 and self._inflight_requests.get(cache_path) is entry:
                     del self._inflight_requests[cache_path]
 
     def _sanitize_path_component(self, text: str) -> str:
@@ -1352,6 +1397,12 @@ def compute_global_latency_stats(
     Returns:
         Dict with global mean, percentiles, and 95% confidence intervals
     """
+    # Chunks served entirely from cache report count=0 with an all-zero
+    # histogram. They carry no latency signal, and letting them into the
+    # bootstrap corrupts the confidence intervals: a resample drawing only
+    # zero chunks yields an all-zero histogram whose percentile is 0.0,
+    # dragging the CI lower bound to 0 on warm-cache/resumed exports.
+    chunk_stats = [s for s in chunk_stats if s["count"] > 0]
     if not chunk_stats:
         return {}
 
@@ -1585,6 +1636,8 @@ def combine_chunk_latency_stats(chunk_path: Path, output_csv_path: Path) -> List
             "p99": float(row["p99"]),
             "min": float(row["min"]),
             "max": float(row["max"]),
+            "cache_hits": int(row.get("cache_hits", 0)),
+            "cache_misses": int(row.get("cache_misses", 0)),
             "histogram": [int(row[name]) for name in bucket_names if name in row],
         }
         for row in combined_df.to_dict("records")

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -644,21 +644,19 @@ class BaseExporter(ABC):
         last_progress_check = time.time()
         PROGRESS_CHECK_INTERVAL = 0.5  # Check shared counters every 0.5 seconds
         all_latency_stats = []  # Collect latency stats from each chunk
-        latest_latency_stats = None  # Track latest for progress bar display
+        latest_latency_stats = None  # Latest stats WITH live requests, for the P50 display
         total_cache_hits = 0  # Cumulative across completed chunks, for hit-rate display
         total_cache_misses = 0
 
         def build_lat_str():
             """Latency + cache hit-rate segment of the progress description.
 
-            Both figures update as chunks complete: latency shows the latest
-            chunk's P50 (or a placeholder when that chunk was served entirely
-            from cache), the cache hit rate is cumulative over all completed
-            chunks (per-chunk stats are what the workers report back).
+            Both figures update as chunks complete: latency shows the P50 of the
+            most recent chunk that made live requests (fully-cached chunks have
+            no latency signal, so they don't blank the readout), the cache hit
+            rate is cumulative over all completed chunks.
             """
-            if latest_latency_stats is None:
-                return "Lat: ---"
-            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms" if latest_latency_stats["count"] > 0 else "Lat: ---"
+            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms" if latest_latency_stats else "Lat: ---"
             cache_checked = total_cache_hits + total_cache_misses
             if cache_checked > 0:
                 lat_str += f" | Cache {100 * total_cache_hits / cache_checked:.0f}%"
@@ -693,7 +691,8 @@ class BaseExporter(ABC):
                                 latency_stats = result.get("latency_stats")
                                 if latency_stats is not None:
                                     all_latency_stats.append(latency_stats)
-                                    latest_latency_stats = latency_stats
+                                    if latency_stats["count"] > 0:
+                                        latest_latency_stats = latency_stats
                                     total_cache_hits += latency_stats["cache_hits"]
                                     total_cache_misses += latency_stats["cache_misses"]
 

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -645,6 +645,23 @@ class BaseExporter(ABC):
         PROGRESS_CHECK_INTERVAL = 0.5  # Check shared counters every 0.5 seconds
         all_latency_stats = []  # Collect latency stats from each chunk
         latest_latency_stats = None  # Track latest for progress bar display
+        total_cache_hits = 0  # Cumulative across completed chunks, for hit-rate display
+        total_cache_misses = 0
+
+        def build_lat_str():
+            """Latency + cache hit-rate segment of the progress description.
+
+            Both figures update as chunks complete: latency shows the latest
+            chunk's P50, the cache hit rate is cumulative over all completed
+            chunks (per-chunk stats are what the workers report back).
+            """
+            if latest_latency_stats is None:
+                return "Lat: ---"
+            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
+            cache_checked = total_cache_hits + total_cache_misses
+            if cache_checked > 0:
+                lat_str += f" | Cache {100 * total_cache_hits / cache_checked:.0f}%"
+            return lat_str
 
         # Get initial total
         with progress_counters["lock"]:
@@ -676,6 +693,8 @@ class BaseExporter(ABC):
                                 if latency_stats is not None:
                                     all_latency_stats.append(latency_stats)
                                     latest_latency_stats = latency_stats
+                                    total_cache_hits += latency_stats["cache_hits"]
+                                    total_cache_misses += latency_stats["cache_misses"]
 
                             # Update progress bar immediately. Blocking acquire
                             # so the displayed counter actually tracks the
@@ -688,14 +707,8 @@ class BaseExporter(ABC):
                                 pbar.total = requests_total
                             pbar.n = requests_completed
 
-                            # Build latency string for progress bar
-                            if latest_latency_stats:
-                                lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
-                            else:
-                                lat_str = "Lat: ---"
-
                             pbar.set_description(
-                                self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str)
+                                self._format_progress_description(completed_jobs, num_jobs, lat_str=build_lat_str())
                             )
                             pbar.refresh()
 
@@ -729,15 +742,11 @@ class BaseExporter(ABC):
                     if pbar.total != requests_total:
                         pbar.total = requests_total
 
-                    # Build latency string for progress bar
-                    if latest_latency_stats:
-                        lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
-                    else:
-                        lat_str = "Lat: ---"
-
                     # Update position and description
                     pbar.n = requests_completed
-                    pbar.set_description(self._format_progress_description(completed_jobs, num_jobs, lat_str=lat_str))
+                    pbar.set_description(
+                        self._format_progress_description(completed_jobs, num_jobs, lat_str=build_lat_str())
+                    )
                     pbar.refresh()
                     last_progress_check = current_time
 
@@ -746,15 +755,9 @@ class BaseExporter(ABC):
                 requests_completed = progress_counters["completed"]
                 requests_total = progress_counters["total"]
 
-            # Build final latency string
-            if latest_latency_stats:
-                lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
-            else:
-                lat_str = "Lat: ---"
-
             pbar.n = requests_completed
             pbar.total = requests_total
-            pbar.set_description(self._format_progress_description(num_jobs, num_jobs, lat_str=lat_str))
+            pbar.set_description(self._format_progress_description(num_jobs, num_jobs, lat_str=build_lat_str()))
             pbar.refresh()
 
         finally:

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -652,12 +652,13 @@ class BaseExporter(ABC):
             """Latency + cache hit-rate segment of the progress description.
 
             Both figures update as chunks complete: latency shows the latest
-            chunk's P50, the cache hit rate is cumulative over all completed
+            chunk's P50 (or a placeholder when that chunk was served entirely
+            from cache), the cache hit rate is cumulative over all completed
             chunks (per-chunk stats are what the workers report back).
             """
             if latest_latency_stats is None:
                 return "Lat: ---"
-            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms"
+            lat_str = f"P50={latest_latency_stats['p50']:.0f}ms" if latest_latency_stats["count"] > 0 else "Lat: ---"
             cache_checked = total_cache_hits + total_cache_misses
             if cache_checked > 0:
                 lat_str += f" | Cache {100 * total_cache_hits / cache_checked:.0f}%"

--- a/nmaipy/damage_conflation_api.py
+++ b/nmaipy/damage_conflation_api.py
@@ -409,11 +409,11 @@ class DamageConflationApi(BaseApiClient):
         cache_key = self._build_cache_key(aoi=aoi)
         cached = self._load_from_cache(cache_key)
         if cached is not None:
-            self._cache_hits += 1
+            self._count_cache_hit()
             logger.debug(f"Using cached damage data for {aoi_id}")
             return self._parse_response(cached, aoi_id)
 
-        self._cache_misses += 1
+        self._count_cache_miss()
         url = f"{self.base_url}.{file_format}"
         # In bearer mode the apikey param is omitted (auth is the session header).
         params = {} if self.bearer_token else {"apikey": self.api_key}
@@ -443,11 +443,11 @@ class DamageConflationApi(BaseApiClient):
         cache_key = self._build_cache_key(address=address)
         cached = self._load_from_cache(cache_key)
         if cached is not None:
-            self._cache_hits += 1
+            self._count_cache_hit()
             logger.debug(f"Using cached damage data for {aoi_id}")
             return self._parse_response(cached, aoi_id)
 
-        self._cache_misses += 1
+        self._count_cache_miss()
         url = f"{self.base_url}.{file_format}"
         # In bearer mode the apikey param is omitted (auth is the session header).
         params = {} if self.bearer_token else {"apikey": self.api_key}

--- a/nmaipy/damage_conflation_exporter.py
+++ b/nmaipy/damage_conflation_exporter.py
@@ -36,6 +36,7 @@ from nmaipy.api_common import (
     combine_chunk_latency_stats,
     compute_global_latency_stats,
     format_error_summary_table,
+    log_request_cache_summary,
     sanitize_error_message,
     save_chunk_latency_stats,
 )
@@ -355,6 +356,7 @@ class DamageConflationExporter(BaseExporter):
                     f"P50={global_stats['p50']:.0f}ms, P90={global_stats['p90']:.0f}ms, "
                     f"P95={global_stats['p95']:.0f}ms, P99={global_stats['p99']:.0f}ms, n={global_stats['count']}"
                 )
+            log_request_cache_summary(self.logger, all_latency_stats)
 
         self.logger.info("Combining chunk results...")
         features_gdf = self.combine_chunk_files("damage_features", num_chunks, geo=True)

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -67,6 +67,7 @@ from nmaipy.api_common import (
     combine_chunk_latency_stats,
     compute_global_latency_stats,
     format_error_summary_table,
+    log_request_cache_summary,
     sanitize_error_message,
     save_chunk_latency_stats,
 )
@@ -4587,6 +4588,7 @@ class NearmapAIExporter(BaseExporter):
                     f"P99={global_stats['p99']:.0f}ms [{global_stats['p99_ci'][0]:.0f}-{global_stats['p99_ci'][1]:.0f}], "
                     f"n={global_stats['count']}"
                 )
+            log_request_cache_summary(self.logger, all_latency_stats)
 
         data = []
         data_features = []

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -31,6 +31,7 @@ from typing import Dict, List, Optional
 
 import geopandas as gpd
 import numpy as np
+import orjson
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -2958,10 +2959,11 @@ class NearmapAIExporter(BaseExporter):
             "class_level_files": class_level_files,
             "max_retries": max_retries,
         }
-        # Round-trip through JSON now (with default=str) so the in-memory copy
-        # used for fast-path comparison matches the on-disk shape — same
-        # str-coercion of Path objects, list-not-tuple, etc.
-        self._current_config_params = json.loads(json.dumps(config_params, default=str))
+        # Round-trip through the same serializer that writes export_config.json
+        # (orjson, via storage.json_dumps_bytes) so the in-memory copy used for
+        # fast-path comparison matches the on-disk shape — same str-coercion of
+        # Path objects, list-not-tuple, numpy/datetime handling, etc.
+        self._current_config_params = orjson.loads(storage.json_dumps_bytes(config_params, default=str))
 
         # Save export configuration at start (before processing begins)
         self._save_config(config_params)

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, parse_qsl, quote, urlencode, urlparse, urlunp
 
 import geopandas as gpd
 import numpy as np
+import orjson
 import pandas as pd
 import requests
 import shapely.geometry
@@ -402,7 +403,10 @@ class FeatureApi(GriddedApiClient):
         # Clean API key from URL
         clean_url = self._clean_api_key(url)
 
-        # Convert body to a stable string representation for cache key
+        # Convert body to a stable string representation for cache key.
+        # Deliberately stdlib json, not orjson: stdlib's default separators
+        # (", ", ": ") are baked into the md5 of every existing cache entry —
+        # changing the serializer would invalidate warm production caches.
         body_str = json.dumps(body, sort_keys=True)
         combined_str = clean_url + body_str
         request_hash = hashlib.md5(combined_str.encode()).hexdigest()
@@ -461,30 +465,41 @@ class FeatureApi(GriddedApiClient):
 
         For local paths, uses atomic write via temp file + rename.
         For S3 paths, writes directly (S3 puts are atomic).
-        """
-        if storage.is_s3_path(str(path)):
-            # S3 puts are atomic, so write directly
-            storage.write_json(str(path), payload, compressed=self.compress_cache)
-        else:
-            # Local: atomic write via temp file + rename
-            parent_dir = str(Path(path).parent)
-            storage.ensure_directory(parent_dir)
-            temp_filename = f"{str(uuid.uuid4())}.tmp"
-            if self.compress_cache:
-                temp_filename = f"{temp_filename}.gz"
-            temp_path = Path(parent_dir) / temp_filename
 
-            try:
-                if self.compress_cache:
-                    with gzip.open(temp_path, "wb") as f:
-                        f.write(json.dumps(payload).encode("utf-8"))
-                else:
-                    with open(temp_path, "w", encoding="utf-8") as f:
-                        json.dump(payload, f)
-                temp_path.replace(path)
-            finally:
-                if temp_path.exists():
+        Best-effort: an external actor can delete the cache tree mid-run, which
+        makes the tmp-file rename race the deletion. One retry re-creates the
+        directory; if the write still fails, the entry is skipped with a warning
+        rather than failing the AOI — the response is simply not cached.
+        """
+        try:
+            if storage.is_s3_path(str(path)):
+                # S3 puts are atomic, so write directly
+                storage.write_json(str(path), payload, compressed=self.compress_cache)
+                return
+
+            # Local: atomic write via temp file + rename. Serialize/compress once,
+            # outside the retry loop — only the directory + file ops can race.
+            blob = storage.json_dumps_bytes(payload)
+            if self.compress_cache:
+                blob = gzip.compress(blob)
+
+            path = Path(path)
+            temp_suffix = ".tmp.gz" if self.compress_cache else ".tmp"
+            for attempt in range(2):
+                storage.ensure_directory(str(path.parent))
+                temp_path = path.parent / f"{uuid.uuid4()}{temp_suffix}"
+                try:
+                    temp_path.write_bytes(blob)
+                    temp_path.replace(path)
+                    return
+                except OSError as e:
+                    if attempt == 1:
+                        raise
+                    logger.debug(f"Cache write to {path} failed ({e}), re-creating cache dir and retrying")
+                finally:
                     temp_path.unlink(missing_ok=True)
+        except Exception as e:
+            logger.warning(f"Failed to write cache entry {path} - continuing without caching it: {e}")
 
     def _create_post_request(
         self,
@@ -700,37 +715,67 @@ class FeatureApi(GriddedApiClient):
         Returns:
             API response as a Dictionary
         """
+        # Use POST request with JSON body for better geometry handling
+        url, body, exact = self._create_post_request(
+            base_url=self.FEATURES_URL,
+            geometry=geometry,
+            packs=packs,
+            classes=classes,
+            include=include,
+            since=since,
+            until=until,
+            address_fields=address_fields,
+            survey_resource_id=survey_resource_id,
+            region=region,
+            param_dic=param_dic,
+            disable_parcel_mode=disable_parcel_mode,
+        )
+        cache_path = None if self.cache_dir is None else self._post_request_cache_path(url, body)
+
+        # Check if it's already cached
+        data = self._read_cached_response(cache_path)
+        if data is not None:
+            self._cache_hits += 1
+            return data
+
+        # Coalesce concurrent duplicate requests (byte-identical url + body ⇒
+        # same cache path): the first requester fetches and writes the cache;
+        # the rest block on the per-key lock, then hit the cache on this
+        # second check instead of re-fetching the same payload.
+        with self._coalesce_inflight(cache_path):
+            data = self._read_cached_response(cache_path)
+            if data is not None:
+                self._cache_hits += 1
+                return data
+            return self._fetch_results(url, body, cache_path, in_gridding_mode)
+
+    def _read_cached_response(self, cache_path: Optional[str]) -> Optional[Dict]:
+        """
+        Return the cached response for cache_path, or None if there is nothing usable:
+        cache disabled, overwrite mode, entry absent, or entry unreadable (logged).
+        """
+        if cache_path is None or self.overwrite_cache:
+            return None
+        if not storage.file_exists(cache_path):
+            return None
+        try:
+            return storage.read_json(cache_path, compressed=self.compress_cache)
+        except EOFError as e:
+            logger.error(f"Error loading compressed cache file {cache_path}.")
+            logger.error(f"Error: {e}")
+        except Exception as e:
+            logger.error(f"Error loading cache file {cache_path}: {e}")
+        return None
+
+    def _fetch_results(self, url: str, body: dict, cache_path: Optional[str], in_gridding_mode: bool):
+        """
+        POST the request to the live API, parse the response, and cache it.
+
+        Split out of _get_results so the cache fast path and in-flight
+        coalescing wrap it cleanly. Raises AIFeatureAPIRequestSizeError /
+        AIFeatureAPIError like the API error handling always has.
+        """
         with self._session_scope(in_gridding_mode) as session:
-            # Use POST request with JSON body for better geometry handling
-            url, body, exact = self._create_post_request(
-                base_url=self.FEATURES_URL,
-                geometry=geometry,
-                packs=packs,
-                classes=classes,
-                include=include,
-                since=since,
-                until=until,
-                address_fields=address_fields,
-                survey_resource_id=survey_resource_id,
-                region=region,
-                param_dic=param_dic,
-                disable_parcel_mode=disable_parcel_mode,
-            )
-            cache_path = None if self.cache_dir is None else self._post_request_cache_path(url, body)
-
-            # Check if it's already cached
-            if self.cache_dir is not None and not self.overwrite_cache:
-                if storage.file_exists(cache_path):
-                    try:
-                        data = storage.read_json(cache_path, compressed=self.compress_cache)
-                        self._cache_hits += 1
-                        return data
-                    except EOFError as e:
-                        logger.error(f"Error loading compressed cache file {cache_path}.")
-                        logger.error(f"Error: {e}")
-                    except Exception as e:
-                        logger.error(f"Error loading cache file {cache_path}: {e}")
-
             # Request data with retry loop for ChunkedEncodingError
             # Note: While urllib3 RetryRequest handles ChunkedEncodingError, this additional
             # retry loop exists to catch cases where the response is successfully received but
@@ -829,7 +874,10 @@ class FeatureApi(GriddedApiClient):
 
             if response.ok:
                 try:
-                    data = response.json()
+                    # orjson.loads(response.content) rather than response.json():
+                    # cache replay and feature-dense responses are parse-bound, and
+                    # orjson is 5-10x faster than stdlib on multi-MB payloads.
+                    data = orjson.loads(response.content)
                 except Exception as e:
                     # Treat JSON parsing errors as size errors to trigger gridding
                     logger.debug(f"JSON parsing error - treat as size error to try again with a gridded approach: {e}")

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -753,20 +753,24 @@ class FeatureApi(GriddedApiClient):
         # duplicates block on the per-key lock, then read the entry it wrote
         # instead of re-fetching the same payload.
         with self._coalesce_inflight(cache_path) as (joined, inflight):
-            if not joined:
-                # Nothing was in flight for this key: fetch it. Flag a failure
-                # so queued duplicates fetch for themselves instead of
-                # serializing behind a key that produced no cache entry.
-                try:
-                    return self._fetch_results(url, body, cache_path, in_gridding_mode)
-                except Exception:
-                    inflight.fetch_failed = True
-                    raise
             if not inflight.fetch_failed:
+                # Double-checked read — for creators too: between the fast-path
+                # check and taking the lock, another thread may have fetched,
+                # cached, AND drained its in-flight entry, so a fresh creator
+                # can still be looking at a warm key.
                 data = self._read_cached_response(cache_path)
                 if data is not None:
                     self._count_cache_hit()
                     return data
+                if not joined:
+                    # Nothing was in flight for this key: fetch it. Flag a
+                    # failure so queued duplicates fetch for themselves instead
+                    # of serializing behind a key that produced no cache entry.
+                    try:
+                        return self._fetch_results(url, body, cache_path, in_gridding_mode)
+                    except Exception:
+                        inflight.fetch_failed = True
+                        raise
                 # The fetch we waited for completed without raising, yet shared
                 # nothing (best-effort cache write skipped) — stop serializing.
                 inflight.fetch_failed = True

--- a/nmaipy/feature_api.py
+++ b/nmaipy/feature_api.py
@@ -499,7 +499,17 @@ class FeatureApi(GriddedApiClient):
                 finally:
                     temp_path.unlink(missing_ok=True)
         except Exception as e:
-            logger.warning(f"Failed to write cache entry {path} - continuing without caching it: {e}")
+            # A systematic failure (read-only dir, ENOSPC, expired S3 creds)
+            # would otherwise warn once per AOI — surface the first few and a
+            # periodic running count instead of flooding the log.
+            with self._lock:
+                self._cache_write_failures += 1
+                n = self._cache_write_failures
+            msg = f"Failed to write cache entry {path} - continuing without caching it ({n} failures so far): {e}"
+            if n <= 3 or n % 1000 == 0:
+                logger.warning(msg)
+            else:
+                logger.debug(msg)
 
     def _create_post_request(
         self,
@@ -735,19 +745,36 @@ class FeatureApi(GriddedApiClient):
         # Check if it's already cached
         data = self._read_cached_response(cache_path)
         if data is not None:
-            self._cache_hits += 1
+            self._count_cache_hit()
             return data
 
         # Coalesce concurrent duplicate requests (byte-identical url + body ⇒
         # same cache path): the first requester fetches and writes the cache;
-        # the rest block on the per-key lock, then hit the cache on this
-        # second check instead of re-fetching the same payload.
-        with self._coalesce_inflight(cache_path):
-            data = self._read_cached_response(cache_path)
-            if data is not None:
-                self._cache_hits += 1
-                return data
-            return self._fetch_results(url, body, cache_path, in_gridding_mode)
+        # duplicates block on the per-key lock, then read the entry it wrote
+        # instead of re-fetching the same payload.
+        with self._coalesce_inflight(cache_path) as (joined, inflight):
+            if not joined:
+                # Nothing was in flight for this key: fetch it. Flag a failure
+                # so queued duplicates fetch for themselves instead of
+                # serializing behind a key that produced no cache entry.
+                try:
+                    return self._fetch_results(url, body, cache_path, in_gridding_mode)
+                except Exception:
+                    inflight.fetch_failed = True
+                    raise
+            if not inflight.fetch_failed:
+                data = self._read_cached_response(cache_path)
+                if data is not None:
+                    self._count_cache_hit()
+                    return data
+                # The fetch we waited for completed without raising, yet shared
+                # nothing (best-effort cache write skipped) — stop serializing.
+                inflight.fetch_failed = True
+        # The in-flight fetch for this key failed to produce a cache entry.
+        # Fetch independently OUTSIDE the lock, restoring the legacy
+        # concurrent-duplicates behaviour rather than repeating a potentially
+        # long-timeout failure serially, once per duplicate.
+        return self._fetch_results(url, body, cache_path, in_gridding_mode)
 
     def _read_cached_response(self, cache_path: Optional[str]) -> Optional[Dict]:
         """
@@ -786,7 +813,7 @@ class FeatureApi(GriddedApiClient):
             response_time_ms = None
 
             # Track this as a cache miss (we're making an API call)
-            self._cache_misses += 1
+            self._count_cache_miss()
 
             for retry_attempt in range(MAX_RETRIES):
                 try:
@@ -817,7 +844,8 @@ class FeatureApi(GriddedApiClient):
                     # READ_TIMEOUT_SECONDS, so grid the AOI into smaller requests rather
                     # than re-sending the same oversized one (each resend closes the
                     # connection server-side and re-runs the full computation).
-                    self._timeout_count += 1
+                    with self._lock:
+                        self._timeout_count += 1
                     logger.info(
                         f"Read timeout after {READ_TIMEOUT_SECONDS}s on attempt {retry_attempt + 1}/{MAX_RETRIES}, treating as 504"
                     )
@@ -840,7 +868,8 @@ class FeatureApi(GriddedApiClient):
                 except requests.exceptions.ChunkedEncodingError as e:
                     if retry_attempt < MAX_RETRIES - 1:
                         # Log debug message for retry attempts
-                        self._retry_count += 1
+                        with self._lock:
+                            self._retry_count += 1
                         logger.debug(
                             f"ChunkedEncodingError on attempt {retry_attempt + 1}/{MAX_RETRIES}, retrying: {e}"
                         )
@@ -878,6 +907,16 @@ class FeatureApi(GriddedApiClient):
                     # cache replay and feature-dense responses are parse-bound, and
                     # orjson is 5-10x faster than stdlib on multi-MB payloads.
                     data = orjson.loads(response.content)
+                except orjson.JSONDecodeError as e:
+                    # Usually a truncated over-large response, so treat as a size
+                    # error to trigger gridding — but log visibly, because orjson
+                    # also rejects payloads stdlib accepted (NaN/Infinity literals,
+                    # BOM, invalid UTF-8) and those would masquerade as size errors.
+                    logger.warning(
+                        f"JSON parse error on 200 response ({len(response.content)} bytes) - "
+                        f"treating as size error to trigger gridding: {e}"
+                    )
+                    raise AIFeatureAPIRequestSizeError(response, self._clean_api_key(url))
                 except Exception as e:
                     # Treat JSON parsing errors as size errors to trigger gridding
                     logger.debug(f"JSON parsing error - treat as size error to try again with a gridded approach: {e}")

--- a/nmaipy/roof_age_api.py
+++ b/nmaipy/roof_age_api.py
@@ -582,12 +582,12 @@ class RoofAgeApi(BaseApiClient):
             cache_key, until_as_of_date=effective_until, since_as_of_date=effective_since
         )
         if cached_response is not None:
-            self._cache_hits += 1
+            self._count_cache_hit()
             logger.debug(f"Using cached roof age data for {aoi_id}")
             return self._parse_response(cached_response, aoi_id)
 
         # Fetch all pages (this is a cache miss)
-        self._cache_misses += 1
+        self._count_cache_miss()
         url = f"{self.base_url}.{file_format}"
         # In bearer mode the apikey param is omitted (auth is the session header).
         params = {} if self.bearer_token else {"apikey": self.api_key}
@@ -652,12 +652,12 @@ class RoofAgeApi(BaseApiClient):
             cache_key, until_as_of_date=effective_until, since_as_of_date=effective_since
         )
         if cached_response is not None:
-            self._cache_hits += 1
+            self._count_cache_hit()
             logger.debug(f"Using cached roof age data for {aoi_id}")
             return self._parse_response(cached_response, aoi_id)
 
         # Fetch all pages (this is a cache miss)
-        self._cache_misses += 1
+        self._count_cache_miss()
         url = f"{self.base_url}.{file_format}"
         # In bearer mode the apikey param is omitted (auth is the session header).
         params = {} if self.bearer_token else {"apikey": self.api_key}

--- a/nmaipy/roof_age_exporter.py
+++ b/nmaipy/roof_age_exporter.py
@@ -37,6 +37,7 @@ from nmaipy.api_common import (
     combine_chunk_latency_stats,
     compute_global_latency_stats,
     format_error_summary_table,
+    log_request_cache_summary,
     sanitize_error_message,
     save_chunk_latency_stats,
 )
@@ -506,6 +507,7 @@ class RoofAgeExporter(BaseExporter):
                     f"P99={global_stats['p99']:.0f}ms [{global_stats['p99_ci'][0]:.0f}-{global_stats['p99_ci'][1]:.0f}], "
                     f"n={global_stats['count']}"
                 )
+            log_request_cache_summary(self.logger, all_latency_stats)
 
         # Combine chunk results (BaseExporter.combine_chunk_files invalidates the s3fs
         # listing first, so present chunks aren't missed on S3 output).

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -11,7 +11,6 @@ or ~/.aws/credentials.
 """
 
 import gzip
-import json
 import logging
 import os
 import shutil
@@ -21,6 +20,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import boto3
 import fsspec
+import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
 from boto3.s3.transfer import TransferConfig
@@ -376,9 +376,46 @@ def move_file(src: str, dst: str) -> None:
         os.replace(src, dst)
 
 
+def json_dumps_bytes(data: Any, default=None, indent: Optional[int] = None) -> bytes:
+    """
+    Serialize data to JSON bytes via orjson (5-10x faster than stdlib json on
+    the multi-MB API payloads that dominate cache writes).
+
+    Compatibility with the stdlib json.dumps this replaced:
+    - Non-str dict keys are stringified (OPT_NON_STR_KEYS), matching stdlib
+      semantics (1 -> "1", 2.5 -> "2.5").
+    - Numpy scalars/arrays serialize as JSON numbers (OPT_SERIALIZE_NUMPY);
+      stdlib pushed non-float numpy values through ``default`` instead, which
+      turned them into strings when ``default=str``.
+    - Float NaN/Infinity serialize as ``null``; stdlib emitted the
+      non-standard ``NaN``/``Infinity`` literals.
+    - Only ``indent=2`` or ``None`` is supported (orjson limitation); no
+      caller uses any other indent.
+
+    Args:
+        data: Data to serialize
+        default: Function for non-serializable types (e.g. str)
+        indent: None for compact output, or 2 for pretty-printed
+
+    Returns:
+        UTF-8 encoded JSON bytes.
+    """
+    option = orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+    if indent is not None:
+        if indent != 2:
+            raise ValueError(f"json_dumps_bytes supports indent=None or 2, got {indent}")
+        option |= orjson.OPT_INDENT_2
+    return orjson.dumps(data, default=default, option=option)
+
+
 def read_json(path: str, compressed: bool = False) -> Dict:
     """
     Read a JSON file, optionally gzip-compressed. Works for both local and S3.
+
+    Parses with orjson: cache hits on large exports are parse-bound, and orjson
+    is 5-10x faster than stdlib json.loads on the multi-MB payloads that
+    dominate wall-clock. orjson is strict UTF-8/RFC 8259 (rejects the
+    non-standard NaN/Infinity literals stdlib accepted).
 
     Args:
         path: File path to read
@@ -388,16 +425,17 @@ def read_json(path: str, compressed: bool = False) -> Dict:
         Parsed JSON data.
 
     Raises:
-        OSError / json.JSONDecodeError on missing or unparseable files —
-        callers that tolerate failure wrap this in their own try/except.
+        OSError / orjson.JSONDecodeError (a json.JSONDecodeError subclass) on
+        missing or unparseable files — callers that tolerate failure wrap this
+        in their own try/except.
     """
     if compressed:
         with open_file(path, "rb") as raw_f:
             with gzip.GzipFile(fileobj=raw_f) as gz_f:
-                return json.loads(gz_f.read().decode("utf-8"))
+                return orjson.loads(gz_f.read())
     else:
-        with open_file(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        with open_file(path, "rb") as f:
+            return orjson.loads(f.read())
 
 
 def write_json(
@@ -410,20 +448,25 @@ def write_json(
     """
     Write data as JSON, optionally gzip-compressed. Works for both local and S3.
 
+    Serializes via json_dumps_bytes (orjson) — see its docstring for the
+    compatibility notes vs stdlib json.
+
     Args:
         path: File path to write
         data: Data to serialize as JSON
         compressed: If True, write as gzip-compressed JSON
-        indent: JSON indentation level (None for compact)
-        default: Function for non-serializable types (e.g. str). Passed to json.dump/json.dumps.
+        indent: JSON indentation level (None for compact, 2 is the only other
+            supported value)
+        default: Function for non-serializable types (e.g. str)
     """
+    payload = json_dumps_bytes(data, default=default, indent=indent)
     if compressed:
         with open_file(path, "wb") as raw_f:
             with gzip.GzipFile(fileobj=raw_f, mode="wb") as gz_f:
-                gz_f.write(json.dumps(data, default=default).encode("utf-8"))
+                gz_f.write(payload)
     else:
-        with open_file(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=indent, default=default)
+        with open_file(path, "wb") as f:
+            f.write(payload)
 
 
 def write_parquet(data, path: str, **kwargs) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "fsspec>=2025.3.0",
     "geopandas>=1.1.1",
     "numpy>=2.3.5",
+    "orjson>=3.9",
     "pandas>=2.3.3",
     "psutil>=7.1.3",
     "pyarrow>=20.0.0",

--- a/tests/test_feature_api_prefer3d.py
+++ b/tests/test_feature_api_prefer3d.py
@@ -62,6 +62,9 @@ class _MockResponse:
             self.text = json.dumps(body)
         else:
             self.text = body
+        # Successful responses are parsed from raw bytes (orjson), like
+        # requests.Response.content.
+        self.content = self.text.encode("utf-8")
 
     def json(self):
         if isinstance(self._body, dict):

--- a/tests/test_latency_stats.py
+++ b/tests/test_latency_stats.py
@@ -176,13 +176,29 @@ class TestComputeGlobalLatencyStats:
         assert result["mean"] == 150.0
 
     def test_zero_count_chunks_handled(self):
-        """Chunks with zero count should be handled gracefully."""
+        """Chunks with zero count carry no latency signal - result is empty."""
         chunk_stats = [
             {"mean": 0, "count": 0, "histogram": [0] * (len(LATENCY_BUCKETS) - 1)},
         ]
 
         result = compute_global_latency_stats(chunk_stats)
-        assert result["count"] == 0
+        assert result.get("count", 0) == 0
+
+    def test_zero_count_chunks_do_not_corrupt_confidence_intervals(self):
+        """Fully-cached chunks (count=0, all-zero histogram) must not enter the
+        bootstrap: a resample drawing only zero chunks yields percentile 0.0 and
+        drags the CI lower bound to 0 on warm-cache/resumed exports."""
+        hist = [0] * (len(LATENCY_BUCKETS) - 1)
+        hist[10] = 500  # all latencies in one bucket
+        live_chunk = {"mean": 400.0, "count": 500, "histogram": hist}
+        cached_chunk = {"mean": 0.0, "count": 0, "histogram": [0] * (len(LATENCY_BUCKETS) - 1)}
+
+        live_only = compute_global_latency_stats([live_chunk], seed=42)
+        with_cached = compute_global_latency_stats([live_chunk] + [dict(cached_chunk) for _ in range(99)], seed=42)
+
+        assert with_cached["p50_ci"] == live_only["p50_ci"]
+        assert with_cached["p99_ci"] == live_only["p99_ci"]
+        assert with_cached["count"] == live_only["count"]
 
 
 class TestCollectLatencyStatsFromApis:
@@ -262,8 +278,8 @@ class TestCollectLatencyStatsFromApis:
 
         assert result["count"] == 3
 
-    def test_empty_latencies_returns_none(self):
-        """API with empty latencies should return None."""
+    def test_no_activity_returns_none(self):
+        """API with no latencies and no cache/retry activity should return None."""
         api = self._create_mock_api([])
 
         result = collect_latency_stats_from_apis(
@@ -271,6 +287,22 @@ class TestCollectLatencyStatsFromApis:
         )
 
         assert result is None
+
+    def test_fully_cached_chunk_reports_zeroed_stats(self):
+        """A chunk served entirely from cache has no latencies but must keep its
+        cache counters (hit-rate display, latency sidecars) with zeroed latency
+        fields - consumers guard on count == 0."""
+        api = self._create_mock_api([], cache_hits=65)
+
+        result = collect_latency_stats_from_apis(
+            [api], "chunk_0", "2024-01-01T00:00:00Z", "2024-01-01T00:01:00Z", 60000
+        )
+
+        assert result["count"] == 0
+        assert result["cache_hits"] == 65
+        assert result["cache_misses"] == 0
+        assert result["p50"] == 0.0
+        assert result["histogram"] == [0] * (len(LATENCY_BUCKETS) - 1)
 
 
 class TestLatencyIO:

--- a/tests/test_request_cache.py
+++ b/tests/test_request_cache.py
@@ -146,6 +146,59 @@ class TestInflightCoalescing:
         assert api._cache_hits == 0
         assert api._inflight_requests == {}
 
+    def test_creator_reprobes_cache_after_entry_drains(self, tmp_path, real_feature_payload):
+        """A thread parked between its fast-path cache miss and entering the
+        coalescer can find the in-flight entry already drained (a competing
+        thread fetched, cached, and left). It becomes a fresh entry creator and
+        must re-probe the cache under the lock instead of re-fetching a warm key."""
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        posts = []
+        post_lock = threading.Lock()
+
+        def fake_post(self, url, *args, **kwargs):
+            with post_lock:
+                posts.append(threading.current_thread().name)
+            return _CannedResponse(200, real_feature_payload)
+
+        a_parked = threading.Event()
+        b_done = threading.Event()
+        real_read = FeatureApi._read_cached_response
+
+        def parking_read(self, cache_path):
+            # Park thread A after its first (fast-path) cache read, while B
+            # runs a complete fetch-and-cache cycle and drains its entry.
+            result = real_read(self, cache_path)
+            if threading.current_thread().name == "park-A" and not a_parked.is_set():
+                a_parked.set()
+                assert b_done.wait(timeout=10)
+            return result
+
+        aoi = _square(-111.926, 33.414)
+
+        def run_a():
+            threading.current_thread().name = "park-A"
+            return api._get_results(geometry=aoi, region="us", packs=["building"])
+
+        def run_b():
+            threading.current_thread().name = "run-B"
+            assert a_parked.wait(timeout=10)
+            result = api._get_results(geometry=aoi, region="us", packs=["building"])
+            b_done.set()
+            return result
+
+        with patch("requests.Session.post", new=fake_post):
+            with patch.object(FeatureApi, "_read_cached_response", parking_read):
+                with ThreadPoolExecutor(max_workers=2) as pool:
+                    future_a = pool.submit(run_a)
+                    future_b = pool.submit(run_b)
+                    result_a, result_b = future_a.result(), future_b.result()
+
+        assert posts == ["run-B"], "thread A must hit the cache B populated, not re-fetch it"
+        assert api._cache_hits == 1
+        assert api._cache_misses == 1
+        assert result_a == result_b == real_feature_payload
+        assert api._inflight_requests == {}
+
     def test_overwrite_cache_mode_does_not_coalesce(self, tmp_path, real_feature_payload):
         """Overwrite mode must refetch every request by design."""
         api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True, overwrite_cache=True)
@@ -236,7 +289,11 @@ class TestInflightCoalescing:
                         statuses.append("error")
         elapsed = time.monotonic() - t0
 
-        assert post_count[0] == 4
+        # Between 2 and 4 fetches: normally all four threads fetch, but a worker
+        # scheduled late enough may legitimately hit the cache a successful
+        # waiter populated. The timing bound is the serialization check: four
+        # serialized 0.25s fetches would take >= 1.0s.
+        assert 2 <= post_count[0] <= 4
         assert sorted(statuses) == ["error", "ok", "ok", "ok"]
         assert elapsed < 3 * fetch_seconds + 0.1, f"waiters serialized after leader failure ({elapsed:.2f}s)"
         assert api._inflight_requests == {}

--- a/tests/test_request_cache.py
+++ b/tests/test_request_cache.py
@@ -201,6 +201,46 @@ class TestInflightCoalescing:
         assert payloads == [real_feature_payload]
         assert api._inflight_requests == {}
 
+    def test_waiters_fail_in_parallel_after_leader_failure(self, tmp_path, real_feature_payload):
+        """After a failed fetch, queued duplicates fetch independently in
+        parallel (legacy behaviour) rather than serializing behind the per-key
+        lock — serialized, four 0.25s fetches would take >= 1.0s; the leader
+        plus three parallel waiters take ~0.5s."""
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        post_count = [0]
+        count_lock = threading.Lock()
+        fetch_seconds = 0.25
+
+        def fake_post(self, url, *args, **kwargs):
+            with count_lock:
+                post_count[0] += 1
+                calls = post_count[0]
+            time.sleep(fetch_seconds)
+            if calls == 1:
+                return _CannedResponse(404, {"message": "not found"})
+            return _CannedResponse(200, real_feature_payload)
+
+        aoi = _square(-111.926, 33.414)
+        statuses = []
+        t0 = time.monotonic()
+        with patch("requests.Session.post", new=fake_post):
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [
+                    pool.submit(api._get_results, geometry=aoi, region="us", packs=["building"]) for _ in range(4)
+                ]
+                for f in futures:
+                    try:
+                        f.result()
+                        statuses.append("ok")
+                    except AIFeatureAPIError:
+                        statuses.append("error")
+        elapsed = time.monotonic() - t0
+
+        assert post_count[0] == 4
+        assert sorted(statuses) == ["error", "ok", "ok", "ok"]
+        assert elapsed < 3 * fetch_seconds + 0.1, f"waiters serialized after leader failure ({elapsed:.2f}s)"
+        assert api._inflight_requests == {}
+
 
 class TestTolerantCacheWrite:
     """Cache writes are best-effort: an externally-deleted cache dir must not fail the AOI."""

--- a/tests/test_request_cache.py
+++ b/tests/test_request_cache.py
@@ -1,0 +1,237 @@
+"""Tests for the per-request cache hot paths: orjson round-trip, in-flight
+coalescing of duplicate requests, and tolerant cache writes.
+
+These run without API_KEY by patching ``requests.Session.post`` to return
+canned responses built from the real cached Feature API payload in
+``tests/data/test_defensible_space_raw_payload.json`` — no synthetic mock
+data (see project memory: real data only).
+"""
+
+import gzip
+import json
+import logging
+import shutil
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from shapely.geometry import Polygon
+
+from nmaipy import storage
+from nmaipy.api_common import AIFeatureAPIError
+from nmaipy.feature_api import FeatureApi
+
+
+@pytest.fixture(scope="module")
+def real_feature_payload() -> dict:
+    path = Path(__file__).parent / "data" / "test_defensible_space_raw_payload.json"
+    return json.loads(path.read_text())
+
+
+def _square(lon: float, lat: float, size: float = 0.0005) -> Polygon:
+    return Polygon(
+        [
+            (lon, lat),
+            (lon + size, lat),
+            (lon + size, lat + size),
+            (lon, lat + size),
+            (lon, lat),
+        ]
+    )
+
+
+class _CannedResponse:
+    """Minimal stand-in for requests.Response used by FeatureApi._fetch_results."""
+
+    def __init__(self, status_code: int, body: dict):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.history = []
+        self.text = json.dumps(body)
+        self.content = self.text.encode("utf-8")
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+class TestCacheRoundTrip:
+    """orjson-serialized cache entries must read back identical to the payload."""
+
+    @pytest.mark.parametrize("compress", [False, True])
+    def test_write_to_cache_round_trip(self, tmp_path, real_feature_payload, compress):
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=compress)
+        ext = "json.gz" if compress else "json"
+        cache_path = tmp_path / "151" / "-33" / f"roundtrip.{ext}"
+
+        api._write_to_cache(cache_path, real_feature_payload)
+
+        assert cache_path.exists()
+        result = storage.read_json(str(cache_path), compressed=compress)
+        assert result == real_feature_payload
+
+    def test_read_cached_response_returns_none_for_corrupt_entry(self, tmp_path):
+        """A truncated/corrupt entry is a miss (logged), never an exception."""
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        cache_path = tmp_path / "corrupt.json.gz"
+        cache_path.write_bytes(b"not gzip at all")
+
+        assert api._read_cached_response(str(cache_path)) is None
+
+    def test_read_cached_response_returns_none_for_legacy_nan_entry(self, tmp_path):
+        """stdlib json wrote non-standard NaN literals, which orjson rejects.
+
+        Such legacy entries must degrade to a cache miss (refetch and rewrite),
+        not an exception.
+        """
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        cache_path = tmp_path / "legacy_nan.json.gz"
+        legacy = json.dumps({"features": [], "score": float("nan")})  # emits NaN literal
+        cache_path.write_bytes(gzip.compress(legacy.encode("utf-8")))
+
+        assert api._read_cached_response(str(cache_path)) is None
+
+
+class TestInflightCoalescing:
+    """Concurrent byte-identical requests must result in exactly one API fetch."""
+
+    N_THREADS = 8
+
+    def _run_concurrent(self, api, geometries):
+        with ThreadPoolExecutor(max_workers=len(geometries)) as pool:
+            futures = [pool.submit(api._get_results, geometry=g, region="us", packs=["building"]) for g in geometries]
+            return [f.result() for f in futures]
+
+    def test_duplicate_requests_fetch_once(self, tmp_path, real_feature_payload):
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        post_count = [0]
+        count_lock = threading.Lock()
+
+        def fake_post(self, url, *args, **kwargs):
+            with count_lock:
+                post_count[0] += 1
+            time.sleep(0.2)  # hold the fetch in flight so duplicates pile up
+            return _CannedResponse(200, real_feature_payload)
+
+        aoi = _square(-111.926, 33.414)
+        with patch("requests.Session.post", new=fake_post):
+            results = self._run_concurrent(api, [aoi] * self.N_THREADS)
+
+        assert post_count[0] == 1
+        assert api._cache_misses == 1
+        assert api._cache_hits == self.N_THREADS - 1
+        assert all(r == real_feature_payload for r in results)
+        assert api._inflight_requests == {}, "lock map must drain when requests complete"
+
+    def test_distinct_requests_do_not_coalesce(self, tmp_path, real_feature_payload):
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        post_count = [0]
+        count_lock = threading.Lock()
+
+        def fake_post(self, url, *args, **kwargs):
+            with count_lock:
+                post_count[0] += 1
+            time.sleep(0.2)
+            return _CannedResponse(200, real_feature_payload)
+
+        geometries = [_square(-111.926, 33.414), _square(-111.936, 33.424)]
+        with patch("requests.Session.post", new=fake_post):
+            self._run_concurrent(api, geometries)
+
+        assert post_count[0] == 2
+        assert api._cache_misses == 2
+        assert api._cache_hits == 0
+        assert api._inflight_requests == {}
+
+    def test_overwrite_cache_mode_does_not_coalesce(self, tmp_path, real_feature_payload):
+        """Overwrite mode must refetch every request by design."""
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True, overwrite_cache=True)
+        post_count = [0]
+        count_lock = threading.Lock()
+
+        def fake_post(self, url, *args, **kwargs):
+            with count_lock:
+                post_count[0] += 1
+            time.sleep(0.1)
+            return _CannedResponse(200, real_feature_payload)
+
+        aoi = _square(-111.926, 33.414)
+        with patch("requests.Session.post", new=fake_post):
+            self._run_concurrent(api, [aoi] * 4)
+
+        assert post_count[0] == 4
+        assert api._cache_misses == 4
+        assert api._cache_hits == 0
+
+    def test_failed_fetch_does_not_poison_the_key(self, tmp_path, real_feature_payload):
+        """If the first fetch errors, a waiter proceeds with its own fetch."""
+        api = FeatureApi(api_key="dummy", cache_dir=tmp_path, compress_cache=True)
+        post_count = [0]
+        count_lock = threading.Lock()
+
+        def fake_post(self, url, *args, **kwargs):
+            with count_lock:
+                post_count[0] += 1
+                calls = post_count[0]
+            time.sleep(0.2)
+            if calls == 1:
+                return _CannedResponse(404, {"message": "not found"})
+            return _CannedResponse(200, real_feature_payload)
+
+        aoi = _square(-111.926, 33.414)
+        outcomes = []
+        with patch("requests.Session.post", new=fake_post):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(api._get_results, geometry=aoi, region="us", packs=["building"]) for _ in range(2)
+                ]
+                for f in futures:
+                    try:
+                        outcomes.append(("ok", f.result()))
+                    except AIFeatureAPIError:
+                        outcomes.append(("error", None))
+
+        assert post_count[0] == 2
+        statuses = sorted(status for status, _ in outcomes)
+        assert statuses == ["error", "ok"]
+        payloads = [payload for status, payload in outcomes if status == "ok"]
+        assert payloads == [real_feature_payload]
+        assert api._inflight_requests == {}
+
+
+class TestTolerantCacheWrite:
+    """Cache writes are best-effort: an externally-deleted cache dir must not fail the AOI."""
+
+    def test_write_recreates_externally_deleted_cache_dir(self, tmp_path, real_feature_payload):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        api = FeatureApi(api_key="dummy", cache_dir=cache_dir, compress_cache=True)
+        cache_path = cache_dir / "151" / "-33" / "entry.json.gz"
+
+        shutil.rmtree(cache_dir)  # external actor deletes the whole cache tree mid-run
+        api._write_to_cache(cache_path, real_feature_payload)
+
+        assert cache_path.exists()
+        assert storage.read_json(str(cache_path), compressed=True) == real_feature_payload
+
+    def test_unwritable_cache_path_warns_and_skips(self, tmp_path, real_feature_payload, caplog):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        api = FeatureApi(api_key="dummy", cache_dir=cache_dir, compress_cache=True)
+        (cache_dir / "blocker").write_text("a file where a directory must go")
+        cache_path = cache_dir / "blocker" / "entry.json.gz"
+
+        # The nmaipy logger has propagate=False, so attach caplog's handler directly.
+        nmaipy_logger = logging.getLogger("nmaipy")
+        nmaipy_logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.WARNING, logger="nmaipy"):
+                api._write_to_cache(cache_path, real_feature_payload)  # must not raise
+        finally:
+            nmaipy_logger.removeHandler(caplog.handler)
+
+        assert not cache_path.exists()
+        assert any("Failed to write cache entry" in r.message for r in caplog.records)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
+import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
@@ -355,6 +356,40 @@ class TestJsonIO:
         storage.write_json(fpath, data, compressed=True, default=str)
         result = storage.read_json(fpath, compressed=True)
         assert result["path"] == str(Path("/tmp/test"))
+
+
+class TestJsonDumpsBytes:
+    """orjson compat shim: must keep the semantics stdlib json.dumps provided."""
+
+    def test_returns_bytes(self):
+        assert isinstance(storage.json_dumps_bytes({"a": 1}), bytes)
+
+    def test_non_str_keys_stringified_like_stdlib(self):
+        data = {1: "a", 2.5: "b"}
+        assert json.loads(storage.json_dumps_bytes(data)) == json.loads(json.dumps(data))
+
+    def test_numpy_scalars_serialize_as_numbers(self):
+        data = {"f": np.float64(0.95), "i": np.int64(7), "b": np.bool_(True)}
+        assert json.loads(storage.json_dumps_bytes(data)) == {"f": 0.95, "i": 7, "b": True}
+
+    def test_indent_two_supported(self):
+        assert b"\n" in storage.json_dumps_bytes({"a": 1}, indent=2)
+
+    def test_other_indent_rejected(self):
+        with pytest.raises(ValueError, match="indent"):
+            storage.json_dumps_bytes({"a": 1}, indent=4)
+
+    def test_nan_serializes_as_null(self):
+        """orjson emits null for NaN; stdlib emitted the non-standard NaN literal."""
+        assert json.loads(storage.json_dumps_bytes({"x": float("nan")})) == {"x": None}
+
+    def test_read_json_rejects_legacy_nan_literal(self, tmp_path):
+        """orjson-backed read_json is strict RFC 8259: stdlib-era entries holding
+        a NaN literal now fail to parse (callers treat that as a cache miss)."""
+        fpath = tmp_path / "legacy.json"
+        fpath.write_text(json.dumps({"x": float("nan")}))  # writes {"x": NaN}
+        with pytest.raises(ValueError):
+            storage.read_json(str(fpath))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Production measurement of the per-request cache on national-scale address exports (~3–4M AOIs, all packs + includes, parcelMode, prefer3d, compress_cache) surfaced three improvements, implemented here in priority order.

### P1 — orjson on the parse/serialize hot paths
Cache hits are parse-bound, not I/O-bound (measured on NVMe: a 37.6MB entry = 5ms read + 180ms gunzip + **763ms json.loads**; parse is 75–80% of hit cost and GIL-serialized, capping replay at ~2 AOIs/s/process). orjson is 5–10× faster on exactly those payloads:

- `storage.read_json` parses with orjson (cache-hit hot path, all clients)
- `storage.write_json` / new `storage.json_dumps_bytes` serialize with orjson (`OPT_NON_STR_KEYS` + `OPT_SERIALIZE_NUMPY` preserve stdlib semantics; `indent` restricted to `None`/`2` — the only values used)
- `FeatureApi` parses live responses via `orjson.loads(response.content)`
- **Cache keys deliberately stay on stdlib `json.dumps`** — its separators are baked into every existing entry's md5, so switching would invalidate warm production caches

### P2 — per-key in-flight coalescing
33.5% of production requests are byte-identical geometry (strata units share one polygon; worst parcel: 1,287 identical requests), adjacent in input order — so they enter flight together and all miss the cold cache. `BaseApiClient._coalesce_inflight` adds a bounded per-cache-path lock map: the first requester fetches and writes the cache; duplicates wait, then read the entry it wrote (double-checked read under the lock, for entry creators too). Converts the duplicate fraction to cache hits from run start instead of after a ~12h warmup.

Failure safety: if the in-flight fetch raises or produces no cache entry (e.g. skipped best-effort write), a `fetch_failed` flag makes waiters fetch independently **outside** the lock — legacy parallel behaviour, never K× serialized timeouts. Worst case on a failing key is therefore ~2× the legacy latency (the leader's full timeout, then the parallel waiter burst), not K×. Gridding only ever runs after the size error unwinds out of the lock, so no lock-ordering hazard.

### P3 — operational items
- Progress bar shows cumulative cache hit rate (e.g. `P50=245ms | Cache 69%`), fed from per-chunk stats, and each exporter logs an export-wide summary at closeout (`Request cache: 65/65 requests served without an API call (100.0%)`). **What the number measures:** requests served without reaching the API — pre-existing cache entries *plus* duplicates coalesced onto an in-flight fetch. On a cold cache dir with duplicate-heavy address data it can legitimately read well above 0% from the first chunk.
- Fully-cached chunks now report a zeroed-latency stats row (count=0) instead of `None`, so warm runs keep their `cache_hits`/`cache_misses` in the latency sidecars and the display (count=0 rows are excluded from the bootstrap CIs).
- `FeatureApi._write_to_cache` is best-effort: an externally-deleted cache tree used to fail the AOI with an ERROR each; now one retry re-creates the directory, persistent failures skip caching with a rate-limited warning (first 3, then every 1000th).

## Behaviour notes
- Coalesced duplicates count as cache hits (they are served from the just-written entry) — matches the production evidence framing of "in-run hit rate".
- orjson is strict RFC 8259: legacy cache entries containing stdlib's non-standard `NaN` literal degrade to a cache miss (refetch + rewrite, logged); a live 200 response that fails to parse logs at WARNING with the payload size before triggering gridding. A scan of 4,000 real cache entries found zero NaN/Infinity literals.
- `classes_availability.json` value types change: numpy ints/bools now serialize as JSON numbers/booleans (previously stringified via `default=str`), and NaN becomes `null` (previously an invalid bare `NaN` literal). Schema improvement, but customer-visible.
- New runtime dependency: `orjson>=3.9` (pyproject + environment.yaml).

## Validation
- 850 offline tests pass; new suites cover the orjson round-trip on a real 1.5MB payload, coalescing (fetch-once, no false sharing, overwrite-mode bypass, parallel failure fallback, creator re-probe race, lock-map drain), tolerant cache writes, and count=0 stats rows.
- Two independent adversarial review passes (concurrency protocol audit + 480-request/45%-injected-failure stress holding all invariants: map drained, hit+miss == requests, payloads byte-identical, no deadlock); all findings fixed or consciously documented here.
- Live E2E (65 AOIs, 20 unique geometries, duplicates adjacent): cold run = 20 fetches + 45 coalesced hits, `Cache 69%` displayed; warm re-run = 65 hits / 0 fetches, `Cache 100%`, rollup byte-identical to cold.

Deferred (per the request): the structural fix — fetch once per distinct geometry and fan rollups out to all rows locally — is a separate ticket; P2 approximates it cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)