### PR TITLE
Fix consolidation slowness at national scale: bounded row groups + shared filesystem for chunk reads

### DIFF
--- a/nmaipy/api_common.py
+++ b/nmaipy/api_common.py
@@ -1608,8 +1608,11 @@ def combine_chunk_latency_stats(chunk_path: Path, output_csv_path: Path) -> List
         return []
 
     def _read_one(path):
+        # Open via storage.open_file so S3 reads share the per-process fsspec
+        # filesystem instead of constructing a fresh one per bare-URI read.
         try:
-            return pd.read_parquet(path)
+            with storage.open_file(path, "rb") as f:
+                return pd.read_parquet(f)
         except Exception:
             return None
 

--- a/nmaipy/base_exporter.py
+++ b/nmaipy/base_exporter.py
@@ -383,7 +383,12 @@ class BaseExporter(ABC):
             f = storage.join_path(self.chunk_path, f"{prefix}_{chunk_id}.parquet")
             if storage.file_exists(f):
                 try:
-                    parts.append(reader(f))
+                    # Open via storage.open_file so S3 reads share the
+                    # per-process fsspec filesystem; a bare-URI read constructs
+                    # a fresh S3 filesystem per file — a fixed per-file cost
+                    # this serial loop pays with no concurrency to mask it.
+                    with storage.open_file(f, "rb") as fh:
+                        parts.append(reader(fh))
                 except Exception as e:
                     self.logger.warning(f"Chunk {chunk_id}: failed to read {prefix} file {f}: {e}. Skipping.")
         if not parts:

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -283,6 +283,17 @@ AREA_CRS = {
 }
 API_CRS = "EPSG:4326"
 
