### PR TITLE
Release version 5.1.7

### DIFF
--- a/nmaipy/__version__.py
+++ b/nmaipy/__version__.py
@@ -1,6 +1,6 @@
 """Version information for nmaipy."""
 
-__version__ = "5.1.6"
+__version__ = "5.1.7"
 __version_info__ = tuple(
     int(i) for i in __version__.replace("a", ".").replace("b", ".").replace("rc", ".").split(".")[:3]
 )

--- a/nmaipy/constants.py
+++ b/nmaipy/constants.py
@@ -284,14 +284,16 @@ AREA_CRS = {
 API_CRS = "EPSG:4326"
 
 # Max rows per row group when streaming the combined features.parquet. The table
-# is sorted by class_id first, so row-group min/max statistics stay class-clustered
-# and filtered reads still skip the vast majority of groups. An explicit cap keeps
-# group count (and the footer) bounded: one group per class_id *run* — the previous
-# scheme — produced ~110 groups per chunk (169k groups / a 1.6GB footer on a
-# 1,544-chunk national export), which made every row-group-granular reader
-# pathologically slow: pyarrow's iter_batches over S3 pays one serial range-GET per
-# group, and every open of the file parses the full footer. 65,536 rows ≈ 60MB per
-# group on an all-packs export.
+# is still sorted by class_id per chunk, which keeps class values contiguous for
+# dictionary/RLE compression and gives class pushdown only when a chunk exceeds
+# this cap (a typical chunk fits in one group, whose min/max statistics then span
+# every class in the chunk — class-filtered readers scan those groups in full).
+# The explicit cap keeps group count (and the footer) bounded: one group per
+# class_id *run* — the previous scheme — produced ~110 groups per chunk (169k
+# groups / a 1.6GB footer on a 1,544-chunk national export), which made every
+# row-group-granular reader pathologically slow: pyarrow's iter_batches over S3
+# pays one serial range-GET per group, and every open of the file parses the full
+# footer. 65,536 rows ≈ 60MB per group on an all-packs export.
 FEATURES_ROW_GROUP_SIZE = 65_536
 
 IMPERIAL_COUNTRIES = ["us"]

--- a/nmaipy/exporter.py
+++ b/nmaipy/exporter.py
@@ -176,7 +176,7 @@ def _read_parquet_chunks_parallel(
 
     def _read_one(path: str):
         # Open via storage.open_file so S3 reads share the per-process fsspec
-        # filesystem; a bare-URI gpd/pd.read_parquet constructs a fresh pyarrow
+        # filesystem; a bare-URI gpd.read_parquet constructs a fresh pyarrow
         # S3FileSystem per call — a fixed per-file cost that dominates when
         # reading thousands of small chunk files. One open serves both the geo
         # attempt and the plain fallback (seek(0) instead of a second download).
@@ -3260,13 +3260,15 @@ class NearmapAIExporter(BaseExporter):
                                     f"{', '.join(type_warnings)}"
                                 )
                             schema_promotion_count += 1
-                    # Sort by class_id so row-group min/max statistics stay
-                    # class-clustered (filtered reads skip non-matching groups),
-                    # but cap rows per group explicitly. One group per class_id
-                    # run — the previous scheme — produced ~110 tiny groups per
-                    # chunk (169k groups / a 1.6GB footer at 1,544 chunks), which
-                    # made every row-group-granular reader pathologically slow;
-                    # a per-group scan over S3 pays one serial range-GET per group.
+                    # Sort by class_id for compression locality (contiguous class
+                    # values dictionary/RLE-encode well) and for class pushdown in
+                    # the oversized-chunk case, but cap rows per group explicitly —
+                    # a chunk under the cap lands in one group whose statistics span
+                    # all its classes. One group per class_id run — the previous
+                    # scheme — produced ~110 tiny groups per chunk (169k groups /
+                    # a 1.6GB footer at 1,544 chunks), which made every
+                    # row-group-granular reader pathologically slow; a per-group
+                    # scan over S3 pays one serial range-GET per group.
                     if "class_id" in table.column_names:
                         table = table.sort_by("class_id")
                     pqwriter.write_table(table, row_group_size=FEATURES_ROW_GROUP_SIZE)
@@ -4420,8 +4422,8 @@ class NearmapAIExporter(BaseExporter):
         # falling back to the output dir (mirrors process_chunk). Warning on
         # output_dir unconditionally mis-fired on every S3 export that had a
         # local --cache-dir configured.
-        cache_path = storage.join_path(self.cache_dir if self.cache_dir else self.output_dir, "cache")
         if not self.no_cache:
+            cache_path = storage.join_path(self.cache_dir if self.cache_dir else self.output_dir, "cache")
             if storage.is_s3_path(cache_path):
                 self.logger.warning(
                     "API cache will be written to S3, which may be slow due to many small files. "

--- a/nmaipy/storage.py
+++ b/nmaipy/storage.py
@@ -311,8 +311,8 @@ def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.File
         Tuple of (paths_for_pyarrow, filesystem); filesystem is None for local.
 
     Raises:
-        ValueError: If paths mix s3:// and local schemes, or the bucket name in
-            the first path cannot be parsed as a URI authority.
+        ValueError: If paths mix s3:// and local schemes, span more than one S3
+            bucket, or the bucket name cannot be parsed as a URI authority.
     """
     if not paths:
         return [], None
@@ -326,7 +326,10 @@ def pyarrow_read_paths(paths: List[str]) -> Tuple[List[str], Optional[pa_fs.File
     # which would hold element 0 to a stricter contract than the raw
     # scheme-stripped keys handed to pyarrow below — the same chunk set could
     # then pass or fail on sort order alone. Bucket names are URI-safe.
-    bucket = paths[0][len("s3://") :].split("/", 1)[0]
+    buckets = {p[len("s3://") :].split("/", 1)[0] for p in paths}
+    if len(buckets) > 1:
+        raise ValueError(f"pyarrow_read_paths requires all paths in one S3 bucket (got {sorted(buckets)})")
+    bucket = buckets.pop()
     filesystem, _ = pa_fs.FileSystem.from_uri(f"s3://{bucket}/")
     return [p[len("s3://") :] for p in paths], filesystem
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -668,6 +668,13 @@ class TestPyarrowReadPaths:
         with pytest.raises(ValueError, match="one scheme"):
             storage.pyarrow_read_paths(["s3://bucket/a.parquet", "/tmp/b.parquet"])
 
+    def test_cross_bucket_paths_raise(self):
+        # All paths share the single filesystem resolved from one bucket root;
+        # a second bucket would silently read through the wrong bucket's
+        # filesystem, so it must fail loudly instead.
+        with pytest.raises(ValueError, match="one S3 bucket"):
+            storage.pyarrow_read_paths(["s3://bucket-a/x.parquet", "s3://bucket-b/y.parquet"])
+
     def test_s3_paths_stripped_and_single_filesystem(self, monkeypatch):
         sentinel_fs = object()
         calls = []


### PR DESCRIPTION
## Summary

Version bump to 5.1.7 plus pre-release review fixes. The release content itself is already on main (merged PRs):

- #229 — consolidation performance at national scale: cap combined `features.parquet` row groups at 65,536 rows (was one group per class run → 169k groups / 1.6 GB footer on a 1,544-chunk export), and share one filesystem across consolidation chunk reads instead of constructing a fresh S3 filesystem per file.
- #228 — fix the spurious "API cache will be written to S3" warning to check the effective cache root (`--cache-dir` when set) instead of `--output-dir`, and stop creating an unused `cache/` prefix under S3 output (including under `--no-cache`).

## This PR

- Bump `__version__` to 5.1.7
- Pre-release review fixes (code-reviewer pass over the v5.1.6..HEAD diff, no blockers):
  - Re-document the `class_id` sort honestly — a typical chunk fits in one row group, so class pushdown only applies to oversized chunks; the sort's main value is compression locality
  - `pyarrow_read_paths` now rejects paths spanning multiple S3 buckets (one filesystem is resolved from a single bucket root) + test
  - Skip the effective-cache-path computation entirely under `--no-cache`

## Validation

- Full test suite including live API: 915 passed / 2 transient failures that re-ran clean (external working-tree interference mid-run), 12 skipped
- `black -l 120` / `isort` clean
- Reviewer verified fork-safety of the shared-filesystem change (parent-process-only, spawn context), row-group arithmetic edge cases, and confirmed the bucket-root URI resolution fixes a latent percent-decoding bug for S3 keys with spaces/`%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)