+# Max rows per row group when streaming the combined features.parquet. The table
+# is sorted by class_id first, so row-group min/max statistics stay class-clustered
+# and filtered reads still skip the vast majority of groups. An explicit cap keeps
+# group count (and the footer) bounded: one group per class_id *run* — the previous
+# scheme — produced ~110 groups per chunk (169k groups / a 1.6GB footer on a
+# 1,544-chunk national export), which made every row-group-granular reader
+# pathologically slow: pyarrow's iter_batches over S3 pays one serial range-GET per
+# group, and every open of the file parses the full footer. 65,536 rows ≈ 60MB per
+# group on an all-packs export.
+FEATURES_ROW_GROUP_SIZE = 65_536
+
 IMPERIAL_COUNTRIES = ["us"]
 
 

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -178,16 +178,16 @@ def _read_parquet_chunks_parallel(
         # Open via storage.open_file so S3 reads share the per-process fsspec
         # filesystem; a bare-URI gpd/pd.read_parquet constructs a fresh pyarrow
         # S3FileSystem per call — a fixed per-file cost that dominates when
-        # reading thousands of small chunk files.
-        if geo:
-            try:
-                with storage.open_file(path, "rb") as f:
+        # reading thousands of small chunk files. One open serves both the geo
+        # attempt and the plain fallback (seek(0) instead of a second download).
+        with storage.open_file(path, "rb") as f:
+            if geo:
+                try:
                     df = gpd.read_parquet(f)
-            except Exception:
-                with storage.open_file(path, "rb") as f:
+                except Exception:
+                    f.seek(0)
                     df = pd.read_parquet(f)
-        else:
-            with storage.open_file(path, "rb") as f:
+            else:
                 df = pd.read_parquet(f)
         if len(df) > 0:
             return df

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -88,6 +88,7 @@ from nmaipy.constants import (
     FEATURE_CLASS_DESCRIPTIONS,
     FEATURE_PREFETCH_FLOOR,
     FEATURE_PREFETCH_MULTIPLIER,
+    FEATURES_ROW_GROUP_SIZE,
     GRID_SIZE_DEGREES,
     IMPERIAL_COUNTRIES,
     LAT_PRIMARY_COL_NAME,
@@ -3240,23 +3241,16 @@ class NearmapAIExporter(BaseExporter):
                                     f"{', '.join(type_warnings)}"
                                 )
                             schema_promotion_count += 1
-                    # Write one row group per class_id so pyarrow's predicate
-                    # pushdown can skip non-matching row groups during filtered reads.
-                    # Uses zero-copy table.slice() on the sorted table instead of
-                    # per-class filter() to avoid N full-table scans and row copies.
+                    # Sort by class_id so row-group min/max statistics stay
+                    # class-clustered (filtered reads skip non-matching groups),
+                    # but cap rows per group explicitly. One group per class_id
+                    # run — the previous scheme — produced ~110 tiny groups per
+                    # chunk (169k groups / a 1.6GB footer at 1,544 chunks), which
+                    # made every row-group-granular reader pathologically slow;
+                    # a per-group scan over S3 pays one serial range-GET per group.
                     if "class_id" in table.column_names:
                         table = table.sort_by("class_id")
-                        n = table.num_rows
-                        if n > 0:
-                            class_vals = table.column("class_id").to_pylist()
-                            run_start = 0
-                            for j in range(1, n):
-                                if class_vals[j] != class_vals[run_start]:
-                                    pqwriter.write_table(table.slice(run_start, j - run_start))
-                                    run_start = j
-                            pqwriter.write_table(table.slice(run_start, n - run_start))
-                    else:
-                        pqwriter.write_table(table)
+                    pqwriter.write_table(table, row_group_size=FEATURES_ROW_GROUP_SIZE)
 
         finally:
             # Cancel queued futures and wait for running ones to finish,

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -175,13 +175,20 @@ def _read_parquet_chunks_parallel(
         return []
 
     def _read_one(path: str):
+        # Open via storage.open_file so S3 reads share the per-process fsspec
+        # filesystem; a bare-URI gpd/pd.read_parquet constructs a fresh pyarrow
+        # S3FileSystem per call — a fixed per-file cost that dominates when
+        # reading thousands of small chunk files.
         if geo:
             try:
-                df = gpd.read_parquet(path)
+                with storage.open_file(path, "rb") as f:
+                    df = gpd.read_parquet(f)
             except Exception:
-                df = pd.read_parquet(path)
+                with storage.open_file(path, "rb") as f:
+                    df = pd.read_parquet(f)
         else:
-            df = pd.read_parquet(path)
+            with storage.open_file(path, "rb") as f:
+                df = pd.read_parquet(f)
         if len(df) > 0:
             return df
         return None
@@ -814,12 +821,17 @@ def _stream_merge_chunks_to_parquet(
     if total == 0:
         return 0
 
+    # One shared filesystem for every schema/data read (see pyarrow_read_paths);
+    # bare-URI pq.read_*() would construct a fresh S3 filesystem per file.
+    # Original chunk_paths are kept for log messages.
+    read_paths, read_fs = storage.pyarrow_read_paths(list(chunk_paths))
+
     # Pass 1 — derive the unified target schema from footers only (no row data).
     # Positional collection preserves chunk_paths order regardless of completion
     # order, so the resulting column order is deterministic.
     schemas = [None] * total
     with ThreadPoolExecutor(max_workers=scan_workers) as scan_executor:
-        futures = {scan_executor.submit(pq.read_schema, chunk_paths[i]): i for i in range(total)}
+        futures = {scan_executor.submit(pq.read_schema, read_paths[i], filesystem=read_fs): i for i in range(total)}
         for future in as_completed(futures):
             idx = futures[future]
             try:
@@ -828,6 +840,7 @@ def _stream_merge_chunks_to_parquet(
                 logger.error(f"Failed to read schema from {chunk_paths[idx]}: {e}")
 
     valid_paths = [chunk_paths[i] for i, s in enumerate(schemas) if s is not None]
+    valid_read_paths = [read_paths[i] for i, s in enumerate(schemas) if s is not None]
     valid_schemas = [s for s in schemas if s is not None]
     if not valid_schemas:
         logger.error("All chunk schemas failed to read — cannot merge")
@@ -861,7 +874,7 @@ def _stream_merge_chunks_to_parquet(
     prefetch_futures = {}
     initial_submit = min(prefetch_workers, n)
     for idx in range(initial_submit):
-        prefetch_futures[idx] = executor.submit(pq.read_table, valid_paths[idx])
+        prefetch_futures[idx] = executor.submit(pq.read_table, valid_read_paths[idx], filesystem=read_fs)
     next_submit_idx = initial_submit
 
     try:
@@ -872,7 +885,9 @@ def _stream_merge_chunks_to_parquet(
             # is always in flight (read-ahead), keeping the resident count at the
             # prefetch_workers cap.
             if next_submit_idx < n:
-                prefetch_futures[next_submit_idx] = executor.submit(pq.read_table, valid_paths[next_submit_idx])
+                prefetch_futures[next_submit_idx] = executor.submit(
+                    pq.read_table, valid_read_paths[next_submit_idx], filesystem=read_fs
+                )
                 next_submit_idx += 1
             if pbar is not None:
                 pbar.update(1)
@@ -3058,9 +3073,13 @@ class NearmapAIExporter(BaseExporter):
         # resilience of the streaming loop, which also skips bad chunks.
         self.logger.info(f"Scanning schemas from {total} chunk files...")
         scan_workers = S3_PARALLEL_READ_WORKERS if self.is_s3_output else PARALLEL_READ_WORKERS
+        # One shared filesystem for every schema/data read in this method (see
+        # pyarrow_read_paths); bare-URI pq.read_*() constructs a fresh S3
+        # filesystem per file. feature_paths are kept for log messages.
+        read_paths, read_fs = storage.pyarrow_read_paths(list(feature_paths))
         chunk_schemas = [None] * total
         with ThreadPoolExecutor(max_workers=scan_workers) as scan_executor:
-            futures = {scan_executor.submit(pq.read_schema, feature_paths[i]): i for i in range(total)}
+            futures = {scan_executor.submit(pq.read_schema, read_paths[i], filesystem=read_fs): i for i in range(total)}
             for future in as_completed(futures):
                 idx = futures[future]
                 try:
@@ -3110,7 +3129,7 @@ class NearmapAIExporter(BaseExporter):
         initial_submit = min(prefetch_workers, total)
         for idx in range(initial_submit):
             if idx in valid_indices:
-                prefetch_futures[idx] = executor.submit(pq.read_table, feature_paths[idx])
+                prefetch_futures[idx] = executor.submit(pq.read_table, read_paths[idx], filesystem=read_fs)
         next_submit_idx = initial_submit
 
         try:
@@ -3134,7 +3153,7 @@ class NearmapAIExporter(BaseExporter):
                     if next_submit_idx < total:
                         if next_submit_idx in valid_indices:
                             prefetch_futures[next_submit_idx] = executor.submit(
-                                pq.read_table, feature_paths[next_submit_idx]
+                                pq.read_table, read_paths[next_submit_idx], filesystem=read_fs
                             )
                         next_submit_idx += 1
                     continue
@@ -3148,7 +3167,7 @@ class NearmapAIExporter(BaseExporter):
                     if next_submit_idx < total:
                         if next_submit_idx in valid_indices:
                             prefetch_futures[next_submit_idx] = executor.submit(
-                                pq.read_table, feature_paths[next_submit_idx]
+                                pq.read_table, read_paths[next_submit_idx], filesystem=read_fs
                             )
                         next_submit_idx += 1
                     continue
@@ -3157,7 +3176,7 @@ class NearmapAIExporter(BaseExporter):
                 if next_submit_idx < total:
                     if next_submit_idx in valid_indices:
                         prefetch_futures[next_submit_idx] = executor.submit(
-                            pq.read_table, feature_paths[next_submit_idx]
+                            pq.read_table, read_paths[next_submit_idx], filesystem=read_fs
                         )
                     next_submit_idx += 1
 

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -300,8 +300,9 @@ def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.File
     Fork-safety: pyarrow's native S3 filesystem must not be carried across a
     fork (see ``_get_s3_filesystem`` / ``write_parquet``). This helper is for
     the consolidation read paths, which run in the parent process after the
-    spawn-context worker pool has shut down; do not call it from code that
-    precedes worker spawning.
+    worker pool has shut down. (nmaipy uses a spawn multiprocessing context
+    everywhere, so no fork can inherit the object today — the constraint is
+    defence-in-depth for future callers.)
 
     Args:
         paths: Parquet paths, all sharing one scheme (all s3:// or all local).
@@ -310,7 +311,8 @@ def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.File
         Tuple of (paths_for_pyarrow, filesystem); filesystem is None for local.
 
     Raises:
-        ValueError: If paths mix s3:// and local schemes.
+        ValueError: If paths mix s3:// and local schemes, or the bucket name in
+            the first path cannot be parsed as a URI authority.
     """
     if not paths:
         return [], None
@@ -319,7 +321,13 @@ def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.File
         raise ValueError("pyarrow_read_paths requires all paths to share one scheme (got mixed s3:// and local)")
     if not s3_flags.pop():
         return list(paths), None
-    filesystem, _ = pa_fs.FileSystem.from_uri(paths[0])
+    # Resolve the filesystem from the bucket ROOT, not paths[0] verbatim: a full
+    # key goes through strict URI parsing (percent-decoding, no literal spaces),
+    # which would hold element 0 to a stricter contract than the raw
+    # scheme-stripped keys handed to pyarrow below — the same chunk set could
+    # then pass or fail on sort order alone. Bucket names are URI-safe.
+    bucket = paths[0][len("s3://") :].split("/", 1)[0]
+    filesystem, _ = pa_fs.FileSystem.from_uri(f"s3://{bucket}/")
     return [p[len("s3://") :] for p in paths], filesystem
 
 

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -16,12 +16,13 @@ import os
 import shutil
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import boto3
 import fsspec
 import orjson
 import pyarrow as pa
+import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config as BotoConfig
@@ -279,6 +280,47 @@ def open_file(path: str, mode: str = "r", **kwargs):
         return fs.open(path, mode, **kwargs)
     else:
         return open(path, mode, **kwargs)
+
+
+def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.FileSystem]]:
+    """Resolve same-scheme parquet paths for pyarrow readers sharing ONE filesystem.
+
+    For s3:// URIs, returns scheme-stripped "bucket/key" paths plus a single
+    pyarrow filesystem resolved once via ``FileSystem.from_uri`` — credential
+    resolution and the connection pool are then shared across every
+    ``pq.read_table``/``pq.read_schema`` call. A bare-URI ``pq.read_*(s3://…)``
+    constructs and tears down a fresh S3 filesystem per call, a fixed per-file
+    cost that dominates when scanning thousands of small chunk files
+    (consolidation phases were observed pinned at ~1-3 files/s regardless of
+    file size, at ~0% CPU, under 24-48-way read concurrency).
+
+    For local paths, returns them unchanged with ``filesystem=None`` (pyarrow's
+    default local handling — behaviour identical to today).
+
+    Fork-safety: pyarrow's native S3 filesystem must not be carried across a
+    fork (see ``_get_s3_filesystem`` / ``write_parquet``). This helper is for
+    the consolidation read paths, which run in the parent process after the
+    spawn-context worker pool has shut down; do not call it from code that
+    precedes worker spawning.
+
+    Args:
+        paths: Parquet paths, all sharing one scheme (all s3:// or all local).
+
+    Returns:
+        Tuple of (paths_for_pyarrow, filesystem); filesystem is None for local.
+
+    Raises:
+        ValueError: If paths mix s3:// and local schemes.
+    """
+    if not paths:
+        return [], None
+    s3_flags = {is_s3_path(p) for p in paths}
+    if len(s3_flags) > 1:
+        raise ValueError("pyarrow_read_paths requires all paths to share one scheme (got mixed s3:// and local)")
+    if not s3_flags.pop():
+        return list(paths), None
+    filesystem, _ = pa_fs.FileSystem.from_uri(paths[0])
+    return [p[len("s3://") :] for p in paths], filesystem
 
 
 def file_size(path: str) -> int:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -725,6 +725,84 @@ class TestExporter:
                 lob_field.type == pa.large_string()
             ), f"Expected large_string type for promoted null column, got {lob_field.type}"
 
+    def test_stream_and_convert_features_coalesces_row_groups(self):
+        """Row groups are capped by FEATURES_ROW_GROUP_SIZE, not one per class run.
+
+        The previous writer emitted one row group per class_id run per chunk,
+        which at national scale produced ~110 tiny groups per chunk (169k groups
+        and a 1.6GB footer on a 1,544-chunk export) and made every
+        row-group-granular reader pathologically slow. Now each chunk is written
+        sorted by class_id (so row-group stats stay class-clustered) in groups of
+        at most FEATURES_ROW_GROUP_SIZE rows.
+        """
+        from shapely.geometry import Point
+
+        from nmaipy.constants import FEATURES_ROW_GROUP_SIZE
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            chunk_dir = tmpdir / "chunks"
+            chunk_dir.mkdir()
+
+            # Chunk 1: one row more than the cap, class_ids interleaved so the
+            # old scheme would have produced many groups (one per sorted run).
+            n1 = FEATURES_ROW_GROUP_SIZE + 1
+            class_ids_1 = [f"class_{i % 40:02d}" for i in range(n1)]
+            chunk1 = gpd.GeoDataFrame(
+                {
+                    "feature_id": [f"f{i}" for i in range(n1)],
+                    "class_id": class_ids_1,
+                    "description": ["Test feature"] * n1,
+                    "geometry": [Point(0, 0)] * n1,
+                },
+                crs="EPSG:4326",
+            )
+            chunk1.to_parquet(chunk_dir / "features_test_1.parquet")
+
+            # Chunk 2: small, 30 distinct interleaved class_ids (old scheme: 30
+            # groups; new scheme: 1).
+            n2 = 90
+            chunk2 = gpd.GeoDataFrame(
+                {
+                    "feature_id": [f"g{i}" for i in range(n2)],
+                    "class_id": [f"class_{i % 30:02d}" for i in range(n2)],
+                    "description": ["Test feature"] * n2,
+                    "geometry": [Point(1, 1)] * n2,
+                },
+                crs="EPSG:4326",
+            )
+            chunk2.to_parquet(chunk_dir / "features_test_2.parquet")
+
+            exporter = AOIExporter(
+                output_dir=tmpdir,
+                country="au",
+                packs=["building"],
+                save_features=True,
+            )
+            output_path = tmpdir / "merged_features.parquet"
+            exporter._stream_and_convert_features(
+                [chunk_dir / "features_test_1.parquet", chunk_dir / "features_test_2.parquet"],
+                output_path,
+            )
+
+            meta = pq.read_metadata(output_path)
+            assert meta.num_rows == n1 + n2
+            # Chunk 1 → 2 groups (cap + remainder of 1), chunk 2 → 1 group. The
+            # old per-class-run writer would have produced 40 + 30 = 70.
+            assert meta.num_row_groups == 3, f"Expected 3 coalesced row groups, got {meta.num_row_groups}"
+
+            # Each row group is internally sorted by class_id so min/max stats
+            # stay useful for predicate pushdown on filtered reads.
+            pf = pq.ParquetFile(output_path)
+            for rg in range(meta.num_row_groups):
+                vals = pf.read_row_group(rg, columns=["class_id"]).column("class_id").to_pylist()
+                assert vals == sorted(vals), f"Row group {rg} not sorted by class_id"
+
+            # Still a valid GeoParquet: geo metadata survived the writer change.
+            merged = gpd.read_parquet(output_path)
+            assert merged.crs is not None
+            assert len(merged) == n1 + n2
+
 
 class TestReadParquetChunksParallel:
     """Tests for _read_parquet_chunks_parallel."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -646,3 +646,43 @@ class TestInvalidateCache:
         mock_get_fs.return_value = mock_fs
         storage.invalidate_cache("s3://bucket/dir")
         mock_fs.invalidate_cache.assert_called_once_with("s3://bucket/dir")
+
+
+# ---------------------------------------------------------------------------
+# pyarrow_read_paths
+# ---------------------------------------------------------------------------
+
+
+class TestPyarrowReadPaths:
+    def test_empty_list(self):
+        assert storage.pyarrow_read_paths([]) == ([], None)
+
+    def test_local_paths_pass_through_with_no_filesystem(self):
+        paths = ["/tmp/a.parquet", "/tmp/b.parquet"]
+        out_paths, fs = storage.pyarrow_read_paths(paths)
+        assert out_paths == paths
+        assert out_paths is not paths  # defensive copy, caller list not aliased
+        assert fs is None
+
+    def test_mixed_schemes_raise(self):
+        with pytest.raises(ValueError, match="one scheme"):
+            storage.pyarrow_read_paths(["s3://bucket/a.parquet", "/tmp/b.parquet"])
+
+    def test_s3_paths_stripped_and_single_filesystem(self, monkeypatch):
+        sentinel_fs = object()
+        calls = []
+
+        class _StubFileSystem:
+            @staticmethod
+            def from_uri(uri):
+                calls.append(uri)
+                return sentinel_fs, uri[len("s3://") :]
+
+        monkeypatch.setattr(storage, "pa_fs", type("stub", (), {"FileSystem": _StubFileSystem}))
+        paths = ["s3://bucket/chunks/a.parquet", "s3://bucket/chunks/b.parquet"]
+        out_paths, fs = storage.pyarrow_read_paths(paths)
+
+        assert out_paths == ["bucket/chunks/a.parquet", "bucket/chunks/b.parquet"]
+        assert fs is sentinel_fs
+        # The filesystem is resolved exactly once, from the first path.
+        assert calls == ["s3://bucket/chunks/a.parquet"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -684,5 +684,30 @@ class TestPyarrowReadPaths:
 
         assert out_paths == ["bucket/chunks/a.parquet", "bucket/chunks/b.parquet"]
         assert fs is sentinel_fs
-        # The filesystem is resolved exactly once, from the first path.
-        assert calls == ["s3://bucket/chunks/a.parquet"]
+        # The filesystem is resolved exactly once, from the BUCKET ROOT — not
+        # paths[0] verbatim. Resolving from a full key would percent-decode it
+        # and reject legal-but-unusual key characters, holding element 0 to a
+        # stricter contract than the raw-stripped keys handed to pyarrow.
+        assert calls == ["s3://bucket/"]
+
+    def test_s3_key_with_literal_space_does_not_break_resolution(self, monkeypatch):
+        # Literal spaces are legal in S3 keys but illegal in URIs. Only the
+        # bucket name reaches the URI parser; keys are passed through raw.
+        sentinel_fs = object()
+        calls = []
+
+        class _StubFileSystem:
+            @staticmethod
+            def from_uri(uri):
+                calls.append(uri)
+                if " " in uri:
+                    raise ValueError(f"Cannot parse URI: {uri}")
+                return sentinel_fs, uri[len("s3://") :]
+
+        monkeypatch.setattr(storage, "pa_fs", type("stub", (), {"FileSystem": _StubFileSystem}))
+        paths = ["s3://bucket/My Project/chunks/a.parquet", "s3://bucket/My Project/chunks/b.parquet"]
+        out_paths, fs = storage.pyarrow_read_paths(paths)
+
+        assert out_paths == ["bucket/My Project/chunks/a.parquet", "bucket/My Project/chunks/b.parquet"]
+        assert fs is sentinel_fs
+        assert calls == ["s3://bucket/"]


### PR DESCRIPTION
Two related fixes for post-API consolidation performance on large exports, found while debugging a national-scale all-packs export (1,544 chunks, 296M feature rows, 268GB combined features.parquet) whose close-out phases ran for hours at ~0% CPU.

## 1. Cap combined features.parquet row groups (was: one per class run)

The streaming writer sorted each chunk by class_id and wrote one row group per class run to enable predicate pushdown. At scale this produced **169,118 row groups (median 133 rows) and a 1.6GB footer**. Every row-group-granular reader pays for that: a single-column scan via `ParquetFile.iter_batches` over S3 issues one serial range-GET per group (observed 8+ hours to read ~30MB of column data), and every open of the file parses the full footer. The per-class filtered reads that motivated the layout were removed when per-class outputs moved to chunk-file merges — nothing in nmaipy consumes it.

Now: keep the class_id sort (row-group min/max stats stay class-clustered, so filtered readers still skip non-matching groups) but cut groups at `FEATURES_ROW_GROUP_SIZE = 65,536` rows → ~60MB groups, ~6k groups and a ~60MB footer at the same scale. **Same rows, same order, same schema and GeoParquet metadata — only parquet internals change.** Safe for resumes: per-chunk cache files are untouched, and the combined file is always rebuilt whole from chunks.

**Disclosed trade-off:** an external consumer doing a class_id-filtered read of the delivered file touches the same *number* of row groups per chunk as before, but each group is now up to ~500x larger, so such reads decode more bytes. Nothing in nmaipy performs filtered reads; whole-file and column scans (the dominant access patterns we see) get dramatically faster, and any footer-parsing open drops from ~minutes to ~seconds.

## 2. Share one filesystem across consolidation chunk reads

Every consolidation phase read its chunk files with bare `s3://` URIs — `pq.read_schema`/`pq.read_table` in the two streaming mergers, `gpd/pd.read_parquet` in the rollup, error-file, latency, and simple-chunk (roof-age / damage-conflation) readers. Each call constructs and tears down its own S3 filesystem — including a `ResolveS3BucketRegion` HTTP round trip — per file. Phases sat pinned at ~1–3 files/s at ~0% CPU under 24–48-way read concurrency, regardless of file size.

- New `storage.pyarrow_read_paths()` resolves ONE filesystem from the **bucket root** (keys never reach the URI parser — legal-but-unusual key characters can't fail, and all N paths are treated symmetrically), returning scheme-stripped paths + the shared filesystem (local paths pass through with `filesystem=None`). Used for schema scans and data prefetch in both streaming mergers.
- Pandas-family readers (`_read_parquet_chunks_parallel`, `combine_chunk_latency_stats`, `_consolidate_simple_chunks`) open chunks via `storage.open_file()`, reusing the per-process fsspec filesystem. The geo→plain fallback now reuses a single open handle via `seek(0)` instead of a second download.

Read-side only: same files, same order, same per-file error semantics. Fork-safety: these paths run in the parent after the worker pool has shut down (nmaipy uses a spawn context everywhere; the constraint documented on the helper is defence-in-depth).

**Note:** throughput at production concurrency (one shared filesystem serving 24–48 reader threads) is expected to far exceed the ~1–3 files/s baseline but hasn't been measured yet — the next large export will confirm.

## Tests

- Row-group coalescing (group count, per-group class_id sort, GeoParquet metadata intact), `pyarrow_read_paths` units (local pass-through, scheme stripping, bucket-root resolution, literal-space keys, mixed-scheme rejection).
- Full offline suite: 917 passed, 12 skipped. Black clean.

Version not bumped here — assuming the usual release flow bumps to 5.1.7 at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)